### PR TITLE
검색어 저장 문제 해결 (modified 컬럼 삭제)

### DIFF
--- a/src/main/java/com/bbangle/bbangle/search/domain/Search.java
+++ b/src/main/java/com/bbangle/bbangle/search/domain/Search.java
@@ -1,6 +1,5 @@
 package com.bbangle.bbangle.search.domain;
 
-import com.bbangle.bbangle.common.domain.BaseEntity;
 import com.bbangle.bbangle.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
@@ -13,16 +12,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Table(name = "search")
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Search extends BaseEntity {
+public class Search {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,11 +33,14 @@ public class Search extends BaseEntity {
     @JoinColumn(name = "member_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Member member;
 
-    @Column(name = "is_deleted", columnDefinition = "tinyint")
-    private boolean isDeleted;
-
     @Column(name = "keyword")
     private String keyword;
+
+    @Column(name = "is_deleted", columnDefinition = "tinyint")
+    private boolean isDeleted = false;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
 
     @Builder
     public Search(Long memberId, String keyword) {
@@ -45,5 +49,4 @@ public class Search extends BaseEntity {
             .build();
         this.keyword = keyword;
     }
-
 }


### PR DESCRIPTION
## History
- Full TestCase 작성 도중 안되는 것을 확인
- 디자인, 프론트 팀이 긴급하게 요청 줌

## 🚀 Major Changes & Explanations
- Search 도메인엔 ModifiedAt 컬럼이 존재하지만 데이터베이스 컬럼엔 없음
- 이 문제로 인해 저장 에러 발생
- 위 문제를 해결하기 위해 BaseEntity 상속을 포기하고, 직접 CreatedAt을 입력

## 📷 Test Image
![image](https://github.com/user-attachments/assets/99fce392-c9b9-436c-addb-eaa0539981c1)

## 💡 ETC
- 언제부터 이 에러 발생했는지 확인이 필요할 것 같습니다..