### PR TITLE
유저 삭제 후 제 가입 시 제대로 삭제되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/bbangle/bbangle/member/domain/Member.java
+++ b/src/main/java/com/bbangle/bbangle/member/domain/Member.java
@@ -127,11 +127,6 @@ public class Member extends BaseEntity implements UserDetails {
         return true;
     }
 
-    public Member updateNickname(String nickname) {
-        this.nickname = nickname;
-        return this;
-    }
-
     public void updateFirst(MemberInfoRequest request) {
         if (request.birthDate() != null) {
             UserValidator.validateBirthDate(request.birthDate());
@@ -172,6 +167,7 @@ public class Member extends BaseEntity implements UserDetails {
         this.name = "-";
         this.nickname = "-";
         this.birth = "-";
+        this.providerId = "-";
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/fixture/MemberFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/MemberFixture.java
@@ -26,4 +26,12 @@ public class MemberFixture {
             .build();
     }
 
+    public static Member sameKaKaoMember(Member quitKakaoMember){
+        return Member.builder()
+            .nickname(quitKakaoMember.getNickname())
+            .provider(OauthServerType.KAKAO)
+            .providerId(quitKakaoMember.getProviderId())
+            .build();
+    }
+
 }

--- a/src/test/java/com/bbangle/bbangle/member/service/MemberServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/member/service/MemberServiceTest.java
@@ -23,11 +23,13 @@ class MemberServiceTest extends AbstractIntegrationTest {
     @Autowired
     PreferenceService preferenceService;
 
+    Member kakaoMember;
     Long memberId;
 
     @BeforeEach
     void setup() {
-        memberId = memberService.getFirstJoinedMember(MemberFixture.createKakaoMember());
+        kakaoMember = MemberFixture.createKakaoMember();
+        memberId = memberService.getFirstJoinedMember(kakaoMember);
     }
 
     @Test
@@ -98,6 +100,20 @@ class MemberServiceTest extends AbstractIntegrationTest {
         Assertions.assertThat(deletedMember.getNickname()).isEqualTo("-");
         Assertions.assertThat(deletedMember.getBirth()).isEqualTo("-");
         Assertions.assertThat(deletedMember.getProviderId()).isEqualTo("-");
+    }
+
+    @Test
+    @DisplayName("탈퇴 후 새로 가입한 멤버는 다른 멤버로 취급한다.")
+    void reJoinMemberIsNotSameWithBefore(){
+        //given
+        memberService.deleteMember(memberId);
+        Member sameMemberQuit = MemberFixture.sameKaKaoMember(kakaoMember);
+
+        //when
+        Long rejoinedId = memberService.getFirstJoinedMember(sameMemberQuit);
+
+        //then
+        Assertions.assertThat(memberId).isNotEqualTo(rejoinedId);
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/member/service/MemberServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/member/service/MemberServiceTest.java
@@ -8,6 +8,7 @@ import com.bbangle.bbangle.member.dto.MemberInfoRequest;
 import com.bbangle.bbangle.preference.domain.PreferenceType;
 import com.bbangle.bbangle.preference.dto.PreferenceSelectRequest;
 import com.bbangle.bbangle.preference.service.PreferenceService;
+import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -78,6 +79,25 @@ class MemberServiceTest extends AbstractIntegrationTest {
             .isTrue();
         Assertions.assertThat(isAssigned.isPreferenceAssigned())
             .isFalse();
+    }
+
+    @Test
+    @DisplayName("멤버는 정상적으로 탈퇴가 가능하다")
+    void getWithdrawSuccess(){
+        //given
+        memberService.deleteMember(memberId);
+
+        //when
+        Member deletedMember = memberRepository.findById(memberId).orElseThrow();
+
+        //then
+        Assertions.assertThat(deletedMember.isDeleted()).isTrue();
+        Assertions.assertThat(deletedMember.getEmail()).isEqualTo("-");
+        Assertions.assertThat(deletedMember.getPhone()).isEqualTo("-");
+        Assertions.assertThat(deletedMember.getName()).isEqualTo("-");
+        Assertions.assertThat(deletedMember.getNickname()).isEqualTo("-");
+        Assertions.assertThat(deletedMember.getBirth()).isEqualTo("-");
+        Assertions.assertThat(deletedMember.getProviderId()).isEqualTo("-");
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/search/service/SearchServiceMockTest.java
+++ b/src/test/java/com/bbangle/bbangle/search/service/SearchServiceMockTest.java
@@ -20,6 +20,8 @@ import com.bbangle.bbangle.search.dto.response.RecencySearchResponse;
 import com.bbangle.bbangle.search.dto.response.SearchResponse;
 import com.bbangle.bbangle.search.repository.SearchRepository;
 import com.bbangle.bbangle.search.service.utils.KeywordUtil;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -83,7 +85,12 @@ class SearchServiceMockTest extends AbstractIntegrationTest {
                 true,
                 false,
                 false,
-                false);
+                false,
+                BigDecimal.ONE,
+                10,
+                LocalDateTime.now(),
+                false,
+                10);
             boardResponseDao2 = new BoardResponseDao(
                 3L,
                 1L,
@@ -96,7 +103,12 @@ class SearchServiceMockTest extends AbstractIntegrationTest {
                 true,
                 false,
                 false,
-                false);
+                false,
+                BigDecimal.ONE,
+                10,
+                LocalDateTime.now(),
+                false,
+                10);
         }
 
         @Test


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History
- 카카오 로그인으로 정보를 받아온 후 해당 멤버가 DB에 존재하는지 확인하기 위해 provider(social login 제공처), providerId(식별자)로 구분함
- 그러나 providerId를 삭제 시 같이 변경해주지 않아 다시 가입하더라도 아직 존재하는 멤버처럼 조회하는 문제 발생
<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations
- providerId 정보를 다른 개인정보와 함께 '-' 처리해주는 방식으로 변경
- 같은 정보로 다시 회원 가입 시 정상적으로 가입됨을 확인
- 이로 인해 보이지 않던 폴더와 찜하기 기능도 다시 활성화

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
