### PR TITLE
FCM 날짜별 알림 기능 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/config/CorsConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/CorsConfig.java
@@ -23,9 +23,7 @@ public class CorsConfig implements WebMvcConfigurer {
                         "http://api.bbangle.store",
                         "http://www.bbangle.store",
                         "https://api.bbangle.store",
-                        "https://www.bbangle.store",
-                        "http://115.85.181.105:3001",
-                        "http://localhost:8080"
+                        "https://www.bbangle.store"
                     )
                     .allowedHeaders("*")
                     .exposedHeaders("ACCESS_KEY", "Authorization", "RefreshToken")

--- a/src/main/java/com/bbangle/bbangle/push/domain/Push.java
+++ b/src/main/java/com/bbangle/bbangle/push/domain/Push.java
@@ -16,8 +16,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-import java.time.LocalDate;
-
 @Table(name = "push")
 @Getter
 @Entity
@@ -52,18 +50,14 @@ public class Push extends BaseEntity {
     private PushCategory pushCategory;
 
     @Column(name = "is_active", columnDefinition = "tinyint")
-    private boolean active;
-
-    @Column(name = "date")
-    private LocalDate date;
-
+    private boolean isActive;
 
     public void updateDays(String days) {
         this.days = days;
     }
 
-    public void updateActive(boolean active) {
-        this.active = active;
+    public void updateActive(boolean isActive) {
+        this.isActive = isActive;
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/push/domain/PushCategory.java
+++ b/src/main/java/com/bbangle/bbangle/push/domain/PushCategory.java
@@ -1,15 +1,11 @@
 package com.bbangle.bbangle.push.domain;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum PushCategory {
-    @JsonProperty("BBANGCKETING")
     BBANGCKETING("입고"),
-    @JsonProperty("RESTOCK")
     RESTOCK("재입고");
 
     private final String description;

--- a/src/main/java/com/bbangle/bbangle/push/dto/CreatePushRequest.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/CreatePushRequest.java
@@ -4,15 +4,15 @@ import com.bbangle.bbangle.push.domain.PushType;
 import jakarta.validation.constraints.NotNull;
 
 public record CreatePushRequest(
-        @NotNull
-        String fcmToken,
-        @NotNull
-        PushType pushType,
-        String days,
-        @NotNull
-        PushCategory pushCategory,
-        String date,
-        @NotNull
-        Long productId
+    @NotNull
+    String fcmToken,
+    @NotNull
+    PushType pushType,
+    String days,
+    @NotNull
+    PushCategory pushCategory,
+    String date,
+    @NotNull
+    Long productId
 ) {
 }

--- a/src/main/java/com/bbangle/bbangle/push/dto/FcmMessageDto.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/FcmMessageDto.java
@@ -9,8 +9,8 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)//test
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FcmMessageDto {
     @JsonProperty("validate_only")
     private boolean validateOnly;

--- a/src/main/java/com/bbangle/bbangle/push/dto/FcmPush.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/FcmPush.java
@@ -1,9 +1,9 @@
 package com.bbangle.bbangle.push.dto;
 
-import com.bbangle.bbangle.common.domain.Days;
 import com.bbangle.bbangle.push.domain.PushCategory;
 import com.bbangle.bbangle.push.domain.PushType;
 import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
 
 public record FcmPush(
     Long pushId,
@@ -15,7 +15,8 @@ public record FcmPush(
     PushType pushType,
     String days,
     PushCategory pushCategory,
-    boolean isSoldOut
+    boolean isSoldOut,
+    LocalDateTime date
 ) {
 
     @QueryProjection

--- a/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepositoryImpl.java
@@ -40,7 +40,7 @@ public class PushQueryDSLRepositoryImpl implements PushQueryDSLRepository {
                         store.name,
                         product.title,
                         board.profile,
-                        push.active
+                        push.isActive
                 ))
                 .from(push)
                 .join(product).on(push.productId.eq(product.id))
@@ -63,13 +63,14 @@ public class PushQueryDSLRepositoryImpl implements PushQueryDSLRepository {
                         push.pushType,
                         push.days,
                         push.pushCategory,
-                        product.soldout
+                        product.soldout,
+                        product.orderStartDate
                 ))
                 .from(push)
                 .join(member).on(push.memberId.eq(member.id))
                 .join(product).on(push.productId.eq(product.id))
                 .join(board).on(product.board.id.eq(board.id))
-                .where(push.active.isTrue())
+                .where(push.isActive.isTrue())
                 .fetch();
     }
 

--- a/src/main/java/com/bbangle/bbangle/push/service/PushService.java
+++ b/src/main/java/com/bbangle/bbangle/push/service/PushService.java
@@ -42,9 +42,8 @@ public class PushService {
                     .productId(request.productId())
                     .pushType(request.pushType())
                     .days(!StringUtils.isBlank(request.days()) ? request.days() : null)
-                    .date(!StringUtils.isBlank(request.date()) ? LocalDate.parse(request.date()) : null)
                     .pushCategory(request.pushCategory())
-                    .active(true)
+                    .isActive(true)
                     .build();
             pushRepository.save(newPush);
             return;
@@ -117,14 +116,17 @@ public class PushService {
         return requestList;
     }
 
-    private boolean shouldSendPush(FcmPush fcmPush, List<Long> targetProductIdSet) {
-        //TODO 날짜별 구현해야함(아직 프론트로부터 어떻게 API 요청이 오는 지 모름)
+    private boolean shouldSendPush(FcmPush fcmPush, List<Long> targetProductIds) {
         if (fcmPush.pushType() == PushType.DATE) {
-            return targetProductIdSet.contains(fcmPush.productId());
+            return targetProductIds.contains(fcmPush.productId()) && isEqualToday(fcmPush.date().toLocalDate());
         } else if (fcmPush.pushType() == PushType.WEEK) {
-            return targetProductIdSet.contains(fcmPush.productId()) && doDaysContainToday(fcmPush.days());
+            return targetProductIds.contains(fcmPush.productId()) && doDaysContainToday(fcmPush.days());
         }
         return false;
+    }
+
+    private boolean isEqualToday(LocalDate pushDate) {
+        return LocalDate.now().isEqual(pushDate);
     }
 
     private boolean doDaysContainToday(String days) {

--- a/src/main/java/com/bbangle/bbangle/review/scheduler/ReviewScheduler.java
+++ b/src/main/java/com/bbangle/bbangle/review/scheduler/ReviewScheduler.java
@@ -24,8 +24,6 @@ public class ReviewScheduler {
     private static final Long MINIMUM_BEST_REVIEW_STANDARD = 5L;
     private static final Long TEMP_DOMAINID = -1L;
 
-
-
     @Scheduled(cron = "0 0 0 * * *")//매일 밤 12시
     @Transactional
     public void action() {

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
@@ -36,7 +36,8 @@ public class StoreRepositoryImpl implements StoreQueryDSLRepository {
             .where(store.id.eq(storeId))
             .leftJoin(wishListStore)
             .on(wishListStoreFilter.equalMemberId(memberId)
-                .and(wishListStoreFilter.equalStoreId(store)))
+                .and(wishListStoreFilter.equalStoreId(store))
+                .and(wishListStore.isDeleted.isFalse()))
             .fetchOne();
     }
 

--- a/src/test/java/com/bbangle/bbangle/fixture/ProductFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/ProductFixture.java
@@ -101,6 +101,23 @@ public class ProductFixture {
             .build();
     }
 
+    public static Product randomProductWithOrderDate(Board board) {
+        String dishName = getProductTitle();
+        List<Boolean> productIngredient = getRandomIngredient(6);
+
+        return Product.builder()
+                .board(board)
+                .title(dishName)
+                .veganTag(productIngredient.get(0))
+                .ketogenicTag(productIngredient.get(1))
+                .sugarFreeTag(productIngredient.get(2))
+                .highProteinTag(productIngredient.get(3))
+                .glutenFreeTag(productIngredient.get(4))
+                .category(Category.BREAD)
+                .orderStartDate(LocalDateTime.now())
+                .build();
+    }
+
     public static Product gluetenFreeProduct(Board board) {
         String dishName = getProductTitle();
         List<Boolean> productIngredient = getRandomIngredient(5);

--- a/src/test/java/com/bbangle/bbangle/fixture/PushFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/PushFixture.java
@@ -15,7 +15,7 @@ public class PushFixture {
                 .memberId(memberId)
                 .productId(productId)
                 .pushCategory(PushCategory.BBANGCKETING)
-                .active(true)
+                .isActive(true)
                 .build();
     }
 
@@ -26,7 +26,7 @@ public class PushFixture {
                 .memberId(memberId)
                 .productId(productId)
                 .pushCategory(PushCategory.RESTOCK)
-                .active(true)
+                .isActive(true)
                 .build();
     }
 
@@ -37,7 +37,7 @@ public class PushFixture {
                 .memberId(memberId)
                 .productId(productId)
                 .pushCategory(PushCategory.BBANGCKETING)
-                .active(false)
+                .isActive(false)
                 .build();
     }
 

--- a/src/test/java/com/bbangle/bbangle/push/service/PushServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/push/service/PushServiceTest.java
@@ -242,7 +242,7 @@ class PushServiceTest extends AbstractIntegrationTest {
     }
 
     private Product createProduct(Board board) {
-        return productRepository.save(ProductFixture.randomProduct(board));
+        return productRepository.save(ProductFixture.randomProductWithOrderDate(board));
     }
 
     private Member createMember() {


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
Closes #140 

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
- FCM 날짜별 알림 기능 구현
- [프론트 요청] 스토어 개별 조회 시 찜 유무 조회 오류

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->
![image](https://github.com/user-attachments/assets/6bbfd7a0-c2e0-4f53-bf97-93b8da79af51)


## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
생각보다 FCM에서 알림 보내는 게 느린데 restTemplate 대안으로 나온 webClient가 있더라구요.
예상보다 빠르게 도입해야 될지도 모르겠습니다