### PR TITLE
🐛 베스트 키워드 계속 쌓이는 문제 해결

### DIFF
--- a/src/main/java/com/bbangle/bbangle/search/service/utils/KeywordUtil.java
+++ b/src/main/java/com/bbangle/bbangle/search/service/utils/KeywordUtil.java
@@ -36,6 +36,7 @@ public class KeywordUtil {
     public void setBestKeywordInRedis(String[] keywords) {
         String bestKeywordNamespace = RedisEnum.BEST_KEYWORD.name();
 
+        redisRepository.delete(bestKeywordNamespace, BEST_KEYWORD_KEY);
         if (keywords.length == 0) {
             redisRepository.set(bestKeywordNamespace, BEST_KEYWORD_KEY, DEFAULT_SEARCH_KEYWORDS);
             return;


### PR DESCRIPTION
## History
베스트키워드 스케줄러 업데이트 시 삭제되는 코드 추가
- 아래 이미지처럼 베스트 키워드가 계속 쌓임
    - 한시간에 한번씩 업데이트를 하는데 기존 키워드를 삭제안하고 지속적으로 추가해서 생기는 문제 
![image](https://github.com/user-attachments/assets/da43429c-7414-40db-a03f-ab259fb19ee6)

## 📷 Test Image
![image](https://github.com/user-attachments/assets/c23222e0-20da-40a8-b0cd-2828a43b4b1c)
