### PR TITLE
푸시 알림 기능 1차 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,9 @@ dependencies {
     // https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client
     implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '3.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation 'org.apache.poi:poi:5.2.5'
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'
 
     //QueryDSL 추가
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/resource/mariadb/init.sql
+++ b/resource/mariadb/init.sql
@@ -190,7 +190,7 @@ CREATE TABLE boardStatistic
     board_review_count INT     NOT NULL default 0,
     board_view_count   INT     NOT NULL default 0,
     board_view_grade   DECIMAL NOT NULL default 0,
-    CONSTRAINT product_img_pk PRIMARY KEY (id),
+    CONSTRAINT product_img_pk PRIMARY KEY (id)
 );
 
 CREATE TABLE notice
@@ -201,6 +201,7 @@ CREATE TABLE notice
     CONSTRAINT product_img_pk PRIMARY KEY (id),
     created_at DATETIME(6)
 );
+
 create table product_detail
 (
     id               bigint auto_increment,
@@ -211,6 +212,7 @@ create table product_detail
     constraint fk_product_board_product_detail
         foreign key (product_board_id) references product_board (id)
 );
+
 create table withdrawal
 (
     id          bigint auto_increment,
@@ -223,3 +225,16 @@ create table withdrawal
         foreign key (member_id) references member (id)
 );
 
+CREATE TABLE push
+(
+    id            BIGINT AUTO_INCREMENT,
+    fcm_token     VARCHAR(255) NOT NULL,
+    member_id     BIGINT       NOT NULL,
+    board_id      BIGINT       NOT NULL,
+    push_category VARCHAR(255) NOT NULL,
+    push_status   TINYINT      NOT NULL,
+    created_at    DATETIME(6)  NULL,
+    modified_at   DATETIME(6)  NULL,
+    CONSTRAINT push_pk PRIMARY KEY (id),
+    INDEX idx_member_board_id (member_id, board_id)
+);

--- a/resource/mariadb/init.sql
+++ b/resource/mariadb/init.sql
@@ -230,11 +230,13 @@ CREATE TABLE push
     id            BIGINT AUTO_INCREMENT,
     fcm_token     VARCHAR(255) NOT NULL,
     member_id     BIGINT       NOT NULL,
+    store_id      BIGINT       NOT NULL,
     board_id      BIGINT       NOT NULL,
+    product_id    BIGINT       NOT NULL,
     push_category VARCHAR(255) NOT NULL,
-    push_status   TINYINT      NOT NULL,
+    is_subscribed TINYINT      NOT NULL,
     created_at    DATETIME(6)  NULL,
     modified_at   DATETIME(6)  NULL,
     CONSTRAINT push_pk PRIMARY KEY (id),
-    INDEX idx_member_board_id (member_id, board_id)
+    INDEX idx_member_product_id (member_id, product_id)
 );

--- a/resource/mariadb/init.sql
+++ b/resource/mariadb/init.sql
@@ -230,8 +230,6 @@ CREATE TABLE push
     id            BIGINT AUTO_INCREMENT,
     fcm_token     VARCHAR(255) NOT NULL,
     member_id     BIGINT       NOT NULL,
-    store_id      BIGINT       NOT NULL,
-    board_id      BIGINT       NOT NULL,
     product_id    BIGINT       NOT NULL,
     push_category VARCHAR(255) NOT NULL,
     is_subscribed TINYINT      NOT NULL,

