### PR TITLE
슬랙 에러 글자 수 제한 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/common/adaptor/slack/SlackMessage.java
+++ b/src/main/java/com/bbangle/bbangle/common/adaptor/slack/SlackMessage.java
@@ -1,0 +1,81 @@
+package com.bbangle.bbangle.common.adaptor.slack;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Data
+@AllArgsConstructor
+public class SlackMessage {
+
+    private List<SlackBlock> blocks;
+
+    public static SlackMessage fromException(HttpServletRequest request, Throwable t) {
+        return new SlackMessage(List.of(
+                SlackBlock.createBlock("header", "plain_text", SlackBlock.SlackText.createHeader(t.getMessage())),
+                SlackBlock.createBlock("section", "plain_text", SlackBlock.SlackText.createSection(request, t))
+        ));
+    }
+
+
+    @Data
+    @AllArgsConstructor
+    public static class SlackBlock {
+        private String type; // ex) header, section
+        private SlackText slackText;
+
+
+        public static SlackBlock createBlock(String part, String type, String title) {
+            return new SlackBlock(part, new SlackText(type, title));
+        }
+
+
+        @Data
+        @AllArgsConstructor
+        public static class SlackText {
+            private String type; // ex) plain_text
+            private String text;
+
+            public static String createHeader(String text) {
+                return truncateText(text, 150);
+            }
+
+            public static String createSection(HttpServletRequest request, Throwable t) {
+                return String.format(
+                        "- url: %s \n - 위치: %s \n - message: %s ",
+                        request.getRequestURI(),
+                        extractMethodPosition(t),
+                        truncateText(t.getMessage(), 3000)
+                );
+            }
+
+            /**
+             * 에러 발생한 메소드 위치 반환
+             */
+            private static String extractMethodPosition(Throwable t) {
+                Optional<StackTraceElement> optional = Arrays.stream(t.getStackTrace())
+                        .filter(it -> it.getClassName().contains("bbangle"))
+                        .findFirst();
+
+                StackTraceElement targetElement = optional.orElseGet(() -> t.getStackTrace()[0]);
+                return String.format("%s, %s", targetElement.getClassName(), targetElement.getMethodName());
+            }
+
+            /**
+             * 문자열 자르기
+             */
+            private static String truncateText(String text, int maxLength) {
+                if (text.length() <= maxLength) {
+                    return text;
+                }
+                return text.substring(0, maxLength - 3) + "...";
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
---
## History
![image](https://github.com/user-attachments/assets/16d68a5b-40da-4b31-8484-e5cb08c4ccf9)
- 에러 길이가 길 시 badRequest로 슬랙 전송이 안됐습니다

## 🚀 Major Changes & Explanations

- 코드 정리( 클래스 분리)
- 글자 수 제한(header는 150자, section은 3000자)

