### PR TITLE
production deploy 변수 실수 수정

### DIFF
--- a/.github/workflows/cd-pipeline-aws-deploy.yml
+++ b/.github/workflows/cd-pipeline-aws-deploy.yml
@@ -78,10 +78,10 @@ jobs:
       - name: 이미지 새로 build 및 docker 서버 재실행
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.DEV_AWS_SSH_HOST }}
-          username: ${{ secrets.DEV_AWS_SSH_USERNAME }}
-          key: ${{ secrets.DEV_AWS_SSH_KEY }}
-          port: ${{ secrets.DEV_AWS_SSH_PORT }}
+          host: ${{ secrets.DEPLOY_AWS_SSH_HOST }}
+          username: ${{ secrets.DEPLOY_AWS_SSH_USERNAME }}
+          key: ${{ secrets.DEPLOY_AWS_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_AWS_SSH_PORT }}
           script: |
             chmod +x deploy-docker.sh
             ./deploy-docker.sh


### PR DESCRIPTION
---
name: "✅ bug"
about: Feature 요구 사항을 입력해주세요.
title: "✅ bug"
labels: ✅ bug
assignees: ''

---
## History

Close #255 

- main 서버에 코드를 merge 시켜도 Production 서버에 도커가 업데이트가 안 되는 오류가 발생했습니다.
- 원인은 production github Action 파일에서 도커 빌드 빌드 주체가 DEPLOY_AWS_SSH_HOST 가 아니라 DEV_AWS_SSH_HOST로 되어있었습니다.
- 즉, 최신 jar파일은 운영서버에 넘겨주고 개발서버에 jar파일을 도커 빌드 한 게 문제였습니다. 
## 🚀 Major Changes & Explanations

- 단순하게 변수명 수정해주었습니다

## 📷 Test Image
![image](https://github.com/user-attachments/assets/e659d398-4da1-42d1-ba39-e1a6c798869d)

