### PR TITLE
refactor: 폴더 내 게시글을 추가했다 다시 삭제하는 경우 폴더가 조회되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/bbangle/bbangle/wishListFolder/repository/WishListFolderRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/wishListFolder/repository/WishListFolderRepositoryImpl.java
@@ -64,7 +64,10 @@ public class WishListFolderRepositoryImpl implements WishListFolderQueryDSLRepos
                     .limit(4)
                     .collect(Collectors.toList());
 
-                int count = productImages.isEmpty() ? 0 : tuples.size();
+                int count = productImages.isEmpty() ? 0 : (int) tuples.stream()
+                    .map(tuple -> tuple.get(board.profile))
+                    .filter(Objects::nonNull)
+                    .count();
 
                 return new FolderResponseDto(folderId, title, count, productImages);
             })


### PR DESCRIPTION
## 문제 상황
![Uploading 스크린샷 2024-03-19 오전 12.27.57.png…]()
- 위와 같이 게시글을 폴더 내에 추가 했다가 다시 삭제하는 경우(folderId = 37) 폴더 조회 시 해당 폴더가 조회되지 않는 문제 발생
- 쿼리 변경으로 문제 해결

- 변경 정
```java
List<Tuple> fetch = queryFactory.select(
                folder.id,
                folder.folderName,
                board.profile)
            .from(folder)
            .leftJoin(wishedBoard)
            .on(wishedBoard.wishlistFolder.eq(folder))
            .leftJoin(board)
            .on(wishedBoard.board.eq(board))
            .where(folder.member.eq(member)
                .and(folder.isDeleted.eq(false))
                .and(wishedBoard.isDeleted.eq(false)
                    .or(wishedBoard.isNull())))
            .fetch();
```
- 변경 후
```java
List<Tuple> fetch = queryFactory.select(
                folder.id,
                folder.folderName,
                board.profile)
            .from(folder)
            .leftJoin(wishedBoard)
            .on(wishedBoard.wishlistFolder.eq(folder))
            .leftJoin(board)
            .on(wishedBoard.board.eq(board)
                .and(wishedBoard.isDeleted.eq(false)))
            .where(folder.member.eq(member)
                .and(folder.isDeleted.eq(false)))
            .fetch();
```