### PR TITLE
[프론트 요청]재입고 및 빵켓팅 알림 재신청시 pushType이 null 이여도 처리

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/repository/ProductQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/ProductQueryDSLRepository.java
@@ -14,6 +14,4 @@ public interface ProductQueryDSLRepository {
     List<TitleDto> findAllTitle();
 
     List<ProductOrderDto> findProductDtoById(Long memberId, Long boardId);
-
-    List<Long> findProductsByActivatedProductIds(List<Long> subscribedProductIdList);
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/ProductRepositoryImpl.java
@@ -69,55 +69,45 @@ public class ProductRepositoryImpl implements ProductQueryDSLRepository {
     @Override
     public List<ProductOrderDto> findProductDtoById(Long memberId, Long boardId) {
         return queryFactory
-            .select(
-                Projections.constructor(
-                    ProductOrderDto.class,
-                    product.id,
-                    product.title,
-                    product.price,
-                    product.category,
-                    product.glutenFreeTag,
-                    product.highProteinTag,
-                    product.sugarFreeTag,
-                    product.veganTag,
-                    product.ketogenicTag,
-                    product.sugars,
-                    product.protein,
-                    product.carbohydrates,
-                    product.fat,
-                    product.weight,
-                    product.calories,
-                    product.monday,
-                    product.tuesday,
-                    product.wednesday,
-                    product.thursday,
-                    product.friday,
-                    product.saturday,
-                    product.sunday,
-                    product.orderStartDate,
-                    product.orderEndDate,
-                    product.soldout,
-                    push.pushType,
-                    push.days,
-                    push.isActive
-                ))
-            .from(product)
-            .leftJoin(push).on(
-                product.id.eq(push.productId)
-                    .and(memberId != null ? push.memberId.eq(memberId)
-                        : Expressions.booleanTemplate("false")))
-            .where(product.board.id.eq(boardId))
-            .orderBy(product.id.desc())
-            .fetch();
+                .select(
+                        Projections.constructor(
+                                ProductOrderDto.class,
+                                product.id,
+                                product.title,
+                                product.price,
+                                product.category,
+                                product.glutenFreeTag,
+                                product.highProteinTag,
+                                product.sugarFreeTag,
+                                product.veganTag,
+                                product.ketogenicTag,
+                                product.sugars,
+                                product.protein,
+                                product.carbohydrates,
+                                product.fat,
+                                product.weight,
+                                product.calories,
+                                product.monday,
+                                product.tuesday,
+                                product.wednesday,
+                                product.thursday,
+                                product.friday,
+                                product.saturday,
+                                product.sunday,
+                                product.orderStartDate,
+                                product.orderEndDate,
+                                product.soldout,
+                                push.pushType,
+                                push.days,
+                                push.isActive
+                        ))
+                .from(product)
+                .leftJoin(push).on(
+                        product.id.eq(push.productId)
+                                .and(memberId != null ? push.memberId.eq(memberId)
+                                        : Expressions.booleanTemplate("false")))
+                .where(product.board.id.eq(boardId))
+                .orderBy(product.id.desc())
+                .fetch();
     }
-
-
-    @Override
-    public List<Long> findProductsByActivatedProductIds(List<Long> subscribedProductIdList) {
-        return queryFactory.select(product.id).distinct()
-            .from(product)
-            .where(product.id.in(subscribedProductIdList))
-            .fetch();
-    }
-
 }

--- a/src/main/java/com/bbangle/bbangle/push/dto/CreatePushRequest.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/CreatePushRequest.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.NotNull;
 public record CreatePushRequest(
     @NotNull
     String fcmToken,
-    @NotNull
     PushType pushType,
     String days,
     @NotNull

--- a/src/main/java/com/bbangle/bbangle/push/dto/FcmRequest.java
+++ b/src/main/java/com/bbangle/bbangle/push/dto/FcmRequest.java
@@ -1,6 +1,5 @@
 package com.bbangle.bbangle.push.dto;
 
-import com.bbangle.bbangle.push.domain.PushCategory;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -27,7 +26,7 @@ public class FcmRequest {
         this.memberName = fcmPush.memberName();
         this.boardTitle = fcmPush.boardTitle();
         this.productTitle = fcmPush.productTitle();
-        this.pushType = fcmPush.pushType().getDescription();
+        this.pushType = fcmPush.pushType() != null ? fcmPush.pushType().getDescription() : null;
         this.days = fcmPush.days();
         this.pushCategory = fcmPush.pushCategory().getDescription();
         this.isSoldOut = fcmPush.isSoldOut();

--- a/src/main/java/com/bbangle/bbangle/token/oauth/OauthService.java
+++ b/src/main/java/com/bbangle/bbangle/token/oauth/OauthService.java
@@ -31,7 +31,6 @@ public class OauthService {
     @Transactional
     public LoginTokenResponse login(OauthServerType oauthServerType, String authCode) {
         Member oauthMember = oauthMemberClientComposite.fetch(oauthServerType, authCode);
-        //TODO 구글, 카카오 식별자 필요
         Long memberId = memberRepository.findByProviderAndProviderId(oauthMember.getProvider(),
                 oauthMember.getProviderId())
             .orElseGet(() -> memberService.getFirstJoinedMember(oauthMember));

--- a/src/test/java/com/bbangle/bbangle/push/service/PushServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/push/service/PushServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -251,7 +252,7 @@ class PushServiceTest extends AbstractIntegrationTest {
 
     private CreatePushRequest createPushRequest(Long productId) {
         return new CreatePushRequest("testFcmToken1", PushType.DATE, null,
-                PushCategory.BBANGCKETING, null, productId);
+                PushCategory.BBANGCKETING, LocalDate.now().toString(), productId);
     }
 
 


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
[프론트 요청] 재입고 및 빵켓팅 알림 재신청시 pushType이 null 이여도 처리

- 재입고는 날짜별, 요일별 알림이 없기 때문에 프론트에서 보낼 필요가 없다는 의견
- 이에 따라 RequestDto의 pushType 을 null 처리

- 빵켓팅 / 재입고 조회 페이지에서 빵켓팅 재신청시 프론트에서 해당 상품이 날짜별, 요일별 알림 유무를 판단할 수 없다는 의견
- API에 요일이 포함되어 있으면 요일만 업데이트 하는 것으로 변경

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
