### PR TITLE
스토어 찜 해제 시 발생하는 오류 해결

### DIFF
--- a/src/main/java/com/bbangle/bbangle/wishListStore/dto/WishListStoreResponseDto.java
+++ b/src/main/java/com/bbangle/bbangle/wishListStore/dto/WishListStoreResponseDto.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 
 @Getter
 public class WishListStoreResponseDto {
-    private Long id;
     private String introduce;
     private String storeName;
     private Long storeId;
@@ -15,12 +14,10 @@ public class WishListStoreResponseDto {
 
     @Builder
     @QueryProjection
-    public WishListStoreResponseDto(Long id,
-                                    String introduce,
+    public WishListStoreResponseDto(String introduce,
                                     String storeName,
                                     Long storeId,
                                     String profile) {
-        this.id = id;
         this.introduce = introduce;
         this.storeName = storeName;
         this.storeId = storeId;

--- a/src/main/java/com/bbangle/bbangle/wishListStore/repository/WishListStoreRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/wishListStore/repository/WishListStoreRepositoryImpl.java
@@ -37,7 +37,6 @@ public class WishListStoreRepositoryImpl implements WishListStoreQueryDSLReposit
     public Page<WishListStoreResponseDto> getWishListStoreRes(Long memberId, Pageable pageable) {
         List<WishListStoreResponseDto> wishListStores = queryFactory
                 .select(new QWishListStoreResponseDto(
-                        wishlistStore.id,
                         store.introduce,
                         store.name.as("storeName"),
                         store.id.as("storeId"),
@@ -67,6 +66,6 @@ public class WishListStoreRepositoryImpl implements WishListStoreQueryDSLReposit
                 .selectFrom(wishlistStore)
                 .where(wishlistStore.member.id.eq(memberId)
                         .and(wishlistStore.store.id.eq(storeId)))
-                .fetchOne());
+                .fetchFirst());
     }
 }


### PR DESCRIPTION
## 오류 상황
- 현재 데이터베이스에 멤버와 스토어가 중복되어 위시리스트 스토어에 저장되어 있음
- 기존 메소드는 fetchOne() 이여서 위처럼 중복된 데이터가 있어 여러 건을 가져올 경우 오류가 나타남
## 개선 방향
- fetchOne() -> fetchFirst()