### PR TITLE
[기획팀 요청] 상품게시글 is_deleted true 일 때 조회 안되는 기능 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/cursor/RecommendCursorGenerator.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/cursor/RecommendCursorGenerator.java
@@ -23,6 +23,7 @@ public class RecommendCursorGenerator implements BoardCursorGenerator {
     @Override
     public BooleanBuilder getCursor(Long cursorId) {
         BooleanBuilder cursorBuilder = new BooleanBuilder();
+        cursorBuilder.and(board.isDeleted.eq(false));
         if (cursorId == null) {
             return cursorBuilder;
         }


### PR DESCRIPTION
스토어와 동일 합니다. 
상품 게시글이 필터가 추천순일때만 추가했습니다