### PR TITLE
Swagger에 로그인 토큰 및 OAuth 처리

### DIFF
--- a/src/main/java/com/bbangle/bbangle/config/SwaggerConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/SwaggerConfig.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.*;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,15 +39,17 @@ public class SwaggerConfig {
         SecurityScheme oauthSchemes = new SecurityScheme()
                 .type(SecurityScheme.Type.OAUTH2)
                 .flows(oAuthFlows);
+        SecurityRequirement tokenLogin = new SecurityRequirement().addList("토큰 로그인");
 
         return new OpenAPI()
                 .info(info)
-                .addSecurityItem(new SecurityRequirement().addList("카카오 토큰 로그인"))
+                .addSecurityItem(tokenLogin)
                 .addSecurityItem(new SecurityRequirement().addList("토큰 받아오기"))
                 .components(new Components()
-                        .addSecuritySchemes("카카오 토큰 로그인", jwtSchemes)
+                        .addSecuritySchemes("토큰 로그인", jwtSchemes)
                         .addSecuritySchemes("토큰 받아오기", oauthSchemes)
-                );
+                )
+            .security(Arrays.asList(tokenLogin));
     }
 
     @Bean


### PR DESCRIPTION
## 구현 사항
- Swagger에서 api 요청 시 인증이 필요한 api 에 토큰 및 OAuth 처리(카카오)

이미지 별첨
![image](https://github.com/eco-dessert-platform/backend/assets/110441578/e15735eb-4603-40fe-a54d-d26bbe392e5a)
![image](https://github.com/eco-dessert-platform/backend/assets/110441578/8f7ed83b-c0c5-44b4-ba56-20367643048e)
위 사진 처럼 api 요청 시 요청 헤더에 토큰이 붙어 있고 자물쇠가 잠겨있는 것을 확인할 수 있습니다

![image](https://github.com/eco-dessert-platform/backend/assets/110441578/ccf6ae0d-e3d5-4b46-bd2e-a871f7f525f7)
리다이렉트 url 도 추가해야해서 추가했습니다 

개선해야 할 부분 있으면 말씀해주세요~