### PR TITLE
유저의 정보를 내려주는 기능 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/config/OctetStreamReadMsgConverter.java
+++ b/src/main/java/com/bbangle/bbangle/config/OctetStreamReadMsgConverter.java
@@ -13,7 +13,7 @@ public class OctetStreamReadMsgConverter extends AbstractJackson2HttpMessageConv
     public OctetStreamReadMsgConverter(ObjectMapper objectMapper) {
         super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
     }
-    
+
     @Override
     public boolean canWrite(Class<?> clazz, MediaType mediaType) {
         return false;

--- a/src/main/java/com/bbangle/bbangle/config/OctetStreamReadMsgConverter.java
+++ b/src/main/java/com/bbangle/bbangle/config/OctetStreamReadMsgConverter.java
@@ -1,0 +1,31 @@
+package com.bbangle.bbangle.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Type;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OctetStreamReadMsgConverter extends AbstractJackson2HttpMessageConverter {
+    @Autowired
+    public OctetStreamReadMsgConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+    
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/config/WebConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.bbangle.bbangle.config;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private OctetStreamReadMsgConverter octetStreamReadMsgConverter;
+
+    @Autowired
+    public WebConfig(OctetStreamReadMsgConverter octetStreamReadMsgConverter) {
+        this.octetStreamReadMsgConverter = octetStreamReadMsgConverter;
+    }
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.add(octetStreamReadMsgConverter);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/member/controller/MemberController.java
+++ b/src/main/java/com/bbangle/bbangle/member/controller/MemberController.java
@@ -7,7 +7,10 @@ import com.bbangle.bbangle.member.dto.WithdrawalRequestDto;
 import com.bbangle.bbangle.member.dto.MemberInfoRequest;
 import com.bbangle.bbangle.member.service.MemberService;
 import com.bbangle.bbangle.util.SecurityUtils;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,10 +24,13 @@ public class MemberController {
     private final ResponseService responseService;
     private static final String DELETE_SUCCESS_MSG = "회원 탈퇴에 성공했습니다";
 
-    @PutMapping("additional-information")
+    @PutMapping(value = "additional-information", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public CommonResult updateInfo(
         @RequestPart
         MemberInfoRequest additionalInfo,
+        @Parameter(
+            description = "프로필 이미지 파일, parameter 명은 profileImg"
+        )
         @RequestPart(required = false)
         MultipartFile profileImg,
         @AuthenticationPrincipal
@@ -43,5 +49,13 @@ public class MemberController {
         memberService.saveDeleteReason(withdrawalRequestDto, memberId);
         memberService.deleteMember(memberId);
         return responseService.getSingleResult(new MessageDto(DELETE_SUCCESS_MSG,true));
+    }
+
+    @GetMapping("/status")
+    public CommonResult getIsAssigned(
+        @AuthenticationPrincipal
+        Long memberId
+    ){
+        return responseService.getSingleResult(memberService.getIsAssigned(memberId));
     }
 }

--- a/src/main/java/com/bbangle/bbangle/member/dto/MemberAssignResponse.java
+++ b/src/main/java/com/bbangle/bbangle/member/dto/MemberAssignResponse.java
@@ -1,0 +1,8 @@
+package com.bbangle.bbangle.member.dto;
+
+public record MemberAssignResponse(
+    Boolean isFullyAssigned,
+    Boolean isPreferenceAssigned
+) {
+
+}

--- a/src/main/java/com/bbangle/bbangle/member/repository/SignatureAgreementRepository.java
+++ b/src/main/java/com/bbangle/bbangle/member/repository/SignatureAgreementRepository.java
@@ -1,8 +1,12 @@
 package com.bbangle.bbangle.member.repository;
 
 import com.bbangle.bbangle.member.domain.SignatureAgreement;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SignatureAgreementRepository extends JpaRepository<SignatureAgreement, Long> {
 
+    @Query("select count(s.id) > 0 from SignatureAgreement s where s.member.id = :memberId")
+    boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/com/bbangle/bbangle/member/service/MemberService.java
+++ b/src/main/java/com/bbangle/bbangle/member/service/MemberService.java
@@ -2,16 +2,20 @@ package com.bbangle.bbangle.member.service;
 
 import static com.bbangle.bbangle.image.domain.ImageCategory.MEMBER_PROFILE;
 
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.image.service.ImageService;
 import com.bbangle.bbangle.member.domain.Agreement;
 import com.bbangle.bbangle.member.domain.Member;
 import com.bbangle.bbangle.member.domain.SignatureAgreement;
 import com.bbangle.bbangle.member.domain.Withdrawal;
+import com.bbangle.bbangle.member.dto.MemberAssignResponse;
 import com.bbangle.bbangle.member.dto.MemberInfoRequest;
 import com.bbangle.bbangle.member.dto.WithdrawalRequestDto;
 import com.bbangle.bbangle.member.repository.MemberRepository;
 import com.bbangle.bbangle.member.repository.SignatureAgreementRepository;
 import com.bbangle.bbangle.member.repository.WithdrawalRepository;
+import com.bbangle.bbangle.preference.repository.MemberPreferenceRepository;
 import com.bbangle.bbangle.wishlist.dto.FolderRequestDto;
 import com.bbangle.bbangle.wishlist.service.WishListBoardService;
 import com.bbangle.bbangle.wishlist.service.WishListFolderService;
@@ -44,6 +48,7 @@ public class MemberService {
     private final WishListBoardService wishListBoardService;
     private final WithdrawalRepository withdrawalRepository;
     private final WishListFolderService wishListFolderService;
+    private final MemberPreferenceRepository memberPreferenceRepository;
 
     @PostConstruct
     public void initSetting() {
@@ -156,6 +161,15 @@ public class MemberService {
         memberRepository.save(newMember);
 
         return newMember;
+    }
+
+    @Transactional(readOnly = true)
+    public MemberAssignResponse getIsAssigned(Long memberId) {
+
+        boolean isFullyAssigned = signatureAgreementRepository.existsByMemberId(memberId);
+        boolean isPreferenceAssigned = memberPreferenceRepository.existsByMemberId(memberId);
+
+        return new MemberAssignResponse(isFullyAssigned, isPreferenceAssigned);
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/member/controller/MemberControllerTest.java
@@ -1,0 +1,59 @@
+package com.bbangle.bbangle.member.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bbangle.bbangle.AbstractIntegrationTest;
+import com.bbangle.bbangle.fixture.MemberFixture;
+import com.bbangle.bbangle.member.domain.Member;
+import com.bbangle.bbangle.preference.service.PreferenceService;
+import com.bbangle.bbangle.token.jwt.TokenProvider;
+import java.time.Duration;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MemberControllerTest extends AbstractIntegrationTest {
+
+    @Autowired
+    PreferenceService preferenceService;
+
+    @Autowired
+    TokenProvider tokenProvider;
+
+    Member member;
+
+    @BeforeEach
+    void setup() {
+        member = memberService.getFirstJoinedMember(MemberFixture.createKakaoMember());
+    }
+
+    @Test
+    @DisplayName("정상적으로 동의서와 선호도 작성 여부를 받아볼 수 있다.")
+    void getIsAssignedApi() throws Exception {
+        //given
+        String authentication = getAuthentication(member);
+
+        //when, then
+        mockMvc.perform(get("/api/v1/members/status")
+                .header(HttpHeaders.AUTHORIZATION, authentication))
+            .andExpect(status().isOk())
+            .andDo(print())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(0))
+            .andExpect(jsonPath("$.message").value("SUCCESS"))
+            .andExpect(jsonPath("$.result.isFullyAssigned").value(false))
+            .andExpect(jsonPath("$.result.isPreferenceAssigned").value(false));
+
+    }
+
+    private String getAuthentication(Member member) {
+        String token = tokenProvider.generateToken(member, Duration.ofMinutes(1));
+        return "Bearer " + token;
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/member/service/MemberServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/member/service/MemberServiceTest.java
@@ -1,0 +1,83 @@
+package com.bbangle.bbangle.member.service;
+
+import com.bbangle.bbangle.AbstractIntegrationTest;
+import com.bbangle.bbangle.fixture.MemberFixture;
+import com.bbangle.bbangle.member.domain.Member;
+import com.bbangle.bbangle.member.dto.MemberAssignResponse;
+import com.bbangle.bbangle.member.dto.MemberInfoRequest;
+import com.bbangle.bbangle.preference.domain.PreferenceType;
+import com.bbangle.bbangle.preference.dto.PreferenceSelectRequest;
+import com.bbangle.bbangle.preference.service.PreferenceService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.multipart.MultipartFile;
+
+class MemberServiceTest extends AbstractIntegrationTest {
+
+    private static final MultipartFile NULL_FILE = null;
+
+    @Autowired
+    PreferenceService preferenceService;
+
+    Member member;
+
+    @BeforeEach
+    void setup() {
+        member = memberService.getFirstJoinedMember(MemberFixture.createKakaoMember());
+    }
+
+    @Test
+    @DisplayName("정상적으로 멤버가 약관에 동의하고 선호도를 기록했는지 확인할 수 있다.")
+    void getIsFullyAssigned() {
+        //given, when
+        MemberAssignResponse isAssigned = memberService.getIsAssigned(member.getId());
+
+        //then
+        Assertions.assertThat(isAssigned.isFullyAssigned())
+            .isFalse();
+        Assertions.assertThat(isAssigned.isPreferenceAssigned())
+            .isFalse();
+    }
+
+    @Test
+    @DisplayName("취향을 등록한 경우에도 정상적으로 멤버가 약관에 동의하고 선호도를 기록했는지 확인할 수 있다.")
+    void getIsFullyAssignedWithPreferenceTrue() {
+        //given, when
+        preferenceService.register(new PreferenceSelectRequest(PreferenceType.DIET),
+            member.getId());
+        MemberAssignResponse isAssigned = memberService.getIsAssigned(member.getId());
+
+        //then
+        Assertions.assertThat(isAssigned.isFullyAssigned())
+            .isFalse();
+        Assertions.assertThat(isAssigned.isPreferenceAssigned())
+            .isTrue();
+    }
+
+    @Test
+    @DisplayName("취향을 등록한 경우에도 정상적으로 멤버가 약관에 동의하고 선호도를 기록했는지 확인할 수 있다.")
+    void getIsFullyAssignedWithAssignment() {
+        //given, when
+        MemberInfoRequest request = new MemberInfoRequest(
+            "nickname",
+            "01000000000",
+            "1999-01-01",
+            true,
+            true,
+            true
+        );
+
+        memberService.updateMemberInfo(request, member.getId(), NULL_FILE);
+        MemberAssignResponse isAssigned = memberService.getIsAssigned(member.getId());
+
+        //then
+        Assertions.assertThat(isAssigned.isFullyAssigned())
+            .isTrue();
+        Assertions.assertThat(isAssigned.isPreferenceAssigned())
+            .isFalse();
+    }
+
+}


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History
* Resolves #205 
<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations
- 프론트에서 사용자가 완전히 가입을 완료했는지, 취향을 선택했는지를 기준으로 보는 페이지가 달라져 이를 확인할 수 있는 api 추가
- 유저의 동의항목이 정상적으로 DB에 저장되어 있는지 여부로 확인
- 유저의 취향 선택이 정상적으로 DB에 저장되어 있는지 여부로 확인
- 테스트 중 유저 정보 업데이트 과정에서 프로필과 추가정보를 함께 업데이트하는 api(/api/v1/members/additional-information)가 스웨거에서 오류가 나는 것을 확인하고 HttpConvertor 설정을 추가해서 작동하도록 변경
- 각각 케이스별 테스트 케이스 테스트 및 스웨거 화면 추가
    - 취향만 등록된 경우
    - 동의만 한 경우 
    - 둘 다 안된 경우 
    - 둘 다 된 경우 등
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image
<img width="400px" alt="스크린샷 2024-07-17 오후 3 24 10" src="https://github.com/user-attachments/assets/67b99a17-8477-4edb-aa1e-ad8dedbdeb8a">
<img width="400px" alt="스크린샷 2024-07-17 오후 3 25 02" src="https://github.com/user-attachments/assets/6d4a945d-c2f6-4dc9-972d-fb34d6a6c8b4">
<img width="400px" alt="스크린샷 2024-07-17 오후 3 52 38" src="https://github.com/user-attachments/assets/9055beb7-f46c-4580-a3d1-a83f53add487">
<img width="400px" alt="스크린샷 2024-07-17 오후 3 52 52" src="https://github.com/user-attachments/assets/24d0f12c-e07e-42d1-9ba8-65a78ef2ffa2">
<img width="400px" alt="스크린샷 2024-07-17 오후 5 08 21" src="https://github.com/user-attachments/assets/8d9a6412-771d-454b-82f8-e22d16d5423d">

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
