### PR TITLE
리뷰 삭제 리팩토링 및 이미지 삭제 스케줄러 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/image/repository/ImageRepository.java
+++ b/src/main/java/com/bbangle/bbangle/image/repository/ImageRepository.java
@@ -20,8 +20,8 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     List<Image> findByDomainId(Long reviewId);
 
-    @Modifying
-    @Query("delete from Image i where i.path in :imagePaths")
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Image i WHERE i.path IN :imagePaths")
     void deleteAllByPathIn(@Param("imagePaths") List<String> imagePaths);
 
     Image findByPath(String url);

--- a/src/main/java/com/bbangle/bbangle/image/repository/ImageRepository.java
+++ b/src/main/java/com/bbangle/bbangle/image/repository/ImageRepository.java
@@ -25,4 +25,11 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     void deleteAllByPathIn(@Param("imagePaths") List<String> imagePaths);
 
     Image findByPath(String url);
+
+    @Modifying
+    @Query("DELETE FROM Image i WHERE i.domainId = :tempDomainId")
+    void deleteTempImages(@Param("tempDomainId") Long tempDomainId);
+
+    void deleteAllByDomainId(Long reviewId);
+
 }

--- a/src/main/java/com/bbangle/bbangle/image/service/ImageService.java
+++ b/src/main/java/com/bbangle/bbangle/image/service/ImageService.java
@@ -71,10 +71,8 @@ public class ImageService {
         AtomicInteger order = new AtomicInteger(0);
 
         List<Image> entities = imageList.stream().map(image -> {
-            String imagePath = s3Service.saveImage(
-                image,
-                imageFolderPathResolver(category, domainId)
-            );
+            String pathFromS3 = imageFolderPathResolver(category, domainId);
+            String imagePath = s3Service.saveImage(image, pathFromS3);
             imagePath = imagePath.replace(bucketDomain, cdnDomain);
             return createEntity(category, domainId, imagePath, order.getAndIncrement());
         }).toList();

--- a/src/main/java/com/bbangle/bbangle/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/bbangle/bbangle/review/repository/ReviewLikeRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
     Optional<ReviewLike> findByMemberIdAndReviewId(Long reviewId, Long memberId);
     List<ReviewLike> findByReviewId(Long reviewId);
-
+    void deleteAllByReviewId(Long reviewId);
 }

--- a/src/main/java/com/bbangle/bbangle/review/scheduler/SchedulerFactory.java
+++ b/src/main/java/com/bbangle/bbangle/review/scheduler/SchedulerFactory.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.review.scheduler;
 
+import com.bbangle.bbangle.image.repository.ImageRepository;
 import com.bbangle.bbangle.review.dto.LikeCountPerReviewIdDto;
 import com.bbangle.bbangle.review.dto.ReviewCountPerBoardIdDto;
 import com.bbangle.bbangle.review.repository.ReviewRepository;
@@ -17,19 +18,29 @@ import java.util.Map;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class BestReviewSelectionScheduler {
+public class SchedulerFactory {
     private final ReviewRepository reviewRepository;
+    private final ImageRepository imageRepository;
     private static final Long MINIMUM_BEST_REVIEW_STANDARD = 5L;
+    private static final Long TEMP_DOMAINID = -1L;
+
 
 
     @Scheduled(cron = "0 0 12 * * ?")//매일 낮 12시
     @Transactional
-    public void updateBestReview() {
+    public void action() {
         log.info("Scheduler started ........");
         List<Long> bestReviewIds = getBestReviewIds();
         log.info("start update process");
         reviewRepository.updateBestReview(bestReviewIds);
         log.info("finish update process");
+        log.info("start deleting temp Image Process");
+        deleteTempImage();
+        log.info("finish deleting temp Image Process");
+    }
+
+    public void deleteTempImage() {
+        imageRepository.deleteTempImages(TEMP_DOMAINID);
     }
 
     public List<Long> getBestReviewIds() {

--- a/src/test/java/com/bbangle/bbangle/review/BestReviewSchedulerTest.java
+++ b/src/test/java/com/bbangle/bbangle/review/BestReviewSchedulerTest.java
@@ -5,7 +5,7 @@ import com.bbangle.bbangle.fixture.ReviewFixture;
 import com.bbangle.bbangle.review.domain.Review;
 import com.bbangle.bbangle.review.domain.ReviewLike;
 import com.bbangle.bbangle.review.repository.ReviewLikeRepository;
-import com.bbangle.bbangle.review.scheduler.BestReviewSelectionScheduler;
+import com.bbangle.bbangle.review.scheduler.SchedulerFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
  class BestReviewSchedulerTest extends AbstractIntegrationTest {
     @Autowired
-    private BestReviewSelectionScheduler bestReviewSelectionScheduler;
+    private SchedulerFactory schedulerFactory;
     @Autowired
     private ReviewLikeRepository reviewLikeRepository;
 
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         }
 
         //when
-        List<Long> bestReviewIds = bestReviewSelectionScheduler.getBestReviewIds();
+        List<Long> bestReviewIds = schedulerFactory.getBestReviewIds();
 
         //Then
         assertThat(bestReviewIds)
@@ -55,7 +55,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         }
 
         //when
-        List<Long> bestReviewIds = bestReviewSelectionScheduler.getBestReviewIds();
+        List<Long> bestReviewIds = schedulerFactory.getBestReviewIds();
 
 
         //Then


### PR DESCRIPTION
---
name: "✅ Feature"
about: 리뷰 삭제 리팩토링 및 이미지 삭제 스케줄러 추가
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
Resolves #201 

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
- 이미지 업로드만 되고 리뷰 작성에 사용되지 않은 이미지들 삭제하는 스케줄러 추가
- 리뷰 삭제 시 연관된 이미지와 좋아요 deleteAll로 처리했으나 Spring data JPA가 단건으로 처리한다는 이슈가 있어 
  일괄 처리로 변경
- 리뷰 없는 게시글 조회 및 유저가 리뷰를 작성하지 않은 경우 내가 작성한 리뷰 조회 할 시 나타나는 에러 처리

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->
전체 테스트
![image](https://github.com/user-attachments/assets/f6cdb156-54de-4d64-b164-ccea334c9318)

리뷰 삭제 테스트 시 이미지와 좋아요 delete 쿼리 확인
![image](https://github.com/user-attachments/assets/71dd6495-8165-4a33-a521-97d6f5d417e1)

리뷰 없는 게시글 조회
![image](https://github.com/user-attachments/assets/d1b5f50e-5c82-4b90-8b5c-8c5764e4bd82)


## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
