### PR TITLE
Board Profile CDN 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/dto/BoardImageDetailResponse.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/BoardImageDetailResponse.java
@@ -25,13 +25,14 @@ public class BoardImageDetailResponse {
     public static BoardImageDetailResponse from(
         BoardDto boardDto,
         Boolean isWished,
+        String boardProfileUrl,
         List<String> boardImageDtoList,
         List<String> boardDetailList
     ) {
         return BoardImageDetailResponse.builder()
             .boardId(boardDto.getBoardId())
             .storeId(boardDto.getStoreId())
-            .profile(boardDto.getProfile())
+            .profile(boardProfileUrl)
             .title(boardDto.getTitle())
             .price(boardDto.getPrice())
             .purchaseUrl(boardDto.getPurchaseUrl())

--- a/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
@@ -89,7 +89,8 @@ public class BoardService {
 
     private List<String> extractImageUrl(List<BoardAndImageDto> boardAndImageDtos) {
         return boardAndImageDtos.stream()
-            .map(BoardAndImageDto::url)
+            .filter(imageDto -> Objects.nonNull(imageDto.url()))
+            .map(imageDto -> buildFullUrl(imageDto.url()))
             .toList();
     }
 

--- a/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
@@ -51,8 +51,6 @@ public class BoardService {
     @Value("${cdn.domain}")
     private String cdn;
 
-
-
     @Transactional(readOnly = true)
     public BoardCustomPage<List<BoardResponseDto>> getBoardList(
         FilterRequest filterRequest,

--- a/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.board.service;
 
 import static com.bbangle.bbangle.board.validator.BoardValidator.*;
 import static com.bbangle.bbangle.exception.BbangleErrorCode.BOARD_NOT_FOUND;
+import static com.bbangle.bbangle.exception.BbangleErrorCode.IMAGE_URL_NULL;
 
 import com.bbangle.bbangle.board.dto.BoardAndImageDto;
 import com.bbangle.bbangle.board.dto.BoardInfoDto;
@@ -115,10 +116,15 @@ public class BoardService {
 
         List<String> boardImageUrls = extractImageUrl(boardAndImageDtos);
 
+        if (Objects.isNull(boardDto.getProfile())) {
+            throw new BbangleException(IMAGE_URL_NULL);
+        }
+
         String boardProfileUrl = buildFullUrl(boardDto.getProfile());
 
         List<String> boardDetailUrls = boardDetailRepository.findByBoardId(boardId)
             .stream()
+            .filter(Objects::nonNull)
             .map(this::buildFullUrl)
             .toList();
 
@@ -136,6 +142,10 @@ public class BoardService {
     }
 
     private String buildFullUrl(String url) {
+        if (Objects.isNull(url)) {
+            throw new BbangleException(IMAGE_URL_NULL);
+        }
+
         if (url.contains(HTTP)) {
             return url;
         }

--- a/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
@@ -39,10 +39,9 @@ public class BoardService {
 
     private static final Boolean DEFAULT_BOARD = false;
     private static final Boolean BOARD_IN_FOLDER = true;
-
+    private static final String HTTP = "http";
     private final BoardRepository boardRepository;
     private final BoardDetailRepository boardDetailRepository;
-
     private final MemberRepository memberRepository;
     private final BoardStatisticService boardStatisticService;
     private final WishListFolderRepository folderRepository;
@@ -50,7 +49,8 @@ public class BoardService {
     @Qualifier("defaultRedisTemplate")
     private final RedisTemplate<String, Object> redisTemplate;
     @Value("${cdn.domain}")
-    private String cdnDomain;
+    private String cdn;
+
 
 
     @Transactional(readOnly = true)
@@ -115,6 +115,9 @@ public class BoardService {
             && wishListBoardRepository.existsByBoardIdAndMemberId(boardId, memberId);
 
         List<String> boardImageUrls = extractImageUrl(boardAndImageDtos);
+
+        String boardProfileUrl = buildFullUrl(boardDto.getProfile());
+
         List<String> boardDetailUrls = boardDetailRepository.findByBoardId(boardId)
             .stream()
             .map(this::buildFullUrl)
@@ -128,12 +131,17 @@ public class BoardService {
         return BoardImageDetailResponse.from(
             boardDto,
             isWished,
+            boardProfileUrl,
             boardImageUrls,
             boardDetailUrls);
     }
 
     private String buildFullUrl(String url) {
-        return cdnDomain + url;
+        if (url.contains(HTTP)) {
+            return url;
+        }
+
+        return cdn + url;
     }
 
     private void updateLikeStatus(

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -55,6 +55,7 @@ public enum BbangleErrorCode {
     REVIEW_MEMBER_NOT_PROPER(-35, "해당 리뷰를 작성한 사용자가 아닙니다.", BAD_REQUEST),
     EMPTY_PRODUCT_ITEM(-36, "게시판 아이디에 해당하는 상품이 없습니다", HttpStatus.INTERNAL_SERVER_ERROR),
     SURVEY_NOT_FOUND(-37, "수정하고자 하는 설문 정보가 존재하지 않습니다.", NOT_FOUND),
+    IMAGE_URL_NULL(-37, "Image URL이 Null입니다.", NOT_FOUND),
     GOOGLE_AUTHENTICATION_ERROR(-995, "구글 인증 토큰 발행 중 에러가 발생했습니다.",
         HttpStatus.INTERNAL_SERVER_ERROR),
     JSON_SERIALIZATION_ERROR(-996, "json 변환 중 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/test/java/com/bbangle/bbangle/board/service/BoardServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/service/BoardServiceTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 class BoardServiceTest extends AbstractIntegrationTest {
 
@@ -563,6 +564,8 @@ class BoardServiceTest extends AbstractIntegrationTest {
         final Long memberId = null;
         final String TEST_URL = "www.TESTURL.com";
         final Long NOT_EXSIST_ID = -1L;
+        @Value("${cdn.domain}")
+        private String cdn;
 
         @BeforeEach
         void init() {
@@ -594,8 +597,9 @@ class BoardServiceTest extends AbstractIntegrationTest {
                 .findFirst()
                 .get();
 
-            assertThat(boardDetailUrl).isEqualTo(TEST_URL);
-            assertThat(boardImageUrl).isEqualTo(TEST_URL);
+            String cdnWithFilePath = cdn + TEST_URL;
+            assertThat(boardDetailUrl).isEqualTo(cdnWithFilePath);
+            assertThat(boardImageUrl).isEqualTo(cdnWithFilePath);
         }
     }
 


### PR DESCRIPTION
## History
- 동석님께서 DB에 이미지 URL에 붙어있는 CDN 제거
- Board Profile에 CDN URL도 삭제됨
- 그것을 해결하기 위해 Product에 CDN 동적 생성 코드 추가

+ BoardImage에도 CDN 추가

아래 이미지 문제 해결하기 위해 개발 시작함
![image](https://github.com/user-attachments/assets/48970ee6-761a-4500-b019-3ebd7a319887)
![image](https://github.com/user-attachments/assets/89fa20d6-e06e-41fc-9029-5a284dbaf2dd)


## 🚀 Major Changes & Explanations
기존  = "profile": "product_board/4/9782392925/profile.png"
변경 = "profile": "https://d41zmgwrjn4bn.cloudfront.net/product_board/4/9782392925/profile.png",

## 📷 Test Image
![image](https://github.com/user-attachments/assets/46f9a71d-0110-44fb-9c54-3510e4cacd28)
![image](https://github.com/user-attachments/assets/045d0670-142c-4c8b-9387-8fe2fefe9766)
![image](https://github.com/user-attachments/assets/378689f4-2eed-445e-be28-db582a900ef9)

리뷰 업로드는 yml 설정이 잘못돼 나는 에러이고, 나머지 Review 에러는 FixtureMonkey로 인해 발생하는 에러입니다.
매번 돌릴 때 마다 합격 불합격이 나뉘더라구요

## 💡 ETC
이미지가 많아질 수록 이미지 관련 로직이 추가될 때마다 개발이 힘들어질텐데, 공통화 작업을 어떻게 진행할지 고민
