### PR TITLE
오늘 주문 가능 상품 필터 조건 리팩토링

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/controller/BoardController.java
+++ b/src/main/java/com/bbangle/bbangle/board/controller/BoardController.java
@@ -49,7 +49,6 @@ public class BoardController {
     private final RedisTemplate<String, Object> redisTemplate;
     private final ResponseService responseService;
     private final BoardService boardService;
-    private final BoardStatisticService boardStatisticService;
     private final StoreService storeService;
     private final ReviewService reviewService;
 

--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/BoardFilterCreator.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/BoardFilterCreator.java
@@ -8,6 +8,8 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.BooleanPath;
 import com.querydsl.core.types.dsl.NumberPath;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -23,8 +25,24 @@ public class BoardFilterCreator {
         addTagCondition();
         addPriceCondition();
         addCategoryCondition();
+        addDaysOfWeekCondition();
 
         return builder;
+    }
+    private void addDaysOfWeekCondition() {
+        if (filterRequest.orderAvailableToday() != null && filterRequest.orderAvailableToday()) {
+            DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
+
+            switch (dayOfWeek) {
+                case MONDAY -> builder.and(product.monday.eq(true));
+                case TUESDAY -> builder.and(product.tuesday.eq(true));
+                case WEDNESDAY -> builder.and(product.wednesday.eq(true));
+                case THURSDAY -> builder.and(product.thursday.eq(true));
+                case FRIDAY -> builder.and(product.friday.eq(true));
+                case SATURDAY -> builder.and(product.saturday.eq(true));
+                case SUNDAY -> builder.and(product.sunday.eq(true));
+            }
+        }
     }
 
     private void addCategoryCondition() {

--- a/src/test/java/com/bbangle/bbangle/board/repository/basic/cursor/CursorGeneratorTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/repository/basic/cursor/CursorGeneratorTest.java
@@ -224,7 +224,7 @@ class CursorGeneratorTest extends AbstractIntegrationTest {
                 .getCursor(NULL_CURSOR);
 
             //then
-            assertThat(recommendCursor.getValue()).isNull();
+            assertThat(recommendCursor.getValue()).isEqualTo(QBoard.board.isDeleted.eq(false));
         }
 
         @Test
@@ -241,6 +241,7 @@ class CursorGeneratorTest extends AbstractIntegrationTest {
                 .fetchOne();
 
             String expectedBuilder = new BooleanBuilder()
+                .and(QBoard.board.isDeleted.eq(false))
                 .and(QBoardStatistic.boardStatistic.basicScore.lt(expectedScore))
                 .or(QBoardStatistic.boardStatistic.basicScore.eq(expectedScore).and(QBoard.board.id.loe(firstSavedBoardId)))
                 .toString();

--- a/src/test/java/com/bbangle/bbangle/board/service/BoardServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/service/BoardServiceTest.java
@@ -59,15 +59,6 @@ class BoardServiceTest extends AbstractIntegrationTest {
     private static final Long NULL_MEMBER = null;
     private final String TEST_TITLE = "TestTitle";
 
-    @Autowired
-    BoardService boardService;
-
-    @Autowired
-    WishListBoardService wishListBoardService;
-
-    @Autowired
-    EntityManager entityManager;
-
     Board board;
     Board board2;
     Store store;


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History
*Resolves #198 
<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations
- FilterCreator에 금일 주문 가능 조건이 들어갈 경우 우선 오늘에 해당하는 요일을 찾는다
    - 예를들어 오늘이 일요일이면 LocalDate.now().getDayOfWeek();로 일요일을 찾아서 변수로 선언
- switch case로 builder.and(product.sunday.eq(true)); 조건을 찾아 where 조건문에 넣을 수 있도록 BooleanBuilder에 추가
    - 요일마다 분기문처리가 되어 상품 중 그 요일에 주문이 가능한 상품을 필터링할 때 사용됨
    - 해당 조건으로 board 조회
- 실제 테스트 결과로 5개의 product에 sunday 컬럼에 1 값(true)를 넣어주고 테스트
- 오늘 주문 가능 상품만 조회 시 정상적으로 해당 product를 가지고 있는 board만 조회가 됨을 확인
- test 깨지는 현상(board의 isDeleted가 조회 조건문에 추가됨으로 발생한) 수정

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image
![스크린샷 2024-06-30 오후 8 39 00](https://github.com/eco-dessert-platform/backend/assets/85065626/4299008c-fc26-4db8-9c20-9ff2e01e3002)
![스크린샷 2024-06-30 오후 8 39 11](https://github.com/eco-dessert-platform/backend/assets/85065626/658e05b7-5410-40a6-b398-78bb913dadec)
![스크린샷 2024-06-30 오후 8 42 17](https://github.com/eco-dessert-platform/backend/assets/85065626/e997658c-0a43-48f4-9762-ef2e19f21e40)

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
