### PR TITLE
🔨 fix: wishlist 폴더 제한 개수 확인 시 isDeleted 여부를 확인하는 쿼리 날리기

### DIFF
--- a/src/main/java/com/bbangle/bbangle/repository/WishListFolderRepository.java
+++ b/src/main/java/com/bbangle/bbangle/repository/WishListFolderRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface WishListFolderRepository extends JpaRepository<WishlistFolder, Long>, WishListFolderQueryDSLRepository {
 
-    @Query(value = "select count(folder) from WishlistFolder folder where folder.member = :member")
+    @Query(value = "select count(folder) from WishlistFolder folder where folder.member = :member and folder.isDeleted = false ")
     int getFolderCount(@Param("member") Member member);
 
     Optional<WishlistFolder> findByMemberAndId(Member member, Long folderId);


### PR DESCRIPTION
## 문제상황
- 위시리스트 폴더 제한 개수를 채우고 삭제해도 위시리스트 개수를 삭제되기 전의 개수로 인식
- E.g. 10개 리스트를 생성 후 5개를 삭제한 뒤 다시 폴더를 만들려고 시도하면 만들어지지 않는 문

## 해결

```java
    @Query(value = "select count(folder) from WishlistFolder folder where folder.member = :member")
    int getFolderCount(@Param("member") Member member);
```

```java
    @Query(value = "select count(folder) from WishlistFolder folder where folder.member = :member and folder.isDeleted = false ")
    int getFolderCount(@Param("member") Member member);
```

- idDelete가 false인 것으로 count를 세는 방향으로 변경