--- a/src/main/java/com/bbangle/bbangle/config/FirebaseConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/FirebaseConfig.java
@@ -1,0 +1,32 @@
+package com.bbangle.bbangle.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void init() {
+        try {
+            FileInputStream inputStream = new FileInputStream("src/main/resources/firebase/firebase_service_key.json");
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(inputStream))
+                    .build();
+            FirebaseApp.initializeApp(options);
+
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/config/FirebaseConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/FirebaseConfig.java
@@ -3,7 +3,6 @@ package com.bbangle.bbangle.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
-import jakarta.annotation.PostConstruct;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
@@ -15,7 +14,7 @@ import java.io.IOException;
 @Configuration
 public class FirebaseConfig {
 
-    @PostConstruct
+//    @PostConstruct
     public void init() {
         try {
             FileInputStream inputStream = new FileInputStream("src/main/resources/firebase/firebase_service_key.json");

--- a/src/main/java/com/bbangle/bbangle/config/FirebaseConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/FirebaseConfig.java
@@ -3,13 +3,15 @@ package com.bbangle.bbangle.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
-import javax.annotation.PostConstruct;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
+@Profile("!test")
 @Configuration
 public class FirebaseConfig {
 

--- a/src/main/java/com/bbangle/bbangle/config/WebOAuthSecurityConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/WebOAuthSecurityConfig.java
@@ -1,12 +1,5 @@
 package com.bbangle.bbangle.config;
 
-import static org.springframework.http.HttpMethod.DELETE;
-import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.http.HttpMethod.PATCH;
-import static org.springframework.http.HttpMethod.POST;
-import static org.springframework.http.HttpMethod.PUT;
-import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
-
 import com.bbangle.bbangle.token.jwt.TokenAuthenticationFilter;
 import com.bbangle.bbangle.token.jwt.TokenProvider;
 import com.bbangle.bbangle.token.oauth.OauthServerTypeConverter;
@@ -25,6 +18,13 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.PATCH;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 @RequiredArgsConstructor
 @Configuration
@@ -70,6 +70,7 @@ public class WebOAuthSecurityConfig implements WebMvcConfigurer {
                     .requestMatchers("/api/v1/store/**").permitAll()
                     .requestMatchers("/api/v1/stores/**").permitAll()
                     .requestMatchers("/api/v1/health/**").permitAll()
+                    .requestMatchers("/api/v1/push/**").permitAll()
                     .requestMatchers(GET, "/api/v1/boards/**").permitAll()
                     .requestMatchers(PATCH, "/api/v1/boards/**").permitAll()
                     .requestMatchers(GET, "/api/v1/notification/**").permitAll()

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -1,13 +1,12 @@
 package com.bbangle.bbangle.exception;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.CONFLICT;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+
+import java.util.stream.Stream;
+
+import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @RequiredArgsConstructor
@@ -48,7 +47,7 @@ public enum BbangleErrorCode {
     MEMBER_PREFERENCE_NOT_FOUND(-30, "유저의 선호타입 내역을 확인할 수 없습니다.", BAD_REQUEST),
     IMAGE_NOT_FOUND(-31, "해당하는 이미지를 찾을 수 없습니다.", NOT_FOUND),
     REVIEW_NOT_FOUND(-32, "존재하지 않는 리뷰입니다", BAD_REQUEST),
-    ZERO_REGISTERED_USERS(-33, "현재 가입한 사용자의 수는 0명입니다.", BAD_REQUEST),
+    PUSH_NOT_FOUND(-33, "존재하지 않는 푸시 알림 신청입니다.", BAD_REQUEST),
     INTERNAL_SERVER_ERROR(-999, "서버 내부 에러입니다", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final int code;

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -6,7 +6,10 @@ import org.springframework.http.HttpStatus;
 
 import java.util.stream.Stream;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/com/bbangle/bbangle/push/controller/PushController.java
+++ b/src/main/java/com/bbangle/bbangle/push/controller/PushController.java
@@ -2,8 +2,8 @@ package com.bbangle.bbangle.push.controller;
 
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.service.ResponseService;
-import com.bbangle.bbangle.push.dto.PushRequest;
 import com.bbangle.bbangle.push.dto.CreatePushRequest;
+import com.bbangle.bbangle.push.dto.PushRequest;
 import com.bbangle.bbangle.push.dto.SendPushRequest;
 import com.bbangle.bbangle.push.service.FcmService;
 import com.bbangle.bbangle.push.service.PushService;
@@ -33,17 +33,6 @@ public class PushController {
     }
 
 
-    @PatchMapping("/again")
-    public CommonResult recreatePush(
-            @Validated @RequestBody PushRequest request,
-            @AuthenticationPrincipal Long memberId
-    ) {
-        System.out.println("requestDto = " + request);
-        pushService.recreatePush(request, memberId);
-        return responseService.getSuccessResult();
-    }
-
-
     @PatchMapping
     public CommonResult cancelPush(
             @Validated @RequestBody PushRequest request,
@@ -68,11 +57,13 @@ public class PushController {
 
     @GetMapping
     public CommonResult getPush(
-            @RequestParam String productId,
+            @RequestParam(value = "boardId") Long boardId,
+            @RequestParam(value = "pushCategory") String pushCategory,
             @AuthenticationPrincipal Long memberId
     ) {
-
-        return null;
+        System.out.println("boardId = " + boardId);
+        System.out.println("pushCategory = " + pushCategory);
+        return responseService.getListResult(pushService.getPush(boardId, pushCategory, memberId));
     }
 
 

--- a/src/main/java/com/bbangle/bbangle/push/controller/PushController.java
+++ b/src/main/java/com/bbangle/bbangle/push/controller/PushController.java
@@ -4,7 +4,6 @@ import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.push.dto.CreatePushRequest;
 import com.bbangle.bbangle.push.dto.PushRequest;
-import com.bbangle.bbangle.push.dto.SendPushRequest;
 import com.bbangle.bbangle.push.service.FcmService;
 import com.bbangle.bbangle.push.service.PushService;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +26,6 @@ public class PushController {
             @Validated @RequestBody CreatePushRequest request,
             @AuthenticationPrincipal Long memberId
     ) {
-        System.out.println("requestDto = " + request);
         pushService.createPush(request, memberId);
         return responseService.getSuccessResult();
     }
@@ -38,7 +36,6 @@ public class PushController {
             @Validated @RequestBody PushRequest request,
             @AuthenticationPrincipal Long memberId
     ) {
-        System.out.println("requestDto = " + request);
         pushService.cancelPush(request, memberId);
         return responseService.getSuccessResult();
     }
@@ -49,7 +46,6 @@ public class PushController {
             @Validated @RequestBody PushRequest request,
             @AuthenticationPrincipal Long memberId
     ) {
-        System.out.println("requestDto = " + request);
         pushService.deletePush(request, memberId);
         return responseService.getSuccessResult();
     }
@@ -57,22 +53,19 @@ public class PushController {
 
     @GetMapping
     public CommonResult getPush(
-            @RequestParam(value = "boardId") Long boardId,
             @RequestParam(value = "pushCategory") String pushCategory,
             @AuthenticationPrincipal Long memberId
     ) {
-        System.out.println("boardId = " + boardId);
-        System.out.println("pushCategory = " + pushCategory);
-        return responseService.getListResult(pushService.getPush(boardId, pushCategory, memberId));
+        return responseService.getListResult(pushService.getPush(pushCategory, memberId));
     }
 
 
-    @PostMapping("/push")
-    public CommonResult sendPush(@RequestBody SendPushRequest request) {
-        System.out.println("requestDto = " + request);
-
-        fcmService.sendPush(request);
-        return responseService.getSuccessResult();
-    }
+//    @PostMapping("/push")
+//    public CommonResult sendPush(@RequestBody SendPushRequest request) {
+//        System.out.println("requestDto = " + request);
+//
+//        fcmService.sendPush(request);
+//        return responseService.getSuccessResult();
+//    }
 
 }

--- a/src/main/java/com/bbangle/bbangle/push/controller/PushController.java
+++ b/src/main/java/com/bbangle/bbangle/push/controller/PushController.java
@@ -1,0 +1,87 @@
+package com.bbangle.bbangle.push.controller;
+
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.push.dto.PushRequest;
+import com.bbangle.bbangle.push.dto.CreatePushRequest;
+import com.bbangle.bbangle.push.dto.SendPushRequest;
+import com.bbangle.bbangle.push.service.FcmService;
+import com.bbangle.bbangle.push.service.PushService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/push")
+@RequiredArgsConstructor
+public class PushController {
+
+    private final FcmService fcmService;
+    private final PushService pushService;
+    private final ResponseService responseService;
+
+
+    @PostMapping
+    public CommonResult createPush(
+            @Validated @RequestBody CreatePushRequest request,
+            @AuthenticationPrincipal Long memberId
+    ) {
+        System.out.println("requestDto = " + request);
+        pushService.createPush(request, memberId);
+        return responseService.getSuccessResult();
+    }
+
+
+    @PatchMapping("/again")
+    public CommonResult recreatePush(
+            @Validated @RequestBody PushRequest request,
+            @AuthenticationPrincipal Long memberId
+    ) {
+        System.out.println("requestDto = " + request);
+        pushService.recreatePush(request, memberId);
+        return responseService.getSuccessResult();
+    }
+
+
+    @PatchMapping
+    public CommonResult cancelPush(
+            @Validated @RequestBody PushRequest request,
+            @AuthenticationPrincipal Long memberId
+    ) {
+        System.out.println("requestDto = " + request);
+        pushService.cancelPush(request, memberId);
+        return responseService.getSuccessResult();
+    }
+
+
+    @DeleteMapping
+    public CommonResult deletePush(
+            @Validated @RequestBody PushRequest request,
+            @AuthenticationPrincipal Long memberId
+    ) {
+        System.out.println("requestDto = " + request);
+        pushService.deletePush(request, memberId);
+        return responseService.getSuccessResult();
+    }
+
+
+    @GetMapping
+    public CommonResult getPush(
+            @RequestParam String productId,
+            @AuthenticationPrincipal Long memberId
+    ) {
+
+        return null;
+    }
+
+
+    @PostMapping("/push")
+    public CommonResult sendPush(@RequestBody SendPushRequest request) {
+        System.out.println("requestDto = " + request);
+
+        fcmService.sendPush(request);
+        return responseService.getSuccessResult();
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/push/controller/PushController.java
+++ b/src/main/java/com/bbangle/bbangle/push/controller/PushController.java
@@ -9,7 +9,14 @@ import com.bbangle.bbangle.push.service.PushService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/push")

--- a/src/main/java/com/bbangle/bbangle/push/domain/Push.java
+++ b/src/main/java/com/bbangle/bbangle/push/domain/Push.java
@@ -1,8 +1,20 @@
 package com.bbangle.bbangle.push.domain;
 
 import com.bbangle.bbangle.common.domain.BaseEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Table(name = "push")
 @Getter

--- a/src/main/java/com/bbangle/bbangle/push/domain/Push.java
+++ b/src/main/java/com/bbangle/bbangle/push/domain/Push.java
@@ -23,12 +23,6 @@ public class Push extends BaseEntity {
     @Column(name = "member_id")
     private Long memberId;
 
-    @Column(name = "store_id")
-    private Long storeId;
-
-    @Column(name = "board_id")
-    private Long boardId;
-
     @Column(name = "product_id")
     private Long productId;
 

--- a/src/main/java/com/bbangle/bbangle/push/domain/Push.java
+++ b/src/main/java/com/bbangle/bbangle/push/domain/Push.java
@@ -1,0 +1,45 @@
+package com.bbangle.bbangle.push.domain;
+
+import com.bbangle.bbangle.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "push")
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Push extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "fcm_token")
+    private String fcmToken;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "product_id")
+    private Long productId;
+
+    @Column(name = "push_category", columnDefinition = "varchar")
+    @Enumerated(EnumType.STRING)
+    private PushCategory pushCategory;
+
+    @Column(name = "push_status", columnDefinition = "tinyint")
+    private boolean pushStatus;
+
+
+    public void recreatePush() {
+        this.pushStatus = true;
+    }
+
+
+    public void cancelPush() {
+        this.pushStatus = false;
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/push/domain/Push.java
+++ b/src/main/java/com/bbangle/bbangle/push/domain/Push.java
@@ -22,8 +22,8 @@ public class Push extends BaseEntity {
     @Column(name = "member_id")
     private Long memberId;
 
-    @Column(name = "product_id")
-    private Long productId;
+    @Column(name = "board_id")
+    private Long boardId;
 
     @Column(name = "push_category", columnDefinition = "varchar")
     @Enumerated(EnumType.STRING)
@@ -33,12 +33,12 @@ public class Push extends BaseEntity {
     private boolean pushStatus;
 
 
-    public void recreatePush() {
+    public void resubscribePush() {
         this.pushStatus = true;
     }
 
 
-    public void cancelPush() {
+    public void unsubscribePush() {
         this.pushStatus = false;
     }
 

--- a/src/main/java/com/bbangle/bbangle/push/domain/Push.java
+++ b/src/main/java/com/bbangle/bbangle/push/domain/Push.java
@@ -40,13 +40,8 @@ public class Push extends BaseEntity {
     private boolean subscribed;
 
 
-    public void resubscribePush() {
-        this.subscribed = true;
-    }
-
-
-    public void unsubscribePush() {
-        this.subscribed = false;
+    public void updateSubscribed(boolean subscribed) {
+        this.subscribed = subscribed;
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/push/domain/Push.java
+++ b/src/main/java/com/bbangle/bbangle/push/domain/Push.java
@@ -8,6 +8,7 @@ import lombok.*;
 @Getter
 @Entity
 @Builder
+@ToString
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Push extends BaseEntity {
@@ -22,24 +23,30 @@ public class Push extends BaseEntity {
     @Column(name = "member_id")
     private Long memberId;
 
+    @Column(name = "store_id")
+    private Long storeId;
+
     @Column(name = "board_id")
     private Long boardId;
+
+    @Column(name = "product_id")
+    private Long productId;
 
     @Column(name = "push_category", columnDefinition = "varchar")
     @Enumerated(EnumType.STRING)
     private PushCategory pushCategory;
 
-    @Column(name = "push_status", columnDefinition = "tinyint")
-    private boolean pushStatus;
+    @Column(name = "is_subscribed", columnDefinition = "tinyint")
+    private boolean subscribed;
 
 
     public void resubscribePush() {
-        this.pushStatus = true;
+        this.subscribed = true;
     }
 
 
     public void unsubscribePush() {
-        this.pushStatus = false;
+        this.subscribed = false;
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/push/domain/PushCategory.java
+++ b/src/main/java/com/bbangle/bbangle/push/domain/PushCategory.java
@@ -1,0 +1,11 @@
+package com.bbangle.bbangle.push.domain;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum PushCategory {
+    BBANGCKETING("빵켓팅"),
+    RESTOCK("재입고");
+
+    private final String description;
+}

--- a/src/main/java/com/bbangle/bbangle/push/dto/CreatePushRequest.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/CreatePushRequest.java
@@ -1,0 +1,13 @@
+package com.bbangle.bbangle.push.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreatePushRequest(
+    @NotNull
+    String fcmToken,
+    @NotNull
+    String pushCategory,
+    @NotNull
+    Long productId
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/push/dto/CreatePushRequest.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/CreatePushRequest.java
@@ -8,6 +8,10 @@ public record CreatePushRequest(
     @NotNull
     String pushCategory,
     @NotNull
-    Long boardId
+    Long storeId,
+    @NotNull
+    Long boardId,
+    @NotNull
+    Long productId
 ) {
 }

--- a/src/main/java/com/bbangle/bbangle/push/dto/CreatePushRequest.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/CreatePushRequest.java
@@ -8,6 +8,6 @@ public record CreatePushRequest(
     @NotNull
     String pushCategory,
     @NotNull
-    Long productId
+    Long boardId
 ) {
 }

--- a/src/main/java/com/bbangle/bbangle/push/dto/CreatePushRequest.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/CreatePushRequest.java
@@ -8,10 +8,6 @@ public record CreatePushRequest(
     @NotNull
     String pushCategory,
     @NotNull
-    Long storeId,
-    @NotNull
-    Long boardId,
-    @NotNull
     Long productId
 ) {
 }

--- a/src/main/java/com/bbangle/bbangle/push/dto/PushMessage.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/PushMessage.java
@@ -1,0 +1,30 @@
+package com.bbangle.bbangle.push.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PushMessage {
+    private boolean validateOnly;
+    private Notification notification;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Notification {
+        private Message message;
+        private String token;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Message {
+        private String title;
+        private String body;
+        private String image;
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/push/dto/PushRequest.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/PushRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record PushRequest(
     @NotNull
-    Long boardId,
+    Long productId,
     @NotNull
     String pushCategory
 ) {

--- a/src/main/java/com/bbangle/bbangle/push/dto/PushRequest.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/PushRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record PushRequest(
     @NotNull
-    Long productId,
+    Long boardId,
     @NotNull
     String pushCategory
 ) {

--- a/src/main/java/com/bbangle/bbangle/push/dto/PushRequest.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/PushRequest.java
@@ -1,0 +1,11 @@
+package com.bbangle.bbangle.push.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PushRequest(
+    @NotNull
+    Long productId,
+    @NotNull
+    String pushCategory
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/push/dto/PushResponse.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/PushResponse.java
@@ -1,0 +1,15 @@
+package com.bbangle.bbangle.push.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record PushResponse(
+    String storeName,
+    String boardTitle,
+    String boardThumbnail,
+    boolean pushStatus
+) {
+
+    @QueryProjection
+    public PushResponse{}
+
+}

--- a/src/main/java/com/bbangle/bbangle/push/dto/PushResponse.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/PushResponse.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.push.dto;
 import com.querydsl.core.annotations.QueryProjection;
 
 public record PushResponse(
+    Long productId,
     String storeName,
     String productTitle,
     String boardThumbnail,

--- a/src/main/java/com/bbangle/bbangle/push/dto/PushResponse.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/PushResponse.java
@@ -4,9 +4,9 @@ import com.querydsl.core.annotations.QueryProjection;
 
 public record PushResponse(
     String storeName,
-    String boardTitle,
+    String productTitle,
     String boardThumbnail,
-    boolean pushStatus
+    boolean subscribed
 ) {
 
     @QueryProjection

--- a/src/main/java/com/bbangle/bbangle/push/dto/SendPushRequest.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/SendPushRequest.java
@@ -1,0 +1,8 @@
+package com.bbangle.bbangle.push.dto;
+
+public record SendPushRequest(
+    String token,
+    String title,
+    String body
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepository.java
@@ -6,6 +6,6 @@ import com.bbangle.bbangle.push.dto.PushResponse;
 import java.util.List;
 
 public interface PushQueryDSLRepository {
-    Push findPush(Long boardId, String pushCategory, Long memberId);
-    List<PushResponse> findPushList(Long boardId, String pushCategory, Long memberId);
+    Push findPush(Long productId, String pushCategory, Long memberId);
+    List<PushResponse> findPushList(String pushCategory, Long memberId);
 }

--- a/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepository.java
@@ -1,0 +1,11 @@
+package com.bbangle.bbangle.push.repository;
+
+import com.bbangle.bbangle.push.domain.Push;
+import com.bbangle.bbangle.push.dto.PushRequest;
+
+import java.util.List;
+
+public interface PushQueryDSLRepository {
+    Push findPush(PushRequest request, Long memberId);
+    List<Push> findPushList(PushRequest request, Long memberId);
+}

--- a/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepository.java
@@ -1,11 +1,11 @@
 package com.bbangle.bbangle.push.repository;
 
 import com.bbangle.bbangle.push.domain.Push;
-import com.bbangle.bbangle.push.dto.PushRequest;
+import com.bbangle.bbangle.push.dto.PushResponse;
 
 import java.util.List;
 
 public interface PushQueryDSLRepository {
-    Push findPush(PushRequest request, Long memberId);
-    List<Push> findPushList(PushRequest request, Long memberId);
+    Push findPush(Long boardId, String pushCategory, Long memberId);
+    List<PushResponse> findPushList(Long boardId, String pushCategory, Long memberId);
 }

--- a/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 import static com.bbangle.bbangle.board.domain.QBoard.board;
+import static com.bbangle.bbangle.board.domain.QProduct.product;
 import static com.bbangle.bbangle.push.domain.QPush.push;
 import static com.bbangle.bbangle.store.domain.QStore.store;
 
@@ -23,36 +24,37 @@ public class PushQueryDSLRepositoryImpl implements PushQueryDSLRepository {
 
 
     @Override
-    public Push findPush(Long boardId, String pushCategory, Long memberId) {
+    public Push findPush(Long productId, String pushCategory, Long memberId) {
         return queryFactory.selectFrom(push)
-                .where(commonFilter(memberId, boardId, pushCategory))
+                .where(commonFilter(memberId, productId, pushCategory))
                 .fetchFirst();
     }
 
     @Override
-    public List<PushResponse> findPushList(Long boardId, String pushCategory, Long memberId) {
+    public List<PushResponse> findPushList(String pushCategory, Long memberId) {
         return queryFactory.select(new QPushResponse(
                         store.name,
-                        board.title,
+                        product.title,
                         board.profile,
-                        push.pushStatus
+                        push.subscribed
                 ))
                 .from(push)
                 .join(board).on(push.boardId.eq(board.id))
-                .join(store).on(board.store.id.eq(store.id))
-                .where(commonFilter(memberId, boardId, pushCategory))
+                .join(store).on(push.storeId.eq(store.id))
+                .join(product).on(push.productId.eq(product.id))
+                .where(commonFilter(memberId, null, pushCategory))
                 .fetch();
     }
 
 
-    private BooleanBuilder commonFilter(Long memberId, Long boardId, String pushCategory) {
+    private BooleanBuilder commonFilter(Long memberId, Long productId, String pushCategory) {
         BooleanBuilder builder = new BooleanBuilder();
 
         if (memberId != null) {
             builder.and(push.memberId.eq(memberId));
         }
-        if (boardId != null) {
-            builder.and(push.boardId.eq(boardId));
+        if (productId != null) {
+            builder.and(push.productId.eq(productId));
         }
         if (pushCategory != null) {
             builder.and(push.pushCategory.eq(PushCategory.valueOf(pushCategory)));

--- a/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepositoryImpl.java
@@ -33,15 +33,16 @@ public class PushQueryDSLRepositoryImpl implements PushQueryDSLRepository {
     @Override
     public List<PushResponse> findPushList(String pushCategory, Long memberId) {
         return queryFactory.select(new QPushResponse(
+                        product.id,
                         store.name,
                         product.title,
                         board.profile,
                         push.subscribed
                 ))
                 .from(push)
-                .join(board).on(push.boardId.eq(board.id))
-                .join(store).on(push.storeId.eq(store.id))
                 .join(product).on(push.productId.eq(product.id))
+                .join(board).on(product.board.id.eq(board.id))
+                .join(store).on(board.store.id.eq(store.id))
                 .where(commonFilter(memberId, null, pushCategory))
                 .fetch();
     }

--- a/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.bbangle.bbangle.push.repository;
+
+import com.bbangle.bbangle.push.domain.Push;
+import com.bbangle.bbangle.push.domain.PushCategory;
+import com.bbangle.bbangle.push.dto.PushRequest;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.bbangle.bbangle.push.domain.QPush.push;
+
+@Repository
+@RequiredArgsConstructor
+public class PushQueryDSLRepositoryImpl implements PushQueryDSLRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public Push findPush(PushRequest request, Long memberId) {
+        return queryFactory.selectFrom(push)
+                .where(
+                        push.memberId.eq(memberId)
+                        .and(push.productId.eq(request.productId()))
+                        .and(push.pushCategory.eq(PushCategory.valueOf(request.pushCategory())))
+                )
+                .fetchFirst();
+    }
+
+    @Override
+    public List<Push> findPushList(PushRequest request, Long memberId) {
+        return queryFactory.selectFrom(push)
+                .where(
+                        push.memberId.eq(memberId)
+                        .and(push.pushCategory.eq(PushCategory.valueOf(request.pushCategory())))
+                )
+                .fetch();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/push/repository/PushRepository.java
+++ b/src/main/java/com/bbangle/bbangle/push/repository/PushRepository.java
@@ -1,0 +1,7 @@
+package com.bbangle.bbangle.push.repository;
+
+import com.bbangle.bbangle.push.domain.Push;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PushRepository extends JpaRepository<Push, Long>, PushQueryDSLRepository {
+}

--- a/src/main/java/com/bbangle/bbangle/push/service/FcmService.java
+++ b/src/main/java/com/bbangle/bbangle/push/service/FcmService.java
@@ -1,0 +1,90 @@
+package com.bbangle.bbangle.push.service;
+
+import com.bbangle.bbangle.push.dto.PushMessage;
+import com.bbangle.bbangle.push.dto.SendPushRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import lombok.RequiredArgsConstructor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.MediaType;
+import org.apache.http.HttpHeaders;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+
+    private final String API_URL = "https://fcm.googleapis.com/v1/projects/bbanggrioven/messages:send";
+    private final ObjectMapper objectMapper;
+
+
+    public void sendPush(SendPushRequest request) {
+        String message = makeMessage(request);
+        OkHttpClient client = new OkHttpClient();
+        RequestBody requestBody = RequestBody.create(message, MediaType.get("application/json; charset=utf-8"));
+        Request httpRequest = new Request.Builder()
+                .url(API_URL)
+                .post(requestBody)
+                .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken())
+                .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8")
+                .build();
+        System.out.println("httpRequest = " + httpRequest);
+
+        Response httpResponse;
+        try {
+            httpResponse = client.newCall(httpRequest).execute();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        System.out.println("httpResponse = " + httpResponse);
+    }
+
+
+    private String makeMessage(SendPushRequest pushRequest) {
+        PushMessage fcmMessage = PushMessage.builder()
+                .notification(PushMessage.Notification.builder()
+                        .token(pushRequest.token())
+                        .message(PushMessage.Message.builder()
+                                .title(pushRequest.title())
+                                .body(pushRequest.body())
+                                .image(null)
+                                .build())
+                        .build())
+                .validateOnly(false)
+                .build();
+
+        try {
+            return objectMapper.writeValueAsString(fcmMessage);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    private String getAccessToken() {
+        String firebaseKeyPath = "firebase/firebase_service_key.json";
+        GoogleCredentials googleCredentials;
+
+        try {
+            googleCredentials = GoogleCredentials
+                    .fromStream(new ClassPathResource(firebaseKeyPath).getInputStream())
+                    .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));
+
+            googleCredentials.refreshIfExpired();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return googleCredentials.getAccessToken().getTokenValue();
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/push/service/PushService.java
+++ b/src/main/java/com/bbangle/bbangle/push/service/PushService.java
@@ -1,0 +1,64 @@
+package com.bbangle.bbangle.push.service;
+
+import com.bbangle.bbangle.member.repository.MemberRepository;
+import com.bbangle.bbangle.push.domain.Push;
+import com.bbangle.bbangle.push.domain.PushCategory;
+import com.bbangle.bbangle.push.dto.PushRequest;
+import com.bbangle.bbangle.push.dto.CreatePushRequest;
+import com.bbangle.bbangle.push.repository.PushRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PushService {
+
+    private final PushRepository pushRepository;
+    private final MemberRepository memberRepository;
+
+
+    public void createPush(CreatePushRequest request, Long memberId) {
+        memberRepository.findMemberById(memberId);
+        Push newPush = Push.builder()
+                .fcmToken(request.fcmToken())
+                .memberId(memberId)
+                .productId(request.productId())
+                .pushCategory(PushCategory.valueOf(request.pushCategory()))
+                .pushStatus(false)
+                .build();
+
+        pushRepository.save(newPush);
+    }
+
+
+    public void recreatePush(PushRequest request, Long memberId) {
+        memberRepository.findMemberById(memberId);
+        Push push = pushRepository.findPush(request, memberId);
+        push.recreatePush();
+    }
+
+
+    public void cancelPush(PushRequest request, Long memberId) {
+        memberRepository.findMemberById(memberId);
+        Push push = pushRepository.findPush(request, memberId);
+        push.cancelPush();
+    }
+
+
+    public void deletePush(PushRequest request, Long memberId) {
+        memberRepository.findMemberById(memberId);
+        Push push = pushRepository.findPush(request, memberId);
+        pushRepository.delete(push);
+    }
+
+
+    public List<Push> getPush(PushRequest request, Long memberId) {
+        memberRepository.findMemberById(memberId);
+        pushRepository.findPushList(request, memberId);
+        return null;
+    }
+
+
+}

--- a/src/main/java/com/bbangle/bbangle/push/service/PushService.java
+++ b/src/main/java/com/bbangle/bbangle/push/service/PushService.java
@@ -41,7 +41,7 @@ public class PushService {
 
             pushRepository.save(newPush);
         } else {
-            push.resubscribePush();
+            push.updateSubscribed(true);
         }
     }
 
@@ -54,7 +54,7 @@ public class PushService {
         if (push == null) {
             throw new BbangleException(BbangleErrorCode.PUSH_NOT_FOUND);
         } else {
-            push.unsubscribePush();
+            push.updateSubscribed(false);
         }
     }
 

--- a/src/main/java/com/bbangle/bbangle/push/service/PushService.java
+++ b/src/main/java/com/bbangle/bbangle/push/service/PushService.java
@@ -32,8 +32,6 @@ public class PushService {
             Push newPush = Push.builder()
                     .fcmToken(request.fcmToken())
                     .memberId(memberId)
-                    .storeId(request.storeId())
-                    .boardId(request.boardId())
                     .productId(request.productId())
                     .pushCategory(PushCategory.valueOf(request.pushCategory()))
                     .subscribed(true)

--- a/src/test/java/com/bbangle/bbangle/AbstractIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/AbstractIntegrationTest.java
@@ -4,20 +4,22 @@ import com.bbangle.bbangle.analytics.service.AnalyticsService;
 import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.domain.BoardDetail;
 import com.bbangle.bbangle.board.domain.Product;
-import com.bbangle.bbangle.board.repository.BoardImgRepository;
 import com.bbangle.bbangle.board.domain.ProductImg;
 import com.bbangle.bbangle.board.repository.BoardDetailRepository;
+import com.bbangle.bbangle.board.repository.BoardImgRepository;
 import com.bbangle.bbangle.board.repository.BoardRepository;
 import com.bbangle.bbangle.board.repository.ProductRepository;
 import com.bbangle.bbangle.board.service.BoardService;
+import com.bbangle.bbangle.boardstatistic.domain.BoardStatistic;
+import com.bbangle.bbangle.boardstatistic.repository.BoardStatisticRepository;
 import com.bbangle.bbangle.member.domain.Member;
 import com.bbangle.bbangle.member.repository.MemberRepository;
 import com.bbangle.bbangle.member.service.MemberService;
-import com.bbangle.bbangle.boardstatistic.domain.BoardStatistic;
-import com.bbangle.bbangle.boardstatistic.repository.BoardStatisticRepository;
 import com.bbangle.bbangle.notification.repository.NotificationRepository;
-import com.bbangle.bbangle.review.repository.ReviewRepository;
+import com.bbangle.bbangle.push.repository.PushRepository;
+import com.bbangle.bbangle.push.service.PushService;
 import com.bbangle.bbangle.review.domain.Review;
+import com.bbangle.bbangle.review.repository.ReviewRepository;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.repository.StoreRepository;
 import com.bbangle.bbangle.store.service.StoreService;
@@ -31,11 +33,6 @@ import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -43,6 +40,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 
@@ -70,6 +73,8 @@ public abstract class AbstractIntegrationTest {
     @Autowired
     protected WishListBoardService wishListBoardService;
     @Autowired
+    protected PushService pushService;
+    @Autowired
     protected BoardRepository boardRepository;
     @Autowired
     protected StoreRepository storeRepository;
@@ -93,6 +98,8 @@ public abstract class AbstractIntegrationTest {
     protected BoardDetailRepository boardDetailRepository;
     @Autowired
     protected NotificationRepository notificationRepository;
+    @Autowired
+    protected PushRepository pushRepository;
 
     @BeforeEach
     void before() {
@@ -109,6 +116,7 @@ public abstract class AbstractIntegrationTest {
         wishListStoreRepository.deleteAllInBatch();
         reviewRepository.deleteAllInBatch();
         notificationRepository.deleteAllInBatch();
+        pushRepository.deleteAllInBatch();
     }
 
     protected FixtureMonkey fixtureMonkey = FixtureMonkey.builder()

--- a/src/test/java/com/bbangle/bbangle/AbstractIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/AbstractIntegrationTest.java
@@ -17,6 +17,7 @@ import com.bbangle.bbangle.member.repository.MemberRepository;
 import com.bbangle.bbangle.member.service.MemberService;
 import com.bbangle.bbangle.notification.repository.NotificationRepository;
 import com.bbangle.bbangle.push.repository.PushRepository;
+import com.bbangle.bbangle.push.service.FcmService;
 import com.bbangle.bbangle.push.service.PushService;
 import com.bbangle.bbangle.review.domain.Review;
 import com.bbangle.bbangle.review.repository.ReviewRepository;
@@ -74,6 +75,8 @@ public abstract class AbstractIntegrationTest {
     protected WishListBoardService wishListBoardService;
     @Autowired
     protected PushService pushService;
+    @Autowired
+    protected FcmService fcmService;
     @Autowired
     protected BoardRepository boardRepository;
     @Autowired

--- a/src/test/java/com/bbangle/bbangle/DatabaseCleaner.java
+++ b/src/test/java/com/bbangle/bbangle/DatabaseCleaner.java
@@ -45,4 +45,14 @@ public class DatabaseCleaner implements InitializingBean {
         em.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
     }
 
+    @Transactional
+    public void clearMember() {
+        em.clear();
+        em.flush();
+        em.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        em.createNativeQuery("TRUNCATE TABLE member").executeUpdate();
+        em.createNativeQuery("ALTER TABLE member ALTER COLUMN id RESTART WITH 2").executeUpdate();
+        em.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
 }

--- a/src/test/java/com/bbangle/bbangle/fixture/PushFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/PushFixture.java
@@ -1,0 +1,51 @@
+package com.bbangle.bbangle.fixture;
+
+import com.bbangle.bbangle.push.domain.Push;
+import com.bbangle.bbangle.push.domain.PushCategory;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PushFixture {
+
+
+    public static Push newBbangketingPush(Long memberId, Long storeId, Long boardId, Long productId) {
+        return Push.builder()
+                .fcmToken("testFcmToken1")
+                .memberId(memberId)
+                .storeId(storeId)
+                .boardId(boardId)
+                .productId(productId)
+                .pushCategory(PushCategory.BBANGCKETING)
+                .subscribed(true)
+                .build();
+    }
+
+
+    public static Push newRestockPush(Long memberId, Long storeId, Long boardId, Long productId) {
+        return Push.builder()
+                .fcmToken("testFcmToken1")
+                .memberId(memberId)
+                .storeId(storeId)
+                .boardId(boardId)
+                .productId(productId)
+                .pushCategory(PushCategory.RESTOCK)
+                .subscribed(true)
+                .build();
+    }
+
+
+    public static Push newCanceledPush(Long memberId, Long storeId, Long boardId, Long productId) {
+        return Push.builder()
+                .fcmToken("testFcmToken1")
+                .memberId(memberId)
+                .storeId(storeId)
+                .boardId(boardId)
+                .productId(productId)
+                .pushCategory(PushCategory.BBANGCKETING)
+                .subscribed(false)
+                .build();
+    }
+
+
+}

--- a/src/test/java/com/bbangle/bbangle/fixture/PushFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/PushFixture.java
@@ -9,12 +9,10 @@ import lombok.NoArgsConstructor;
 public class PushFixture {
 
 
-    public static Push newBbangketingPush(Long memberId, Long storeId, Long boardId, Long productId) {
+    public static Push newBbangketingPush(Long memberId, Long productId) {
         return Push.builder()
                 .fcmToken("testFcmToken1")
                 .memberId(memberId)
-                .storeId(storeId)
-                .boardId(boardId)
                 .productId(productId)
                 .pushCategory(PushCategory.BBANGCKETING)
                 .subscribed(true)
@@ -22,12 +20,10 @@ public class PushFixture {
     }
 
 
-    public static Push newRestockPush(Long memberId, Long storeId, Long boardId, Long productId) {
+    public static Push newRestockPush(Long memberId, Long productId) {
         return Push.builder()
                 .fcmToken("testFcmToken1")
                 .memberId(memberId)
-                .storeId(storeId)
-                .boardId(boardId)
                 .productId(productId)
                 .pushCategory(PushCategory.RESTOCK)
                 .subscribed(true)
@@ -35,12 +31,10 @@ public class PushFixture {
     }
 
 
-    public static Push newCanceledPush(Long memberId, Long storeId, Long boardId, Long productId) {
+    public static Push newCanceledPush(Long memberId, Long productId) {
         return Push.builder()
                 .fcmToken("testFcmToken1")
                 .memberId(memberId)
-                .storeId(storeId)
-                .boardId(boardId)
                 .productId(productId)
                 .pushCategory(PushCategory.BBANGCKETING)
                 .subscribed(false)

--- a/src/test/java/com/bbangle/bbangle/push/controller/PushControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/push/controller/PushControllerTest.java
@@ -39,8 +39,8 @@ class PushControllerTest extends AbstractIntegrationTest {
     DatabaseCleaner databaseCleaner;
 
 
-    @AfterEach
-    void tearDown() {
+    @BeforeEach
+    void setUp() {
         databaseCleaner.clearMember();
     }
 
@@ -54,9 +54,9 @@ class PushControllerTest extends AbstractIntegrationTest {
         Store store = createStore();
         Board board = createBoard(store);
         Product product = createProduct(board);
-        Member member = createMember();
+        createMember();
 
-        CreatePushRequest request = new CreatePushRequest("testFcmToken1", String.valueOf(PushCategory.BBANGCKETING), store.getId(), board.getId(), product.getId());
+        CreatePushRequest request = new CreatePushRequest("testFcmToken1", String.valueOf(PushCategory.BBANGCKETING), product.getId());
         String requestBody = objectMapper.writeValueAsString(request);
 
         // when & then
@@ -100,7 +100,7 @@ class PushControllerTest extends AbstractIntegrationTest {
         Push newPush = createCanceledPush(member);
         Push push = pushRepository.save(newPush);
 
-        CreatePushRequest request = new CreatePushRequest("testFcmToken1", String.valueOf(PushCategory.BBANGCKETING), push.getStoreId(), push.getBoardId(), push.getProductId());
+        CreatePushRequest request = new CreatePushRequest("testFcmToken1", String.valueOf(PushCategory.BBANGCKETING), push.getProductId());
         String requestBody = objectMapper.writeValueAsString(request);
 
         // when & then
@@ -154,7 +154,7 @@ class PushControllerTest extends AbstractIntegrationTest {
         Store store = createStore();
         Board board = createBoard(store);
         Product product = createProduct(board);
-        return PushFixture.newBbangketingPush(member.getId(), store.getId(), board.getId(), product.getId());
+        return PushFixture.newBbangketingPush(member.getId(), product.getId());
     }
 
 
@@ -162,7 +162,7 @@ class PushControllerTest extends AbstractIntegrationTest {
         Store store = createStore();
         Board board = createBoard(store);
         Product product = createProduct(board);
-        return PushFixture.newCanceledPush(member.getId(), store.getId(), board.getId(), product.getId());
+        return PushFixture.newCanceledPush(member.getId(), product.getId());
     }
 
 
@@ -173,8 +173,8 @@ class PushControllerTest extends AbstractIntegrationTest {
 
         for (int i = 1; i <= 10; i++) {
             Product product = createProduct(board);
-            Push bbangketingPush = PushFixture.newBbangketingPush(member.getId(), store.getId(), board.getId(), product.getId());
-            Push restockPush = PushFixture.newRestockPush(member.getId(), store.getId(), board.getId(), product.getId());
+            Push bbangketingPush = PushFixture.newBbangketingPush(member.getId(), product.getId());
+            Push restockPush = PushFixture.newRestockPush(member.getId(), product.getId());
             pushList.add(bbangketingPush);
             pushList.add(restockPush);
         }

--- a/src/test/java/com/bbangle/bbangle/push/controller/PushControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/push/controller/PushControllerTest.java
@@ -1,0 +1,209 @@
+package com.bbangle.bbangle.push.controller;
+
+import com.bbangle.bbangle.AbstractIntegrationTest;
+import com.bbangle.bbangle.DatabaseCleaner;
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.fixture.BoardFixture;
+import com.bbangle.bbangle.fixture.ProductFixture;
+import com.bbangle.bbangle.fixture.PushFixture;
+import com.bbangle.bbangle.fixture.StoreFixture;
+import com.bbangle.bbangle.member.domain.Member;
+import com.bbangle.bbangle.mock.WithCustomMockUser;
+import com.bbangle.bbangle.push.domain.Push;
+import com.bbangle.bbangle.push.domain.PushCategory;
+import com.bbangle.bbangle.push.dto.CreatePushRequest;
+import com.bbangle.bbangle.push.dto.PushRequest;
+import com.bbangle.bbangle.store.domain.Store;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PushControllerTest extends AbstractIntegrationTest {
+
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    DatabaseCleaner databaseCleaner;
+
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clearMember();
+    }
+
+
+    @Test
+    @Order(0)
+    @DisplayName("신규 푸시 알림 신청이 정상적으로 등록된다.")
+    @WithCustomMockUser
+    void createPushTest() throws Exception {
+        // given
+        Store store = createStore();
+        Board board = createBoard(store);
+        Product product = createProduct(board);
+        Member member = createMember();
+
+        CreatePushRequest request = new CreatePushRequest("testFcmToken1", String.valueOf(PushCategory.BBANGCKETING), store.getId(), board.getId(), product.getId());
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/push")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+
+    @Test
+    @Order(1)
+    @DisplayName("푸시 알림 신청이 정상적으로 해제된다.")
+    @WithCustomMockUser
+    void cancelPushTest() throws Exception {
+        // given
+        Member member = createMember();
+        Push newPush = createPush(member);
+        Push push = pushRepository.save(newPush);
+
+        PushRequest request = new PushRequest(push.getProductId(), String.valueOf(PushCategory.BBANGCKETING));
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/push")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+
+    @Test
+    @Order(2)
+    @DisplayName("해제한 푸시 알림에 대해 재신청이 정상적으로 등록된다.")
+    @WithCustomMockUser
+    void resubscribePushTest() throws Exception {
+        // given
+        Member member = createMember();
+        Push newPush = createCanceledPush(member);
+        Push push = pushRepository.save(newPush);
+
+        CreatePushRequest request = new CreatePushRequest("testFcmToken1", String.valueOf(PushCategory.BBANGCKETING), push.getStoreId(), push.getBoardId(), push.getProductId());
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/push")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+
+    @Test
+    @Order(3)
+    @DisplayName("푸시 알림 신청이 정상적으로 삭제된다.")
+    @WithCustomMockUser
+    void deletePushTest() throws Exception {
+        // given
+        Member member = createMember();
+        Push newPush = createPush(member);
+        Push push = pushRepository.save(newPush);
+
+        PushRequest request = new PushRequest(push.getProductId(), String.valueOf(PushCategory.BBANGCKETING));
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/push")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+
+    @Test
+    @Order(4)
+    @DisplayName("신청한 푸시 알림이 정상적으로 조회된다.")
+    @WithCustomMockUser
+    void getPushTest() throws Exception {
+        // given
+        Member member = createMember();
+        create20Pushes(member);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/push?pushCategory=BBANGCKETING"))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+
+    private Push createPush(Member member) {
+        Store store = createStore();
+        Board board = createBoard(store);
+        Product product = createProduct(board);
+        return PushFixture.newBbangketingPush(member.getId(), store.getId(), board.getId(), product.getId());
+    }
+
+
+    private Push createCanceledPush(Member member) {
+        Store store = createStore();
+        Board board = createBoard(store);
+        Product product = createProduct(board);
+        return PushFixture.newCanceledPush(member.getId(), store.getId(), board.getId(), product.getId());
+    }
+
+
+    private void create20Pushes(Member member) {
+        Store store = createStore();
+        Board board = createBoard(store);
+        List<Push> pushList = new ArrayList<>();
+
+        for (int i = 1; i <= 10; i++) {
+            Product product = createProduct(board);
+            Push bbangketingPush = PushFixture.newBbangketingPush(member.getId(), store.getId(), board.getId(), product.getId());
+            Push restockPush = PushFixture.newRestockPush(member.getId(), store.getId(), board.getId(), product.getId());
+            pushList.add(bbangketingPush);
+            pushList.add(restockPush);
+        }
+
+        pushRepository.saveAll(pushList);
+    }
+
+
+    private Store createStore() {
+        return storeRepository.save(StoreFixture.storeGenerator());
+    }
+
+
+    private Board createBoard(Store store) {
+        return boardRepository.save(BoardFixture.randomBoard(store));
+    }
+
+
+    private Product createProduct(Board board) {
+        return productRepository.save(ProductFixture.randomProduct(board));
+    }
+
+
+    private Member createMember() {
+        Member member = Member.builder()
+                .id(2L)
+                .build();
+
+        return memberRepository.save(member);
+    }
+
+}

--- a/src/test/java/com/bbangle/bbangle/push/service/PushServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/push/service/PushServiceTest.java
@@ -31,16 +31,21 @@ class PushServiceTest extends AbstractIntegrationTest {
         Board board = createBoard(store);
         Product product = createProduct(board);
         Member member = createMember();
-        CreatePushRequest request = new CreatePushRequest("testFcmToken1", String.valueOf(PushCategory.BBANGCKETING), store.getId(), board.getId(), product.getId());
+        CreatePushRequest request = new CreatePushRequest("testFcmToken1", String.valueOf(PushCategory.BBANGCKETING), product.getId());
 
         // when
         pushService.createPush(request, member.getId());
         long pushCount = pushRepository.count();
-        Push push = pushRepository.findById(1L).get();
+        Push resultPush = null;
+        List<Push> pushList = pushRepository.findAll();
+        for (Push p : pushList) {
+            resultPush = p;
+        }
 
         // then
         assertThat(pushCount).isOne();
-        assertThat(push.isSubscribed()).isTrue();
+        assertThat(pushList).hasSize(1);
+        assertThat(resultPush.isSubscribed()).isTrue();
     }
 
 
@@ -58,11 +63,16 @@ class PushServiceTest extends AbstractIntegrationTest {
         // when
         pushService.cancelPush(request, member.getId());
         long pushCount = pushRepository.count();
-        Push foundPush = pushRepository.findById(2L).get();
+        Push resultPush = null;
+        List<Push> pushList = pushRepository.findAll();
+        for (Push p : pushList) {
+            resultPush = p;
+        }
 
         // then
         assertThat(pushCount).isOne();
-        assertThat(foundPush.isSubscribed()).isFalse();
+        assertThat(pushList).hasSize(1);
+        assertThat(resultPush.isSubscribed()).isFalse();
     }
 
 
@@ -75,16 +85,21 @@ class PushServiceTest extends AbstractIntegrationTest {
         Member member = memberRepository.save(newMember);
         Push newPush = createCanceledPush(member);
         Push push = pushRepository.save(newPush);
-        CreatePushRequest request = new CreatePushRequest("testFcmToken1", String.valueOf(PushCategory.BBANGCKETING), push.getStoreId(), push.getBoardId(), push.getProductId());
+        CreatePushRequest request = new CreatePushRequest("testFcmToken1", String.valueOf(PushCategory.BBANGCKETING), push.getProductId());
 
         // when
         pushService.createPush(request, member.getId());
         long pushCount = pushRepository.count();
-        Push foundPush = pushRepository.findById(3L).get();
+        Push resultPush = null;
+        List<Push> pushList = pushRepository.findAll();
+        for (Push p : pushList) {
+            resultPush = p;
+        }
 
         // then
         assertThat(pushCount).isOne();
-        assertThat(foundPush.isSubscribed()).isTrue();
+        assertThat(pushList).hasSize(1);
+        assertThat(resultPush.isSubscribed()).isTrue();
     }
 
 
@@ -133,7 +148,7 @@ class PushServiceTest extends AbstractIntegrationTest {
         Store store = createStore();
         Board board = createBoard(store);
         Product product = createProduct(board);
-        return PushFixture.newBbangketingPush(member.getId(), store.getId(), board.getId(), product.getId());
+        return PushFixture.newBbangketingPush(member.getId(), product.getId());
     }
 
 
@@ -141,7 +156,7 @@ class PushServiceTest extends AbstractIntegrationTest {
         Store store = createStore();
         Board board = createBoard(store);
         Product product = createProduct(board);
-        return PushFixture.newCanceledPush(member.getId(), store.getId(), board.getId(), product.getId());
+        return PushFixture.newCanceledPush(member.getId(), product.getId());
     }
 
 
@@ -152,8 +167,8 @@ class PushServiceTest extends AbstractIntegrationTest {
 
         for (int i = 1; i <= 10; i++) {
             Product product = createProduct(board);
-            Push bbangketingPush = PushFixture.newBbangketingPush(member.getId(), store.getId(), board.getId(), product.getId());
-            Push restockPush = PushFixture.newRestockPush(member.getId(), store.getId(), board.getId(), product.getId());
+            Push bbangketingPush = PushFixture.newBbangketingPush(member.getId(), product.getId());
+            Push restockPush = PushFixture.newRestockPush(member.getId(), product.getId());
             pushList.add(bbangketingPush);
             pushList.add(restockPush);
         }

--- a/src/test/java/com/bbangle/bbangle/push/service/PushServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/push/service/PushServiceTest.java
@@ -1,0 +1,184 @@
+package com.bbangle.bbangle.push.service;
+
+import com.bbangle.bbangle.AbstractIntegrationTest;
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.fixture.*;
+import com.bbangle.bbangle.member.domain.Member;
+import com.bbangle.bbangle.push.domain.Push;
+import com.bbangle.bbangle.push.domain.PushCategory;
+import com.bbangle.bbangle.push.dto.CreatePushRequest;
+import com.bbangle.bbangle.push.dto.PushRequest;
+import com.bbangle.bbangle.push.dto.PushResponse;
+import com.bbangle.bbangle.store.domain.Store;
+import org.junit.jupiter.api.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PushServiceTest extends AbstractIntegrationTest {
+
+
+    @Test
+    @Order(0)
+    @DisplayName("신규 푸시 알림 신청이 정상적으로 등록된다.")
+    void createPushTest() {
+        // given
+        Store store = createStore();
+        Board board = createBoard(store);
+        Product product = createProduct(board);
+        Member member = createMember();
+        CreatePushRequest request = new CreatePushRequest("testFcmToken1", String.valueOf(PushCategory.BBANGCKETING), store.getId(), board.getId(), product.getId());
+
+        // when
+        pushService.createPush(request, member.getId());
+        long pushCount = pushRepository.count();
+        Push push = pushRepository.findById(1L).get();
+
+        // then
+        assertThat(pushCount).isOne();
+        assertThat(push.isSubscribed()).isTrue();
+    }
+
+
+    @Test
+    @Order(1)
+    @DisplayName("푸시 알림 신청이 정상적으로 해제된다.")
+    void cancelPushTest() {
+        // given
+        Member newMember = createMember();
+        Member member = memberRepository.save(newMember);
+        Push newPush = createPush(newMember);
+        Push push = pushRepository.save(newPush);
+        PushRequest request = new PushRequest(push.getProductId(), String.valueOf(PushCategory.BBANGCKETING));
+
+        // when
+        pushService.cancelPush(request, member.getId());
+        long pushCount = pushRepository.count();
+        Push foundPush = pushRepository.findById(2L).get();
+
+        // then
+        assertThat(pushCount).isOne();
+        assertThat(foundPush.isSubscribed()).isFalse();
+    }
+
+
+    @Test
+    @Order(2)
+    @DisplayName("해제한 푸시 알림에 대해 재신청이 정상적으로 등록된다.")
+    void resubscribePushTest() {
+        // given
+        Member newMember = createMember();
+        Member member = memberRepository.save(newMember);
+        Push newPush = createCanceledPush(member);
+        Push push = pushRepository.save(newPush);
+        CreatePushRequest request = new CreatePushRequest("testFcmToken1", String.valueOf(PushCategory.BBANGCKETING), push.getStoreId(), push.getBoardId(), push.getProductId());
+
+        // when
+        pushService.createPush(request, member.getId());
+        long pushCount = pushRepository.count();
+        Push foundPush = pushRepository.findById(3L).get();
+
+        // then
+        assertThat(pushCount).isOne();
+        assertThat(foundPush.isSubscribed()).isTrue();
+    }
+
+
+    @Test
+    @Order(3)
+    @DisplayName("푸시 알림 신청이 정상적으로 삭제된다.")
+    void deletePushTest() {
+        // given
+        Member newMember = createMember();
+        Member member = memberRepository.save(newMember);
+        Push newPush = createPush(newMember);
+        Push push = pushRepository.save(newPush);
+        PushRequest request = new PushRequest(push.getProductId(), String.valueOf(PushCategory.BBANGCKETING));
+
+        // when
+        pushService.deletePush(request, member.getId());
+        long pushCount = pushRepository.count();
+
+        // then
+        assertThat(pushCount).isZero();
+    }
+
+
+    @Test
+    @Order(4)
+    @DisplayName("신청한 푸시 알림이 정상적으로 조회된다.")
+    void getPushTest() {
+        // given
+        Member newMember = createMember();
+        Member member = memberRepository.save(newMember);
+        create20Pushes(member);
+
+        // when
+        List<PushResponse> bbangketingPushList = pushService.getPush(String.valueOf(PushCategory.BBANGCKETING), member.getId());
+        List<PushResponse> restockPushList = pushService.getPush(String.valueOf(PushCategory.RESTOCK), member.getId());
+        long pushCount = pushRepository.count();
+
+        // then
+        assertThat(pushCount).isEqualTo(20);
+        assertThat(bbangketingPushList).hasSize(10);
+        assertThat(restockPushList).hasSize(10);
+    }
+
+
+    private Push createPush(Member member) {
+        Store store = createStore();
+        Board board = createBoard(store);
+        Product product = createProduct(board);
+        return PushFixture.newBbangketingPush(member.getId(), store.getId(), board.getId(), product.getId());
+    }
+
+
+    private Push createCanceledPush(Member member) {
+        Store store = createStore();
+        Board board = createBoard(store);
+        Product product = createProduct(board);
+        return PushFixture.newCanceledPush(member.getId(), store.getId(), board.getId(), product.getId());
+    }
+
+
+    private void create20Pushes(Member member) {
+        Store store = createStore();
+        Board board = createBoard(store);
+        List<Push> pushList = new ArrayList<>();
+
+        for (int i = 1; i <= 10; i++) {
+            Product product = createProduct(board);
+            Push bbangketingPush = PushFixture.newBbangketingPush(member.getId(), store.getId(), board.getId(), product.getId());
+            Push restockPush = PushFixture.newRestockPush(member.getId(), store.getId(), board.getId(), product.getId());
+            pushList.add(bbangketingPush);
+            pushList.add(restockPush);
+        }
+
+        pushRepository.saveAll(pushList);
+    }
+
+
+    private Store createStore() {
+        return storeRepository.save(StoreFixture.storeGenerator());
+    }
+
+
+    private Board createBoard(Store store) {
+        return boardRepository.save(BoardFixture.randomBoard(store));
+    }
+
+
+    private Product createProduct(Board board) {
+        return productRepository.save(ProductFixture.randomProduct(board));
+    }
+
+
+    private Member createMember() {
+        return memberRepository.save(MemberFixture.createKakaoMember());
+    }
+
+}


### PR DESCRIPTION
---
name: "✅ Feature"
about: 푸시 알림 기능 1차 구현

---
## History
Issues [#140](https://github.com/eco-dessert-platform/backend/issues/140)


## 🚀 Major Changes & Explanations

- Push 엔티티 생성
- 푸시 등록(재등록), 해제, 삭제, 조회 기능 구현


## 📷 Test Image
![image](https://github.com/eco-dessert-platform/backend/assets/110921983/1fc61119-4063-4ffd-86eb-dc6b76e38db7)


## 💡 ETC

- 실제로 사용자에게 푸시 알림 나가는 기능은 구현되지 않은 상태이지만 프론트팀 요청으로 1차 merge
- 기능 미구현으로 FirebaseConfig 비활성화
- CRUD만 정상 동작