### PR TITLE
[프론트 요청] 리뷰 수정 시 이미지 처리 로직 리팩토링

### DIFF
--- a/src/main/java/com/bbangle/bbangle/image/repository/ImageRepository.java
+++ b/src/main/java/com/bbangle/bbangle/image/repository/ImageRepository.java
@@ -4,6 +4,9 @@ import com.bbangle.bbangle.image.domain.Image;
 import com.bbangle.bbangle.image.domain.ImageCategory;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
@@ -16,4 +19,10 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     List<Image> findAllByPathIn(List<String> urls);
 
     List<Image> findByDomainId(Long reviewId);
+
+    @Modifying
+    @Query("delete from Image i where i.path in :imagePaths")
+    void deleteAllByPathIn(@Param("imagePaths") List<String> imagePaths);
+
+    Image findByPath(String url);
 }

--- a/src/main/java/com/bbangle/bbangle/image/service/S3Service.java
+++ b/src/main/java/com/bbangle/bbangle/image/service/S3Service.java
@@ -13,6 +13,7 @@ import com.amazonaws.services.s3.model.Permission;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.bbangle.bbangle.exception.BbangleException;
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -61,6 +62,10 @@ class S3Service {
     return amazonS3.copyObject(copyObjectRequest);
   }
 
+  public void deleteImages(List<String> urls){
+    urls.forEach(url -> amazonS3.deleteObject(bucket, url));
+  }
+
   private String uploadImage(
       final MultipartFile image,
       final String ext,
@@ -87,6 +92,4 @@ class S3Service {
         .toString();
     return uuid + ext;
   }
-
-
 }

--- a/src/main/java/com/bbangle/bbangle/review/domain/Review.java
+++ b/src/main/java/com/bbangle/bbangle/review/domain/Review.java
@@ -26,7 +26,6 @@ public class Review extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //동현님 말대로 연관매핑 안해보고 해보기
     @Column(name = "member_id")
     @NotNull
     private Long memberId;

--- a/src/main/java/com/bbangle/bbangle/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/review/repository/ReviewRepositoryImpl.java
@@ -8,7 +8,6 @@ import com.bbangle.bbangle.config.ranking.BoardGrade;
 import com.bbangle.bbangle.image.domain.QImage;
 import com.bbangle.bbangle.image.dto.QImageDto;
 import com.bbangle.bbangle.review.domain.QReview;
-import com.bbangle.bbangle.review.domain.QReviewImg;
 import com.bbangle.bbangle.review.domain.ReviewCursor;
 import com.bbangle.bbangle.review.domain.ReviewLike;
 import com.bbangle.bbangle.review.domain.QReviewLike;
@@ -48,7 +47,6 @@ import static java.util.stream.Collectors.toMap;
 public class ReviewRepositoryImpl implements ReviewQueryDSLRepository{
     private static final QReview review = QReview.review;
     private static final QMember member = QMember.member;
-    private static final QReviewImg reviewImg = QReviewImg.reviewImg;
     private static final QImage image = QImage.image;
     private static final QReviewLike reviewLike = QReviewLike.reviewLike;
     private static final Long PAGE_SIZE = 10L;


### PR DESCRIPTION
---
name: "✅ Feature"
about: 리뷰 수정 시 이미지 처리 로직 리팩토링
title: "✅ Feature"
labels: ✅ Feature
assignees: 윤동석

---
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
#200 

## 🚀 Major Changes & Explanations

리뷰 수정 시 이미지 처리 로직을 리팩토링 했습니다
변경 사항은 이슈에 자세히 적어 놓았으니 확인해주시면 감사하겠습니다

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->
S3 를 확인하는게 핵심이였기 때문에 스웨거로 테스트 진행했습니다
추후 테스트 코드까지 추가하겠습니다

테스트 로직 설명
이미지 업로드 API로 이미지 4개 추가 -> 리뷰 작성 -> 이미지 1개 추가 -> 리뷰 수정 

1. 이미지 업로드 API로 이미지 4개 추가
![image](https://github.com/eco-dessert-platform/backend/assets/110441578/a605f92f-362e-4632-a010-e163a29b8d9f)
해당 로직 수행으로 S3에 review/-1 에 임시로 이미지 저장
![image](https://github.com/eco-dessert-platform/backend/assets/110441578/a9f89e5f-2ba2-4581-a702-2ad4c7d4b798)

2. 리뷰 작성
![image](https://github.com/eco-dessert-platform/backend/assets/110441578/bcafa7cf-c84a-4ee9-8a88-040707bf9754)
S3 review/{reviewId} 폴더에 이미지 담기는 것 확인
![image](https://github.com/eco-dessert-platform/backend/assets/110441578/f0f030ba-6e6f-494d-9ec1-dafd5f3d5bd4)

3. 리뷰 수정 시 사용자가 새로 이미지 1개를 추가했다고 가정
![image](https://github.com/eco-dessert-platform/backend/assets/110441578/ab5b7162-932d-473c-b59a-8ce879f75b4c)

4. 리뷰 수정
테스트 상황
기존 이미지 4개 중 2개는 삭제, 1개는 유지, 3번 단계에서 추가한 이미지 1개를 추가한다고 가정
![image](https://github.com/eco-dessert-platform/backend/assets/110441578/c4f2ae67-b5d4-4b51-9637-1790949dbc9e)

S3 테스트 결과
![image](https://github.com/eco-dessert-platform/backend/assets/110441578/59a13bc2-aa61-4da2-8fda-456ab7e0d504)
해당 리뷰 DB  조회
![image](https://github.com/eco-dessert-platform/backend/assets/110441578/41a84dd6-58e8-45dd-93f2-8bfd7a68e1bb)
 


## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
