### PR TITLE
추천순 선택 시 취향 가중치 반영 조회 로직 수정

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/repository/BoardQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/BoardQueryDSLRepository.java
@@ -16,6 +16,7 @@ public interface BoardQueryDSLRepository {
     List<TitleDto> findAllTitle();
 
     List<BoardResponseDao> getBoardResponseList(
+        Long memberId,
         FilterRequest filterRequest,
         SortType sort,
         Long cursorId

--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/cursor/PreferenceRecommendCursorGenerator.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/cursor/PreferenceRecommendCursorGenerator.java
@@ -1,0 +1,45 @@
+package com.bbangle.bbangle.board.repository.basic.cursor;
+
+import com.bbangle.bbangle.board.domain.QBoard;
+import com.bbangle.bbangle.board.repository.folder.cursor.BoardCursorGenerator;
+import com.bbangle.bbangle.boardstatistic.domain.QBoardPreferenceStatistic;
+import com.bbangle.bbangle.boardstatistic.domain.QBoardStatistic;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.preference.domain.PreferenceType;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PreferenceRecommendCursorGenerator{
+
+    private static final QBoardPreferenceStatistic boardStatistic = QBoardPreferenceStatistic.boardPreferenceStatistic;
+    private static final QBoard board = QBoard.board;
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public BooleanBuilder getCursor(Long cursorId, PreferenceType preferenceType) {
+        BooleanBuilder cursorBuilder = new BooleanBuilder();
+        cursorBuilder.and(board.isDeleted.eq(false));
+        if (cursorId == null) {
+            return cursorBuilder;
+        }
+
+        Double targetScore = Optional.ofNullable(jpaQueryFactory.select(boardStatistic.preferenceScore)
+                .from(boardStatistic)
+                .where(boardStatistic.boardId.eq(cursorId).and(boardStatistic.preferenceType.eq(preferenceType)))
+                .fetchOne())
+            .orElseThrow(() -> new BbangleException(
+                BbangleErrorCode.RANKING_NOT_FOUND));
+
+        cursorBuilder.and(boardStatistic.preferenceScore.lt(targetScore).and(boardStatistic.preferenceType.eq(preferenceType)))
+                .or(boardStatistic.preferenceScore.eq(targetScore).and(board.id.loe(cursorId)).and(boardStatistic.preferenceType.eq(preferenceType)));
+
+        return cursorBuilder;
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/query/PreferenceRecommendBoardQueryProviderResolver.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/query/PreferenceRecommendBoardQueryProviderResolver.java
@@ -1,0 +1,91 @@
+package com.bbangle.bbangle.board.repository.basic.query;
+
+import static com.bbangle.bbangle.board.repository.BoardRepositoryImpl.BOARD_PAGE_SIZE;
+
+import com.bbangle.bbangle.board.dao.BoardResponseDao;
+import com.bbangle.bbangle.board.dao.QBoardResponseDao;
+import com.bbangle.bbangle.board.domain.QBoard;
+import com.bbangle.bbangle.board.domain.QProduct;
+import com.bbangle.bbangle.boardstatistic.domain.QBoardPreferenceStatistic;
+import com.bbangle.bbangle.boardstatistic.domain.QBoardStatistic;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.preference.domain.Preference;
+import com.bbangle.bbangle.preference.domain.PreferenceType;
+import com.bbangle.bbangle.preference.domain.QMemberPreference;
+import com.bbangle.bbangle.preference.domain.QPreference;
+import com.bbangle.bbangle.store.domain.QStore;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PreferenceRecommendBoardQueryProviderResolver{
+
+    private static final QBoard board = QBoard.board;
+    private static final QProduct product = QProduct.product;
+    private static final QStore store = QStore.store;
+    private static final QBoardPreferenceStatistic preferenceBoardStatistic = QBoardPreferenceStatistic.boardPreferenceStatistic;
+    private static final QBoardStatistic boardStatistic = QBoardStatistic.boardStatistic;
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<BoardResponseDao> findBoards(
+        BooleanBuilder filter,
+        BooleanBuilder cursorInfo,
+        OrderSpecifier<?>[] orderCondition,
+        Long memberId,
+        PreferenceType selectedPreference
+    ) {
+        List<Long> boardIds = queryFactory.select(board.id)
+            .distinct()
+            .from(product)
+            .join(board)
+            .on(product.board.id.eq(board.id))
+            .join(preferenceBoardStatistic)
+            .on(preferenceBoardStatistic.boardId.eq(board.id))
+            .where(cursorInfo.and(filter).and(preferenceBoardStatistic.preferenceType.eq(selectedPreference)))
+            .orderBy(orderCondition)
+            .limit(BOARD_PAGE_SIZE + 1)
+            .fetch();
+
+        return queryFactory.select(
+                new QBoardResponseDao(
+                    board.id,
+                    store.id,
+                    store.name,
+                    board.profile,
+                    board.title,
+                    board.price,
+                    product.category,
+                    product.glutenFreeTag,
+                    product.highProteinTag,
+                    product.sugarFreeTag,
+                    product.veganTag,
+                    product.ketogenicTag,
+                    boardStatistic.boardReviewGrade,
+                    boardStatistic.boardReviewCount,
+                    product.orderEndDate,
+                    product.soldout,
+                    board.discountRate
+                ))
+            .from(product)
+            .join(board)
+            .on(product.board.id.eq(board.id))
+            .join(store)
+            .on(board.store.id.eq(store.id))
+            .join(boardStatistic)
+            .on(boardStatistic.boardId.eq(board.id))
+            .join(preferenceBoardStatistic)
+            .on(board.id.eq(preferenceBoardStatistic.boardId))
+            .where(board.id.in(boardIds))
+            .where(preferenceBoardStatistic.preferenceType.eq(selectedPreference))
+            .orderBy(orderCondition)
+            .fetch();
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
@@ -62,7 +62,7 @@ public class BoardService {
         Long memberId
     ) {
         List<BoardResponseDao> boards = boardRepository
-            .getBoardResponseList(filterRequest, sort, cursorId);
+            .getBoardResponseList(memberId, filterRequest, sort, cursorId);
         BoardCustomPage<List<BoardResponseDto>> boardPage = BoardPageGenerator.getBoardPage(boards,
             DEFAULT_BOARD);
 


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations
- 로그인 한 사람의 경우 그 사람의 취향을 조회한다
- 선호도 추천 테이블에서 조회한 취향으로 필터링 
- 필터링 후 커서기반 페이지네이션을 적용

조회 쿼리
```sql
Hibernate: 
    select
        p1_0.id,
        p1_0.preference_type 
    from
        preference p1_0 
    join
        member_preference mp1_0 
            on p1_0.id=mp1_0.preference_id 
    where
        mp1_0.member_id=?
Hibernate: 
    select
        distinct b1_0.id 
    from
        product p1_0 
    join
        product_board b1_0 
            on p1_0.product_board_id=b1_0.id 
    join
        board_preference_statistic bps1_0 
            on bps1_0.board_id=b1_0.id 
    where
        b1_0.is_deleted=? 
        and bps1_0.preference_type=? 
    order by
        bps1_0.preference_score desc 
    limit
        ?
Hibernate: 
    select
        b1_0.id,
        s1_0.id,
        s1_0.name,
        b1_0.profile,
        b1_0.title,
        b1_0.price,
        p1_0.category,
        p1_0.gluten_free_tag,
        p1_0.high_protein_tag,
        p1_0.sugar_free_tag,
        p1_0.vegan_tag,
        p1_0.ketogenic_tag,
        bs1_0.board_review_grade,
        bs1_0.board_review_count,
        p1_0.order_end_date,
        p1_0.is_soldout,
        b1_0.discount_rate 
    from
        product p1_0 
    join
        product_board b1_0 
            on p1_0.product_board_id=b1_0.id 
    join
        store s1_0 
            on b1_0.store_id=s1_0.id 
    join
        board_statistic bs1_0 
            on bs1_0.board_id=b1_0.id 
    join
        board_preference_statistic bps1_0 
            on b1_0.id=bps1_0.board_id 
    where
        b1_0.id in (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) 
        and bps1_0.preference_type=? 
    order by
        bps1_0.preference_score desc
```
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC
- 조회 시 member 취향 타입이 등록되고 그것이 쿼리에 반영되어야 하기 때문에 기존에 cursorId와 필터 조건만 받아오던 QueryProvider, CursorGenerator와 호환이 되지 않아 상속이 아닌 별도의 클래스를 만들어 작성
- 추후 리팩토링하는 것이 좋아보임
<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
