### PR TITLE
운영환경에서 swagger 사용 안되게 조치

### DIFF
--- a/src/main/java/com/bbangle/bbangle/config/SwaggerConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/SwaggerConfig.java
@@ -14,12 +14,14 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
+@Profile({"production"})
 public class SwaggerConfig {
 
     private static final String AUTHORIZATION_URL = "https://kauth.kakao.com/oauth/authorize";


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image
로컬에서 테스트 할때는 이렇게 나옵니다
![image](https://github.com/user-attachments/assets/cc17924c-3a3a-4b46-a518-ce918c8c8c83)
다만 이렇게 나오려면
![image](https://github.com/user-attachments/assets/f2bc7686-04ad-4f7b-be01-5177091a6c7d)
이 설정도 필요한데
![image](https://github.com/user-attachments/assets/11d0c3b8-f2b7-40da-84f3-3f736c07f6fc)
이 대화로 인해 다른 거 건드릴 필요 없이 Swagger Config 파일에 profile만 설정했고
application-production.yml이 어떻게 설정되어 있는지 몰라 건드리지 못했습니다
또한 저희 운영 쪽 서버이기 때문에 swagger 접속은 안 할 것으로 예상됩니다.
제 생각이 틀리다면 코멘트 주세요!

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
