### PR TITLE
위시리스트 기본 폴더에 저장이 안되는 문제

### DIFF
--- a/src/main/java/com/bbangle/bbangle/wishlist/service/WishListBoardService.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/service/WishListBoardService.java
@@ -47,8 +47,7 @@ public class WishListBoardService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new BbangleException(NOTFOUND_MEMBER));
 
-        WishListFolder wishlistFolder = getWishlistFolder(boardId,
-            wishRequest, member);
+        WishListFolder wishlistFolder = getWishlistFolder(wishRequest, member);
 
         Board board = boardRepository.findById(boardId)
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.BOARD_NOT_FOUND));
@@ -96,11 +95,10 @@ public class WishListBoardService {
     }
 
     private WishListFolder getWishlistFolder(
-        Long boardId,
         WishListBoardRequest wishRequest,
         Member member
     ) {
-        if (boardId.equals(0L)) {
+        if (wishRequest.folderId().equals(0L)) {
             return wishListFolderRepository.findByMemberAndFolderName(
                     member, DEFAULT_FOLDER_NAME)
                 .orElseThrow(() -> new BbangleException(BbangleErrorCode.FOLDER_NOT_FOUND));


### PR DESCRIPTION
## History
* Resolves #152 
<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations
- 기본 폴더 검색 필터링 시 folderId = 0인지를 확인해야 하는데 boardId를 비교하고 있는 로직 상 문제 확인
- 이를 수정하고 빠르게 merge 진행
- swagger 정상 작동 확인
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image
![스크린샷 2024-05-08 오전 10 45 22](https://github.com/eco-dessert-platform/backend/assets/85065626/1a78a1d0-d51a-4f3d-b76b-67308471d161)
![스크린샷 2024-05-08 오전 10 45 42](https://github.com/eco-dessert-platform/backend/assets/85065626/ec99a818-39a6-4363-b986-ff5ff1e30f0d)
![스크린샷 2024-05-08 오전 10 45 49](https://github.com/eco-dessert-platform/backend/assets/85065626/161f0857-2ac8-44a2-99c6-212c70bd56be)

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->