### PR TITLE
🔧 검색 부수 기능 리팩토링

### DIFF
--- a/resource/mariadb/init.sql
+++ b/resource/mariadb/init.sql
@@ -41,6 +41,7 @@ CREATE TABLE search
     is_deleted tinyint,
     keyword    VARCHAR(255) NOT NULL,
     created_at DATETIME(6),
+    modified_at DATETIME(6),
     CONSTRAINT search_pk PRIMARY KEY (id),
     CONSTRAINT fk_member_search FOREIGN KEY (member_id) REFERENCES member (id)
 );

--- a/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
@@ -105,6 +105,7 @@ public class BoardService {
             .orElseThrow(() -> new BbangleException(BOARD_NOT_FOUND));
     }
 
+    @Transactional
     public BoardImageDetailResponse getBoardDtos(Long memberId, Long boardId, String viewCountKey) {
         List<BoardAndImageDto> boardAndImageDtos = boardRepository.findBoardAndBoardImageByBoardId(
             boardId);
@@ -167,6 +168,7 @@ public class BoardService {
             .count() > ONE_CATEGOTY;
     }
 
+    @Transactional(readOnly = true)
     public ProductResponse getProductResponse(Long boardId) {
         List<Product> products = productRepository.findByBoardId(boardId);
 
@@ -178,6 +180,7 @@ public class BoardService {
         return ProductResponse.of(isBundled, productDtos);
     }
 
+    @Transactional(readOnly = true)
     public List<PopularBoardResponse> getTopBoardInfo(Long memberId, Long storeId) {
         List<Long> boardIds = boardRepository.getTopBoardIds(storeId);
 

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -51,6 +51,7 @@ public enum BbangleErrorCode {
     IMAGE_NOT_FOUND(-31, "해당하는 이미지를 찾을 수 없습니다.", NOT_FOUND),
     REVIEW_NOT_FOUND(-32, "존재하지 않는 리뷰입니다", BAD_REQUEST),
     PUSH_NOT_FOUND(-33, "존재하지 않는 푸시 알림 신청입니다.", BAD_REQUEST),
+    EMPTY_KEYWORD(-34, "검색어가 비어있습니다.", BAD_REQUEST),
     INTERNAL_SERVER_ERROR(-999, "서버 내부 에러입니다", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final int code;

--- a/src/main/java/com/bbangle/bbangle/page/SearchCustomPage.java
+++ b/src/main/java/com/bbangle/bbangle/page/SearchCustomPage.java
@@ -9,19 +9,15 @@ public class SearchCustomPage<T> extends CustomPage<T> {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long boardCount;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Long storeCount;
 
     public SearchCustomPage(
         T content,
         Long requestCursor,
         Boolean hasNext,
-        Long boardCount,
-        Long storeCount
+        Long boardCount
     ) {
         super(content, requestCursor, hasNext);
         this.boardCount = boardCount;
-        this.storeCount = storeCount;
     }
 
     public SearchCustomPage(
@@ -55,11 +51,9 @@ public class SearchCustomPage<T> extends CustomPage<T> {
         SearchResponse boardList,
         Long requestCursor,
         boolean hasNext,
-        long boardCnt,
-        long storeCnt
+        long boardCnt
     ) {
-        return new SearchCustomPage<>(boardList, requestCursor, hasNext, boardCnt,
-            storeCnt);
+        return new SearchCustomPage<>(boardList, requestCursor, hasNext, boardCnt);
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/search/controller/SearchController.java
+++ b/src/main/java/com/bbangle/bbangle/search/controller/SearchController.java
@@ -10,8 +10,7 @@ import com.bbangle.bbangle.page.SearchCustomPage;
 import com.bbangle.bbangle.search.dto.response.RecencySearchResponse;
 import com.bbangle.bbangle.search.dto.response.SearchResponse;
 import com.bbangle.bbangle.search.service.SearchService;
-import com.bbangle.bbangle.util.SecurityUtils;
-import java.util.Map;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("api/v1/search")
 public class SearchController {
+
     private static final String SUCCESS_SAVEKEYWORD = "검색어 저장 완료";
 
     private final SearchService searchService;
@@ -64,18 +64,19 @@ public class SearchController {
     @PostMapping
     public CommonResult saveKeyword(
         @RequestParam("keyword")
-        String keyword
+        String keyword,
+        @AuthenticationPrincipal
+        Long memberId
     ) {
-        Long memberId = SecurityUtils.getMemberIdWithAnonymous();
-
         searchService.saveKeyword(memberId, keyword);
-        return responseService.getSingleResult(
-            Map.of("content", SUCCESS_SAVEKEYWORD));
+        return responseService.getSuccessResult();
     }
 
     @GetMapping("/recency")
-    public CommonResult getRecencyKeyword() {
-        Long memberId = SecurityUtils.getMemberIdWithAnonymous();
+    public CommonResult getRecencyKeyword(
+        @AuthenticationPrincipal
+        Long memberId
+    ) {
         RecencySearchResponse recencyKeyword = searchService.getRecencyKeyword(memberId);
         return responseService.getSingleResult(recencyKeyword);
     }
@@ -83,19 +84,19 @@ public class SearchController {
     @DeleteMapping("/recency")
     public CommonResult deleteRecencyKeyword(
         @RequestParam(value = "keyword")
-        String keyword
+        String keyword,
+        @AuthenticationPrincipal
+        Long memberId
     ) {
-        Long memberId = SecurityUtils.getMemberId();
+        searchService.deleteRecencyKeyword(keyword, memberId);
 
-        return responseService.getSingleResult(
-                Map.of("content", searchService.deleteRecencyKeyword(keyword, memberId))
-            );
+        return responseService.getSuccessResult();
     }
 
     @GetMapping("/best-keyword")
     public CommonResult getBestKeyword() {
-        return responseService.getSingleResult(
-                Map.of("content", searchService.getBestKeyword()));
+        List<String> bestKeywords = searchService.getBestKeyword();
+        return responseService.getSingleResult(bestKeywords);
     }
 
     @GetMapping("/auto-keyword")
@@ -103,8 +104,7 @@ public class SearchController {
         @RequestParam("keyword")
         String keyword
     ) {
-        return responseService.getSingleResult(
-                Map.of("content", searchService.getAutoKeyword(keyword))
-            );
+        List<String> autoKeywords = searchService.getAutoKeyword(keyword);
+        return responseService.getSingleResult(autoKeywords);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/search/controller/SearchController.java
+++ b/src/main/java/com/bbangle/bbangle/search/controller/SearchController.java
@@ -29,8 +29,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("api/v1/search")
 public class SearchController {
 
-    private static final String SUCCESS_SAVEKEYWORD = "검색어 저장 완료";
-
     private final SearchService searchService;
     private final ResponseService responseService;
 
@@ -96,7 +94,7 @@ public class SearchController {
     @GetMapping("/best-keyword")
     public CommonResult getBestKeyword() {
         List<String> bestKeywords = searchService.getBestKeyword();
-        return responseService.getSingleResult(bestKeywords);
+        return responseService.getListResult(bestKeywords);
     }
 
     @GetMapping("/auto-keyword")
@@ -105,6 +103,6 @@ public class SearchController {
         String keyword
     ) {
         List<String> autoKeywords = searchService.getAutoKeyword(keyword);
-        return responseService.getSingleResult(autoKeywords);
+        return responseService.getListResult(autoKeywords);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/search/domain/Search.java
+++ b/src/main/java/com/bbangle/bbangle/search/domain/Search.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.search.domain;
 
+import com.bbangle.bbangle.common.domain.BaseEntity;
 import com.bbangle.bbangle.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
@@ -12,18 +13,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
 @Table(name = "search")
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Search {
+public class Search extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,14 +38,12 @@ public class Search {
     @Column(name = "keyword")
     private String keyword;
 
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
     @Builder
-    public Search(Member member, String keyword, LocalDateTime createdAt) {
-        this.member = member;
+    public Search(Long memberId, String keyword) {
+        this.member = Member.builder()
+            .id(memberId)
+            .build();
         this.keyword = keyword;
-        this.createdAt = createdAt;
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/search/dto/KeywordDto.java
+++ b/src/main/java/com/bbangle/bbangle/search/dto/KeywordDto.java
@@ -2,12 +2,13 @@ package com.bbangle.bbangle.search.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 
-public record KeywordDto(
-    String keyword
-) {
+public class KeywordDto {
+
+    String keyword;
 
     @QueryProjection
-    public KeywordDto {
+    public KeywordDto(String keyword) {
+        this.keyword = keyword;
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/search/dto/KeywordDto.java
+++ b/src/main/java/com/bbangle/bbangle/search/dto/KeywordDto.java
@@ -1,14 +1,35 @@
 package com.bbangle.bbangle.search.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import java.util.Objects;
 
 public class KeywordDto {
 
-    String keyword;
+    private String keyword;
 
     @QueryProjection
     public KeywordDto(String keyword) {
         this.keyword = keyword;
     }
 
+    public String getKeyword() {
+        return keyword;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        KeywordDto that = (KeywordDto) obj;
+        return Objects.equals(keyword, that.keyword);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keyword);
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/search/dto/response/RecencySearchResponse.java
+++ b/src/main/java/com/bbangle/bbangle/search/dto/response/RecencySearchResponse.java
@@ -10,9 +10,16 @@ import lombok.Builder;
 public record RecencySearchResponse(
     List<KeywordDto> content
 ) {
-    public static RecencySearchResponse getEmpty(){
+
+    public static RecencySearchResponse of(List<KeywordDto> kewords) {
         return RecencySearchResponse.builder()
-                .content(Collections.emptyList())
-                .build();
+            .content(kewords)
+            .build();
+    }
+
+    public static RecencySearchResponse getEmpty() {
+        return RecencySearchResponse.builder()
+            .content(Collections.emptyList())
+            .build();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/search/dto/response/SearchResponse.java
+++ b/src/main/java/com/bbangle/bbangle/search/dto/response/SearchResponse.java
@@ -13,13 +13,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public class SearchResponse {
 
-    private List<BoardResponseDto> boardResponseDtos;
+    private List<BoardResponseDto> boards;
     private Long itemAllCount;
 
     public static SearchResponse of(List<BoardResponseDto> boardResponseDtos,
         Long itemAllCount) {
         return SearchResponse.builder()
-            .boardResponseDtos(boardResponseDtos)
+            .boards(boardResponseDtos)
             .itemAllCount(itemAllCount)
             .build();
     }
@@ -28,7 +28,7 @@ public class SearchResponse {
         List<BoardResponseDto> emptyBoardResponses = Collections.emptyList();
 
         return SearchResponse.builder()
-            .boardResponseDtos(emptyBoardResponses)
+            .boards(emptyBoardResponses)
             .itemAllCount(0L)
             .build();
     }

--- a/src/main/java/com/bbangle/bbangle/search/repository/SearchQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/search/repository/SearchQueryDSLRepository.java
@@ -4,8 +4,8 @@ import com.bbangle.bbangle.board.dao.BoardResponseDao;
 import com.bbangle.bbangle.board.dto.FilterRequest;
 import com.bbangle.bbangle.board.sort.SortType;
 import com.bbangle.bbangle.search.dto.KeywordDto;
-import com.bbangle.bbangle.member.domain.Member;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface SearchQueryDSLRepository {
@@ -23,10 +23,10 @@ public interface SearchQueryDSLRepository {
         SortType sort
     );
 
-    List<KeywordDto> getRecencyKeyword(Member member);
+    List<KeywordDto> getRecencyKeyword(Long memberId);
 
-    String[] getBestKeyword();
+    String[] getBestKeyword(LocalDateTime beforeOneDayTime);
 
-    void markAsDeleted(String keyword, Member member);
+    void markAsDeleted(String keyword, Long memberId);
 
 }

--- a/src/main/java/com/bbangle/bbangle/search/repository/SearchRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/search/repository/SearchRepositoryImpl.java
@@ -65,12 +65,12 @@ public class SearchRepositoryImpl implements SearchQueryDSLRepository {
         return queryFactory.select(
                 new QKeywordDto(
                     search.keyword))
+            .distinct()
             .from(search)
             .where(
                 search.isDeleted.eq(false),
                 search.member.id.eq(memberId))
-            .groupBy(search.keyword)
-            .orderBy(search.createdAt.desc())
+            .orderBy(search.id.desc())
             .limit(7)
             .fetch();
     }

--- a/src/main/java/com/bbangle/bbangle/search/repository/SearchRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/search/repository/SearchRepositoryImpl.java
@@ -4,9 +4,9 @@ import com.bbangle.bbangle.board.dao.BoardResponseDao;
 import com.bbangle.bbangle.board.dto.FilterRequest;
 import com.bbangle.bbangle.board.repository.basic.cursor.BoardCursorGeneratorMapping;
 import com.bbangle.bbangle.board.sort.SortType;
-import com.bbangle.bbangle.member.domain.Member;
 import com.bbangle.bbangle.search.domain.QSearch;
 import com.bbangle.bbangle.search.dto.KeywordDto;
+import com.bbangle.bbangle.search.dto.QKeywordDto;
 import com.bbangle.bbangle.search.repository.basic.SearchFilterCreator;
 import com.bbangle.bbangle.search.repository.basic.query.SearchQueryProviderResolver;
 import com.querydsl.core.BooleanBuilder;
@@ -24,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class SearchRepositoryImpl implements SearchQueryDSLRepository {
 
     private static final QSearch search = QSearch.search;
-    private static final int ONEDAY = 24;
 
     private final BoardCursorGeneratorMapping boardCursorGeneratorMapping;
 
@@ -62,25 +61,24 @@ public class SearchRepositoryImpl implements SearchQueryDSLRepository {
     }
 
     @Override
-    public List<KeywordDto> getRecencyKeyword(Member member) {
-        return queryFactory.select(search.keyword, search.createdAt.max())
+    public List<KeywordDto> getRecencyKeyword(Long memberId) {
+        return queryFactory.select(
+                new QKeywordDto(
+                    search.keyword))
             .from(search)
-            .where(search.isDeleted.eq(false), search.member.eq(member))
+            .where(
+                search.isDeleted.eq(false),
+                search.member.id.eq(memberId))
             .groupBy(search.keyword)
-            .orderBy(search.createdAt.max().desc())
+            .orderBy(search.createdAt.desc())
             .limit(7)
-            .fetch().stream().map(tuple -> new KeywordDto(tuple.get(search.keyword)))
-            .toList();
+            .fetch();
     }
 
     @Override
-    public String[] getBestKeyword() {
-
-        // 현재시간과 하루전 시간을 가져옴
-        LocalDateTime currentTime = LocalDateTime.now();
-        LocalDateTime beforeOneDayTime = currentTime.minusHours(ONEDAY);
-
-        // 현재시간으로부터 24시간 전 검색어를 검색수 내림 차순으로 7개 가져옴
+    public String[] getBestKeyword(
+        LocalDateTime beforeOneDayTime
+    ) {
         return queryFactory.select(search.keyword)
             .from(search)
             .where(search.createdAt.gt(beforeOneDayTime))
@@ -92,11 +90,11 @@ public class SearchRepositoryImpl implements SearchQueryDSLRepository {
     }
 
     @Override
-    public void markAsDeleted(String keyword, Member member) {
+    public void markAsDeleted(String keyword, Long memberId) {
         queryFactory.update(search)
             .set(search.isDeleted, true)
             .where(
-                search.member.eq(member)
+                search.member.id.eq(memberId)
                     .and(search.keyword.eq(keyword))
             )
             .execute();

--- a/src/main/java/com/bbangle/bbangle/search/repository/SearchRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/search/repository/SearchRepositoryImpl.java
@@ -16,10 +16,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 @Repository
-@Transactional
 @RequiredArgsConstructor
 public class SearchRepositoryImpl implements SearchQueryDSLRepository {
 

--- a/src/main/java/com/bbangle/bbangle/search/repository/basic/query/SearchMostWishedBoardQueryProviderResolver.java
+++ b/src/main/java/com/bbangle/bbangle/search/repository/basic/query/SearchMostWishedBoardQueryProviderResolver.java
@@ -66,6 +66,8 @@ public class SearchMostWishedBoardQueryProviderResolver implements SearchQueryPr
             .on(product.board.id.eq(board.id))
             .join(store)
             .on(board.store.id.eq(store.id))
+            .join(boardStatistic)
+            .on(boardStatistic.boardId.eq(board.id))
             .where(board.id.in(boardIds))
             .orderBy(orderCondition)
             .fetch();

--- a/src/main/java/com/bbangle/bbangle/search/repository/basic/query/SearchRecentBoardQueryProviderResolver.java
+++ b/src/main/java/com/bbangle/bbangle/search/repository/basic/query/SearchRecentBoardQueryProviderResolver.java
@@ -74,7 +74,7 @@ public class SearchRecentBoardQueryProviderResolver implements SearchQueryProvid
         return jpaQueryFactory.select(board.id)
             .distinct()
             .from(product)
-            .join(product.board, board)
+            .join(board).on(product.board.id.in(searchedIds))
             .where(filter.and(board.id.in(searchedIds)))
             .fetch().stream().count();
     }

--- a/src/main/java/com/bbangle/bbangle/search/service/SearchService.java
+++ b/src/main/java/com/bbangle/bbangle/search/service/SearchService.java
@@ -1,5 +1,7 @@
 package com.bbangle.bbangle.search.service;
 
+import static com.bbangle.bbangle.search.validation.SearchValidation.checkNullOrEmptyKeyword;
+
 import com.bbangle.bbangle.board.dao.BoardResponseDao;
 import com.bbangle.bbangle.board.dto.BoardResponseDto;
 import com.bbangle.bbangle.board.dto.FilterRequest;
@@ -39,6 +41,8 @@ public class SearchService {
 
     @Transactional
     public void saveKeyword(Long memberId, String keyword) {
+        checkNullOrEmptyKeyword(keyword);
+
         memberId = checkAnonymousId(memberId);
         Search search = Search.builder()
             .memberId(memberId)
@@ -74,7 +78,7 @@ public class SearchService {
 
         Long boardCount = searchRepository.getAllCount(searchedBoardIndexs, filterRequest, sort);
 
-        if (boardCount > LIMIT_KEYWORD_COUNT) {
+        if (boards.size() > LIMIT_KEYWORD_COUNT) {
             boardCount--;
         }
 
@@ -98,7 +102,7 @@ public class SearchService {
         List<Long> likedContentIds = boardRepository.getLikedContentsIds(responseList, memberId);
 
         searchCustomPage.getContent()
-            .getBoardResponseDtos()
+            .getBoards()
             .stream()
             .filter(board -> likedContentIds.contains(board.getBoardId()))
             .forEach(board -> board.updateLike(true));
@@ -108,7 +112,7 @@ public class SearchService {
         SearchCustomPage<SearchResponse> searchCustomPage
     ) {
         return searchCustomPage.getContent()
-            .getBoardResponseDtos()
+            .getBoards()
             .stream()
             .map(BoardResponseDto::getBoardId)
             .toList();

--- a/src/main/java/com/bbangle/bbangle/search/service/utils/KeywordUtil.java
+++ b/src/main/java/com/bbangle/bbangle/search/service/utils/KeywordUtil.java
@@ -12,6 +12,9 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class KeywordUtil {
 
+    private static final String BEST_KEYWORD_KEY = "keyword";
+    private static final String[] DEFAULT_SEARCH_KEYWORDS = {"글루텐프리", "비건", "저당", "키토제닉"};
+
     private final MorphemeAnalyzer morphemeAnalyzer;
     private final RedisRepository redisRepository;
 
@@ -24,6 +27,21 @@ public class KeywordUtil {
             .flatMap(List::stream)
             .distinct()
             .toList();
+    }
+
+    public void setBestKeywordInRedis(String[] keywords) {
+        String bestKeywordNamespace = RedisEnum.BEST_KEYWORD.name();
+
+        if (keywords.length == 0) {
+            redisRepository.set(bestKeywordNamespace, BEST_KEYWORD_KEY, DEFAULT_SEARCH_KEYWORDS);
+            return;
+        }
+
+        redisRepository.set(bestKeywordNamespace, BEST_KEYWORD_KEY, keywords);
+    }
+
+    public List<String> getBestKeyword() {
+        return redisRepository.getStringList(RedisEnum.BEST_KEYWORD.name(), BEST_KEYWORD_KEY);
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/search/service/utils/KeywordUtil.java
+++ b/src/main/java/com/bbangle/bbangle/search/service/utils/KeywordUtil.java
@@ -1,5 +1,7 @@
 package com.bbangle.bbangle.search.service.utils;
 
+import static com.bbangle.bbangle.search.validation.SearchValidation.checkNullOrEmptyKeyword;
+
 import com.bbangle.bbangle.common.redis.domain.RedisEnum;
 import com.bbangle.bbangle.common.redis.repository.RedisRepository;
 import com.bbangle.bbangle.util.MorphemeAnalyzer;
@@ -19,6 +21,8 @@ public class KeywordUtil {
     private final RedisRepository redisRepository;
 
     public List<Long> getBoardIds(String keyword) {
+        checkNullOrEmptyKeyword(keyword);
+
         List<String> keywordTokens = morphemeAnalyzer.getAllTokenizer(keyword);
 
         return keywordTokens.stream()

--- a/src/main/java/com/bbangle/bbangle/search/validation/SearchValidation.java
+++ b/src/main/java/com/bbangle/bbangle/search/validation/SearchValidation.java
@@ -1,0 +1,18 @@
+package com.bbangle.bbangle.search.validation;
+
+import static com.bbangle.bbangle.exception.BbangleErrorCode.EMPTY_KEYWORD;
+
+import com.bbangle.bbangle.exception.BbangleException;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SearchValidation {
+
+    public static void checkNullOrEmptyKeyword(String keyword) {
+        if (Objects.isNull(keyword) || keyword.trim().isEmpty()) {
+            throw new BbangleException(EMPTY_KEYWORD);
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/fixture/FixtureConfig.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/FixtureConfig.java
@@ -1,0 +1,26 @@
+package com.bbangle.bbangle.fixture;
+
+import com.bbangle.bbangle.board.repository.ProductRepository;
+import com.bbangle.bbangle.search.repository.SearchRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class FixtureConfig {
+
+    @Autowired
+    private SearchRepository searchRepository;
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Bean
+    public SearchFixture searchFixture() {
+        return new SearchFixture(searchRepository);
+    }
+
+    @Bean
+    public ProductFixture productFixture() {
+        return new ProductFixture(productRepository);
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/fixture/ProductFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/ProductFixture.java
@@ -3,13 +3,55 @@ package com.bbangle.bbangle.fixture;
 import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.domain.Category;
 import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.board.repository.ProductRepository;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import java.util.Random;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProductFixture {
+
+    private final ProductRepository productRepository;
+    private final Random random;
+
+    public ProductFixture(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+        this.random = new Random();
+    }
+
+    public Product veganCookie(Board board) {
+        int randomPrice = random.nextInt(100000) + 1; // 1부터 10000 사이의 랜덤 값
+        int randomNutrient = random.nextInt(500) + 1; // 1부터 500 사이의 랜덤 값
+        LocalDateTime now = LocalDateTime.now();
+
+        return productRepository.save(Product.builder()
+            .board(board)
+            .title(CommonFaker.faker.dessert().flavor())
+            .price(randomPrice)
+            .category(Category.COOKIE)
+            .glutenFreeTag(random.nextBoolean())
+            .highProteinTag(random.nextBoolean())
+            .sugarFreeTag(random.nextBoolean())
+            .veganTag(true)
+            .ketogenicTag(random.nextBoolean())
+            .sugars(randomNutrient)
+            .protein(randomNutrient)
+            .carbohydrates(randomNutrient)
+            .fat(randomNutrient)
+            .weight(randomNutrient)
+            .calories(randomNutrient)
+            .monday(random.nextBoolean())
+            .tuesday(random.nextBoolean())
+            .wednesday(random.nextBoolean())
+            .thursday(random.nextBoolean())
+            .friday(random.nextBoolean())
+            .saturday(random.nextBoolean())
+            .sunday(random.nextBoolean())
+            .orderStartDate(now)
+            .orderEndDate(now.plusDays(7)) // 주문 종료일을 일주일 뒤로 설정
+            .soldout(random.nextBoolean())
+            .build());
+    }
 
     public static Product veganFreeProduct(Board board) {
         String dishName = getProductTitle();

--- a/src/test/java/com/bbangle/bbangle/fixture/SearchFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/SearchFixture.java
@@ -1,0 +1,20 @@
+package com.bbangle.bbangle.fixture;
+
+import com.bbangle.bbangle.search.domain.Search;
+import com.bbangle.bbangle.search.repository.SearchRepository;
+
+public class SearchFixture {
+
+    private final SearchRepository searchRepository;
+
+    public SearchFixture(SearchRepository searchRepository) {
+        this.searchRepository = searchRepository;
+    }
+
+    public Search create(Long memberId) {
+        return searchRepository.save(Search.builder()
+            .keyword(CommonFaker.faker.dessert().flavor())
+            .memberId(memberId)
+            .build());
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/search/controller/SearchControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/search/controller/SearchControllerTest.java
@@ -14,8 +14,6 @@ import com.bbangle.bbangle.board.domain.Category;
 import com.bbangle.bbangle.board.dto.BoardResponseDto;
 import com.bbangle.bbangle.board.dto.FilterRequest;
 import com.bbangle.bbangle.board.sort.SortType;
-import com.bbangle.bbangle.common.dto.SingleResult;
-import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.page.SearchCustomPage;
 import com.bbangle.bbangle.search.dto.response.SearchResponse;
 import com.bbangle.bbangle.search.service.SearchService;
@@ -23,34 +21,18 @@ import com.bbangle.bbangle.search.service.SearchService;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.context.WebApplicationContext;
 
 class SearchControllerTest extends AbstractIntegrationTest {
 
     private static final Long MEMBER_ID = 2L;
 
-    @Autowired
-    MockMvc mockMvc;
-
     @MockBean
     private SearchService searchService;
-
-    @MockBean
-    private ResponseService responseService;
-
-    @BeforeEach
-    public void setup(WebApplicationContext context) {
-        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
-    }
 
     @Test
     @DisplayName("getOrderResponse 메서드는 주문 정보를 성공적으로 가져올 수 있다")
@@ -89,13 +71,8 @@ class SearchControllerTest extends AbstractIntegrationTest {
         SearchResponse searchResponse = SearchResponse.of(boardResponseDtos, 0L);
         SearchCustomPage searchCustomPage = SearchCustomPage.from(searchResponse, 1L, true);
 
-        SingleResult singleResult = new SingleResult<>();
-        singleResult.setResult(searchCustomPage);
-        singleResult.setSuccess(true);
-
         given(searchService.getBoardList(any(), any(), any(), any(), any())).willReturn(
             searchCustomPage);
-        given(responseService.getSingleResult(any())).willReturn(singleResult);
 
         // When & Then
         mockMvc.perform(get("/api/v1/search/boards")

--- a/src/test/java/com/bbangle/bbangle/search/repository/SearchRepositoryTest.java
+++ b/src/test/java/com/bbangle/bbangle/search/repository/SearchRepositoryTest.java
@@ -15,7 +15,6 @@ import com.bbangle.bbangle.fixture.FixtureConfig;
 import com.bbangle.bbangle.fixture.MemberFixture;
 import com.bbangle.bbangle.fixture.SearchFixture;
 import com.bbangle.bbangle.member.domain.Member;
-import com.bbangle.bbangle.search.domain.Search;
 import com.bbangle.bbangle.search.dto.KeywordDto;
 import com.bbangle.bbangle.search.service.SearchLoadService;
 import java.time.LocalDateTime;
@@ -182,19 +181,6 @@ class SearchRepositoryTest extends AbstractIntegrationTest {
 
         List<KeywordDto> recencyKewords = searchRepository.getRecencyKeyword(member1.getId());
         assertThat(recencyKewords).hasSize(LIMIT_KEYWORD_COUNT);
-    }
-
-    @Test
-    @DisplayName("저장된 키워드를 삭제할 수 있다")
-    void deleteKeyword() {
-        Member member1 = memberRepository.save(MemberFixture.createKakaoMember());
-        Search search = searchFixture.create(member1.getId());
-
-        searchRepository.markAsDeleted(search.getKeyword(), member1.getId());
-        Optional<Search> checkSearch = searchRepository.findById(search.getId());
-
-        assertThat(checkSearch).isPresent();
-        assertThat(checkSearch.get().isDeleted()).isTrue();
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/search/repository/SearchRepositoryTest.java
+++ b/src/test/java/com/bbangle/bbangle/search/repository/SearchRepositoryTest.java
@@ -1,181 +1,200 @@
 package com.bbangle.bbangle.search.repository;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static com.bbangle.bbangle.fixture.BoardStatisticFixture.newBoardStatisticWithBasicScore;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bbangle.bbangle.AbstractIntegrationTest;
+import com.bbangle.bbangle.board.dao.BoardResponseDao;
 import com.bbangle.bbangle.board.domain.Board;
-import com.bbangle.bbangle.board.domain.Category;
 import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.board.dto.FilterRequest;
+import com.bbangle.bbangle.board.sort.SortType;
+import com.bbangle.bbangle.boardstatistic.domain.BoardStatistic;
 import com.bbangle.bbangle.common.redis.repository.RedisRepository;
+import com.bbangle.bbangle.fixture.FixtureConfig;
+import com.bbangle.bbangle.fixture.MemberFixture;
+import com.bbangle.bbangle.fixture.SearchFixture;
 import com.bbangle.bbangle.member.domain.Member;
 import com.bbangle.bbangle.search.domain.Search;
 import com.bbangle.bbangle.search.dto.KeywordDto;
 import com.bbangle.bbangle.search.service.SearchLoadService;
-import com.bbangle.bbangle.store.domain.Store;
-import java.util.Arrays;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-import org.junit.jupiter.api.*;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 
+@Import(FixtureConfig.class)
 class SearchRepositoryTest extends AbstractIntegrationTest {
+
+    private static final int ONEDAY = 24;
+    private static final Long NULL_CURSOR = null;
     @Autowired
     SearchRepository searchRepository;
     @Autowired
     SearchLoadService searchLoadService;
     @Autowired
     RedisRepository redisRepository;
-
-    private Store store;
-    private Board board;
-    private Member member;
-
-
-    @BeforeEach
-    void saveEntity() {
-        createMember();
-        createProductRelatedContent(15);
-        redisRepository.delete("MIGRATION", "board");
-        redisRepository.delete("MIGRATION", "store");
-        searchLoadService.cacheKeywords();
-        searchLoadService.cacheAutoComplete();
-        searchLoadService.updateRedisAtBestKeyword();
-    }
+    @Autowired
+    SearchFixture searchFixture;
 
     @AfterEach
     void deleteAllEntity() {
         redisRepository.deleteAll();
         searchRepository.deleteAll();
-        boardStatisticRepository.deleteAll();
         memberRepository.deleteAll();
-        productRepository.deleteAll();
-        boardRepository.deleteAll();
-        storeRepository.deleteAll();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SortType.class, names = {"RECENT", "LOW_PRICE", "HIGH_PRICE"})
+    @DisplayName("getBoardResponseList 메서드는 게시물을 성공적으로 조회할 수 있다")
+    void getBoardResponseListFromBoard(SortType sort) {
+
+        List<Long> boardIds = new ArrayList<>();
+        for (int i = 0; 3 > i; i++) {
+            Product product = fixtureProduct(Map.of("glutenFreeTag", true));
+            boardIds.add(
+                fixtureBoard(Map.of("productList", List.of(product), "isDeleted", false)).getId());
+        }
+
+        FilterRequest filterRequest = FilterRequest.builder()
+            .glutenFreeTag(true)
+            .build();
+
+        List<BoardResponseDao> boardResponseDaos = searchRepository.getBoardResponseList(boardIds,
+            filterRequest, sort, NULL_CURSOR);
+        assertThat(boardResponseDaos).hasSize(boardIds.size());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SortType.class, names = {"RECOMMEND", "MOST_WISHED", "MOST_REVIEWED",
+        "HIGHEST_RATED"})
+    @DisplayName("getBoardResponseList 메서드는 점수가 계산된 게시물을 성공적으로 조회할 수 있다")
+    void getBoardResponseListFromBoardStatistic(SortType sort) {
+
+        List<Long> boardIds = new ArrayList<>();
+        for (int i = 0; 3 > i; i++) {
+            double score = i;
+
+            Product product = fixtureProduct(Map.of("glutenFreeTag", true));
+            Board board = fixtureBoard(Map.of("productList", List.of(product), "isDeleted", false));
+            BoardStatistic boardStatistic = newBoardStatisticWithBasicScore(board, score);
+            boardStatisticRepository.save(boardStatistic);
+            boardIds.add(board.getId());
+        }
+
+        FilterRequest filterRequest = FilterRequest.builder()
+            .glutenFreeTag(true)
+            .build();
+
+        List<BoardResponseDao> boardResponseDaos = searchRepository.getBoardResponseList(boardIds,
+            filterRequest, sort, NULL_CURSOR);
+        assertThat(boardResponseDaos).hasSize(boardIds.size());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SortType.class, names = {"RECENT", "LOW_PRICE", "HIGH_PRICE"})
+    @DisplayName("getAllCount 메서드는 검색된 게시글의 전체 개수를 조회할 수 있다")
+    void getAllCountFromBoard(SortType sort) {
+
+        List<Long> boardIds = new ArrayList<>();
+        for (int i = 0; 3 > i; i++) {
+            Product product = fixtureProduct(Map.of("glutenFreeTag", true));
+            boardIds.add(
+                fixtureBoard(Map.of("productList", List.of(product), "isDeleted", false)).getId());
+        }
+
+        FilterRequest filterRequest = FilterRequest.builder()
+            .glutenFreeTag(true)
+            .build();
+
+        Long count = searchRepository.getAllCount(boardIds, filterRequest, sort);
+        assertThat(count).isEqualTo(boardIds.size());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SortType.class, names = {"RECOMMEND", "MOST_WISHED", "MOST_REVIEWED",
+        "HIGHEST_RATED"})
+    @DisplayName("getAllCount 메서드는 검색된 게시글의 전체 개수를 조회할 수 있다")
+    void getAllCountFromBoardStatistic(SortType sort) {
+
+        List<Long> boardIds = new ArrayList<>();
+        for (int i = 0; 3 > i; i++) {
+            double score = i;
+
+            Product product = fixtureProduct(Map.of("glutenFreeTag", true));
+            Board board = fixtureBoard(Map.of("productList", List.of(product), "isDeleted", false));
+            BoardStatistic boardStatistic = newBoardStatisticWithBasicScore(board, score);
+            boardStatisticRepository.save(boardStatistic);
+            boardIds.add(board.getId());
+        }
+
+        FilterRequest filterRequest = FilterRequest.builder()
+            .glutenFreeTag(true)
+            .build();
+
+        Long count = searchRepository.getAllCount(boardIds, filterRequest, sort);
+        assertThat(count).isEqualTo(boardIds.size());
     }
 
     @Test
-    @DisplayName("게시물이 잘 저장돼있다")
-    void checkAllBoardCountTest() {
-        var boardCount = boardRepository.findAll().size();
-        assertThat(boardCount, is(15));
-        var productCount = productRepository.findAll().size();
-        assertThat(productCount, is(45));
-    }
+    @DisplayName("getBestKeyword 메서드는 베스트 게시물 검색어를 조회할 수 있다")
+    void getBestKeywordTest() {
+        Member member1 = memberRepository.save(MemberFixture.createKakaoMember());
+        Set<String> keywords = new HashSet<>();
 
-    @Test
-    @DisplayName("최근 키워드를 검색할 수 있다")
-    void getRecentKeywordTest() {
-        createSearchKeyword("초콜릿");
-        createSearchKeyword("키토제닉 빵");
-        createSearchKeyword("비건 베이커리");
-        createSearchKeyword("키토제닉 빵");
-        createSearchKeyword("초코 휘낭시에");
-        createSearchKeyword("바나나 빵");
-        createSearchKeyword("배부른 음식");
-        createSearchKeyword("당당 치킨");
+        while (keywords.size() < 7) {
+            keywords.add(searchFixture.create(member1.getId()).getKeyword());
+        }
+        LocalDateTime oneDayAgo = getOneDayAgo();
+        String[] bestKeywords = searchRepository.getBestKeyword(oneDayAgo);
 
-        var recencyKewords = searchRepository.getRecencyKeyword(member);
-
-        int index = 0;
-        for (KeywordDto recencyKeword : recencyKewords) {
-            index++;
-            // 알고리즘이 잘못되어 임시로 주석처리합니다. 고친 후 다시 PR 요청하겠습니다.
-            //  assertThat(recencyKeword.keyword(), is(savingKeyword.get(savingKeyword.size() - index)));
+        for (String keyword : bestKeywords) {
+            assertThat(keyword).isIn(keywords);
         }
     }
 
+    private LocalDateTime getOneDayAgo() {
+        return LocalDateTime.now()
+            .minusHours(ONEDAY);
+    }
+
     @Test
-    @DisplayName("키워드를 저장할 수 있다")
-    void getAllSearch() {
-        List<String> savingKeyword = Arrays.asList("초콜릿", "키토제닉 빵", "비건", "비건 베이커리", "키토제닉 빵",
-            "초코 휘낭시에", "바나나 빵", "배부른 음식", "당당 치킨");
-        savingKeyword.forEach(keyword -> createSearchKeyword(keyword));
-        var kewords = searchRepository.findAll();
-        assertThat(kewords.size(), is(savingKeyword.size()));
+    @DisplayName("getRecencyKeyword 메서드는 최근 키워드를 조회할 수 있다")
+    void getRecentKeywordTest() {
+        int LIMIT_KEYWORD_COUNT = 7;
+
+        Member member1 = memberRepository.save(MemberFixture.createKakaoMember());
+        Set<String> keywords = new HashSet<>();
+
+        while (keywords.size() < 9) {
+            keywords.add(searchFixture.create(member1.getId()).getKeyword());
+        }
+
+        List<KeywordDto> recencyKewords = searchRepository.getRecencyKeyword(member1.getId());
+        assertThat(recencyKewords).hasSize(LIMIT_KEYWORD_COUNT);
     }
 
     @Test
     @DisplayName("저장된 키워드를 삭제할 수 있다")
     void deleteKeyword() {
-        String keyword = "비건";
-        var search = createSearchKeyword(keyword);
-        checkSearchKeyword(searchRepository, search, keyword);
+        Member member1 = memberRepository.save(MemberFixture.createKakaoMember());
+        Search search = searchFixture.create(member1.getId());
 
-        searchRepository.markAsDeleted(keyword, member);
-        checkSearchKeyword(searchRepository, search, keyword);
+        searchRepository.markAsDeleted(search.getKeyword(), member1.getId());
+        Optional<Search> checkSearch = searchRepository.findById(search.getId());
+
+        assertThat(checkSearch).isPresent();
+        assertThat(checkSearch.get().isDeleted()).isTrue();
     }
 
-    private void checkSearchKeyword(SearchRepository searchRepository, Search search,
-        String keyword) {
-        var savedSearch = searchRepository.findById(search.getId()).get();
-        assertThat(savedSearch.getKeyword(), is(keyword));
-    }
-
-    private void createProductRelatedContent(int count) {
-        for (int i = 0; i < count; i++) {
-            store = storeRepository.save(
-                Store.builder()
-                    .identifier("7962401222")
-                    .name("RAWSOME")
-                    .profile(
-                        "https://firebasestorage.googleapis.com/v0/b/test-1949b.appspot.com/o/stores%2Frawsome%2Fprofile.jpg?alt=media&token=26bd1435-2c28-4b85-a5aa-b325e9aac05e")
-                    .build());
-
-            board = boardRepository.save(
-                Board.builder()
-                    .store(store)
-                    .title("비건 베이커리 로썸 비건빵")
-                    .price(5400)
-                    .status(true)
-                    .profile(
-                        "https://firebasestorage.googleapis.com/v0/b/test-1949b.appspot.com/o/stores%2Frawsome%2Fboards%2F00000000%2F0.jpg?alt=media&token=f3d1925a-1e93-4e47-a487-63c7fc61e203")
-                    .purchaseUrl("https://smartstore.naver.com/rawsome/products/5727069436")
-                    .build());
-
-            productRepository.saveAll(List.of(
-                Product.builder()
-                    .board(board)
-                    .title("콩볼")
-                    .price(3600)
-                    .category(Category.SNACK)
-                    .glutenFreeTag(true)
-                    .sugarFreeTag(true)
-                    .highProteinTag(true)
-                    .veganTag(true)
-                    .ketogenicTag(true)
-                    .build(),
-                Product.builder()
-                    .board(board)
-                    .title("카카모카")
-                    .price(5000)
-                    .category(Category.BREAD)
-                    .glutenFreeTag(true)
-                    .veganTag(true)
-                    .build(),
-                Product.builder()
-                    .board(board)
-                    .title("로미넛쑥")
-                    .price(5000)
-                    .category(Category.BREAD)
-                    .glutenFreeTag(true)
-                    .sugarFreeTag(true)
-                    .veganTag(true)
-                    .build()
-            ));
-        }
-    }
-
-    private void createMember() {
-        member = memberRepository.save(Member.builder()
-            .id(2L)
-            .build());
-    }
-
-    private Search createSearchKeyword(String keyword) {
-        return searchRepository.save(
-            Search.builder()
-                .member(member)
-                .keyword(keyword)
-                .build());
-    }
 }

--- a/src/test/java/com/bbangle/bbangle/search/service/SearchServiceMockTest.java
+++ b/src/test/java/com/bbangle/bbangle/search/service/SearchServiceMockTest.java
@@ -1,0 +1,243 @@
+package com.bbangle.bbangle.search.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bbangle.bbangle.AbstractIntegrationTest;
+import com.bbangle.bbangle.board.dao.BoardResponseDao;
+import com.bbangle.bbangle.board.domain.Category;
+import com.bbangle.bbangle.board.dto.FilterRequest;
+import com.bbangle.bbangle.board.sort.SortType;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.page.SearchCustomPage;
+import com.bbangle.bbangle.search.domain.Search;
+import com.bbangle.bbangle.search.dto.KeywordDto;
+import com.bbangle.bbangle.search.dto.response.RecencySearchResponse;
+import com.bbangle.bbangle.search.dto.response.SearchResponse;
+import com.bbangle.bbangle.search.repository.SearchRepository;
+import com.bbangle.bbangle.search.service.utils.KeywordUtil;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+class SearchServiceMockTest extends AbstractIntegrationTest {
+
+    private static final Long ANONYMOUS_MEMBER_ID = null;
+    private static final Long MEMBER_ID = 2L;
+    @MockBean
+    SearchRepository searchRepository;
+    @MockBean
+    KeywordUtil keywordUtil;
+    @Autowired
+    SearchService searchService;
+
+    @Nested
+    @DisplayName("getBoardList 메서드는")
+    class GetSearchBoard {
+
+        private FilterRequest filterRequest;
+        private SortType sort;
+        private String keyword;
+        private Long cursorId;
+        private Long memberId;
+        private BoardResponseDao boardResponseDao1;
+        private BoardResponseDao boardResponseDao2;
+
+        @BeforeEach
+        void setUp() {
+            filterRequest = new FilterRequest(
+                true,
+                true,
+                false,
+                false,
+                false,
+                Category.COOKIE,
+                null,
+                null,
+                false
+            );
+            sort = SortType.RECOMMEND;
+            keyword = "testKeyword";
+            cursorId = 1L;
+            memberId = 2L;
+
+            boardResponseDao1 = new BoardResponseDao(
+                2L,
+                1L,
+                "testStoreName",
+                "testThumbnail",
+                keyword,
+                3000,
+                Category.COOKIE,
+                true,
+                true,
+                false,
+                false,
+                false);
+            boardResponseDao2 = new BoardResponseDao(
+                3L,
+                1L,
+                "testStoreName",
+                "testThumbnail",
+                keyword,
+                3000,
+                Category.COOKIE,
+                true,
+                true,
+                false,
+                false,
+                false);
+        }
+
+        @Test
+        @DisplayName("검색 결과 게시물을 조회할 수 있다")
+        void successScroll() {
+
+            List<Long> searchedBoardIndexs = Arrays.asList(1L, 2L, 3L);
+
+            List<BoardResponseDao> boards = Arrays.asList(boardResponseDao1, boardResponseDao2);
+            Long boardCount = 2L;
+
+            when(keywordUtil.getBoardIds(keyword)).thenReturn(searchedBoardIndexs);
+            when(searchRepository.getBoardResponseList(searchedBoardIndexs, filterRequest, sort,
+                cursorId)).thenReturn(boards);
+            when(searchRepository.getAllCount(searchedBoardIndexs, filterRequest, sort)).thenReturn(
+                boardCount);
+
+            SearchCustomPage<SearchResponse> searchCustomPage = searchService.getBoardList(
+                filterRequest,
+                sort,
+                keyword,
+                cursorId,
+                memberId
+            );
+
+            assertAll(
+                () -> assertThat(searchCustomPage.getNextCursor()).isEqualTo(-1L),
+                () -> assertThat(searchCustomPage.getHasNext()).isFalse(),
+                () -> assertThat(searchCustomPage.getContent().getBoards()).hasSize(2),
+                () -> assertThat(searchCustomPage.getContent().getItemAllCount()).isEqualTo(
+                    boardCount)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("최근 검색어 조회 테스트")
+    class GetRecencyKeyword {
+
+        @Test
+        @DisplayName("익명 회원일 때 빈 응답을 반환해야 한다")
+        void withAnonymousMember() {
+            RecencySearchResponse response = searchService.getRecencyKeyword(ANONYMOUS_MEMBER_ID);
+
+            assertThat(response).isNotNull();
+            assertThat(response.content()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("유효한 회원일 때 최근 검색어를 반환해야 한다")
+        void withValidMemberId() {
+            Long validMemberId = 2L;
+            List<KeywordDto> keywords = Arrays.asList(new KeywordDto("keyword1"),
+                new KeywordDto("keyword2"));
+
+            when(searchRepository.getRecencyKeyword(validMemberId)).thenReturn(keywords);
+
+            RecencySearchResponse response = searchService.getRecencyKeyword(validMemberId);
+
+            assertThat(response).isNotNull();
+            assertThat(response.content()).isNotNull();
+            assertThat(response.content()).hasSize(keywords.size());
+        }
+
+        @Test
+        @DisplayName("검색어가 없을 때 빈 응답을 반환해야 한다")
+        void withNoKeywords() {
+            Long validMemberId = 2L;
+            when(searchRepository.getRecencyKeyword(validMemberId)).thenReturn(
+                Collections.emptyList());
+
+            RecencySearchResponse response = searchService.getRecencyKeyword(validMemberId);
+
+            assertThat(response).isNotNull();
+            assertThat(response.content()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("검색어 저장 테스트")
+    class SaveKeyword {
+
+        @Test
+        @DisplayName("비회원이면서 검색어가 존재한다면 성공적으로 검색어를 저장할 수 있다")
+        void withAnonymousMember() {
+            String keyword = "testKeyword";
+            searchService.saveKeyword(ANONYMOUS_MEMBER_ID, keyword);
+
+            Search search = Search.builder()
+                .memberId(1L)
+                .keyword(keyword)
+                .build();
+
+            when(searchRepository.save(any(Search.class))).thenReturn(search);
+
+            verify(searchRepository).save(any(Search.class));
+        }
+
+        @Test
+        @DisplayName("회원이면서 검색어가 존재한다면 성공적으로 검색어를 저장할 수 있다")
+        void withValidMemberId() {
+            String keyword = "testKeyword";
+            searchService.saveKeyword(MEMBER_ID, keyword);
+
+            Search search = Search.builder()
+                .memberId(MEMBER_ID)
+                .keyword(keyword)
+                .build();
+
+            when(searchRepository.save(any(Search.class))).thenReturn(search);
+
+            verify(searchRepository).save(any(Search.class));
+        }
+
+        @Test
+        @DisplayName("검색어가 존재하지 않는다면 400 에러를 반환한다")
+        void withUnValidKeyword() {
+            String keyword = "";
+            assertThatThrownBy(() -> searchService.saveKeyword(MEMBER_ID, keyword))
+                .isInstanceOf(BbangleException.class);
+        }
+
+        @Test
+        @DisplayName("검색어가 Null이라면 400 에러를 반환한다")
+        void unvalidKeywordToNull() {
+            String keyword = null;
+            assertThatThrownBy(() -> searchService.saveKeyword(MEMBER_ID, keyword))
+                .isInstanceOf(BbangleException.class);
+        }
+
+    }
+
+    @Test
+    @DisplayName("인기 검색어 조회 테스트")
+    void getBestKeyword() {
+        List<String> bestKeywords = List.of("testBestKeyword1", "testBestKeyword2",
+            "testBestKeyword3");
+
+        when(keywordUtil.getBestKeyword()).thenReturn(bestKeywords);
+
+        assertThat(searchService.getBestKeyword()).hasSize(3);
+    }
+
+}

--- a/src/test/java/com/bbangle/bbangle/search/service/SearchServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/search/service/SearchServiceTest.java
@@ -16,8 +16,12 @@ import com.bbangle.bbangle.boardstatistic.service.BoardStatisticService;
 import com.bbangle.bbangle.common.redis.repository.RedisRepository;
 import com.bbangle.bbangle.fixture.BoardStatisticFixture;
 import com.bbangle.bbangle.fixture.FixtureConfig;
+import com.bbangle.bbangle.fixture.MemberFixture;
 import com.bbangle.bbangle.fixture.ProductFixture;
+import com.bbangle.bbangle.fixture.SearchFixture;
+import com.bbangle.bbangle.member.domain.Member;
 import com.bbangle.bbangle.page.SearchCustomPage;
+import com.bbangle.bbangle.search.domain.Search;
 import com.bbangle.bbangle.search.dto.response.SearchResponse;
 import com.bbangle.bbangle.search.repository.SearchRepository;
 import com.bbangle.bbangle.search.service.utils.AutoCompleteUtil;
@@ -26,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,6 +39,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
 
 @Import(FixtureConfig.class)
 class SearchServiceTest extends AbstractIntegrationTest {
@@ -52,6 +58,8 @@ class SearchServiceTest extends AbstractIntegrationTest {
     AutoCompleteUtil autoCompleteUtil;
     @Autowired
     ProductFixture productFixture;
+    @Autowired
+    SearchFixture searchFixture;
     @MockBean
     KeywordUtil keywordUtil;
 
@@ -190,5 +198,18 @@ class SearchServiceTest extends AbstractIntegrationTest {
                 boardIds.add(board.getId());
             }
         }
+    }
+
+    @Test
+    @DisplayName("저장된 키워드를 삭제할 수 있다")
+    void deleteKeyword() {
+        Member member1 = memberRepository.save(MemberFixture.createKakaoMember());
+        Search search = searchFixture.create(member1.getId());
+
+        searchService.deleteRecencyKeyword(search.getKeyword(), member1.getId());
+        Optional<Search> checkSearch = searchRepository.findById(search.getId());
+
+        assertThat(checkSearch).isPresent();
+        assertThat(checkSearch.get().isDeleted()).isTrue();
     }
 }


### PR DESCRIPTION
## History
<!--연관된 내용, 이슈 링크를 달아주세요-->
https://github.com/eco-dessert-platform/backend/issues/188

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
- 로직은 변화없이 리팩토링 했습니다
- 검색어 저장
    - 회원일 경우 검색어 저장
    - 비회원일 경우 멤버 아이디 1L로 검색어 저장
- 인기 검색어 캐싱 & 조회
    - 현재 시간부터 24시간 전 검색어를 통계내서 레디스에 7개 캐싱
    - 조회 시 캐싱한 데이터 7개 반환
- 최근 검색어 조회 & 삭제
    - 회원일 경우 최근 검색한 검색어 7개를 내려줌
    - 중복 검색어 제외 7개
    - 검색어 삭제 시 isDeleted True로 활성화 
- 검색 결과
    - 테스트 시 에러 발견
    - board_statistics이 SearchMostWishedBoardQueryProviderResolver.java클래스에서 Join이 빠져있음

## 📷 Test Image
![image](https://github.com/user-attachments/assets/efe6079b-5a69-4973-8c8b-2140191e4284)

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC
- 검색 성능이 완전 좋은 것 같지 않아요.. "비건베이커리"와 "비건 베이커리"를 각각 {"비","건","베이커리"}, {"비건", "베이커리"} 이렇게 인식하더라구요. 더 좋은 토큰화 모델 있거나 개선사항이 있다면 의견 부탁드릴게요!!
