### PR TITLE
위시리스트 폴더에 있는 board임에도 board 전체 조회 시 isWished : false 로 나오는 에러 해결

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
@@ -110,7 +110,7 @@ public class BoardService {
             getFirstBoardInfo(boardAndImageDtos));
 
         boolean isWished = Objects.nonNull(memberId)
-            && wishListBoardRepository.existsByBoardIdAndMemberId(memberId, boardId);
+            && wishListBoardRepository.existsByBoardIdAndMemberId(boardId, memberId);
 
         List<String> boardImageUrls = extractImageUrl(boardAndImageDtos);
         List<String> boardDetailUrls = boardDetailRepository.findByBoardId(boardId);

--- a/src/main/java/com/bbangle/bbangle/wishlist/controller/WishListBoardController.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/controller/WishListBoardController.java
@@ -1,6 +1,5 @@
 package com.bbangle.bbangle.wishlist.controller;
 
-import com.bbangle.bbangle.boardstatistic.service.BoardStatisticService;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.wishlist.dto.WishListBoardRequest;
@@ -10,7 +9,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,7 +25,7 @@ public class WishListBoardController {
     public CommonResult wish(
         @AuthenticationPrincipal
         Long memberId,
-        @PathVariable
+        @PathVariable("boardId")
         Long boardId,
         @RequestBody
         WishListBoardRequest wishRequest
@@ -40,7 +38,7 @@ public class WishListBoardController {
     public CommonResult cancel(
         @AuthenticationPrincipal
         Long memberId,
-        @PathVariable
+        @PathVariable("boardId")
         Long boardId
     ) {
         wishListBoardService.cancel(memberId, boardId);


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
- 위시리스트 폴더에 있는 board임에도 board 전체 조회 시 isWished : false 로 나오는 에러 해결
로직의 문제보다 Sprinfg data JPA 의 exist 를 사용하여 만든 쿼리의 매개변수 순서가 문제였음


## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
이번일을 통해 테스트 코드에서 이를 잡아내지 못함은 
어떻게 테스트 코드를 짜야하는 가에 대해서 한번 생각해볼 만 문제라고 생각함

**추가 논의 사항
Board와 Product, ProductIImg가 여전히 @OneToMany @ManyToOne 을 사용중이여서 
엔티티 수정 및 쿼리 수정도 추후 리팩토링 시에 필요해 보임
