### PR TITLE
게시글 조회 성능 개선(heap 메모리 사용량 줄이기, 첫 조회에 대하여 캐싱 적용)

### DIFF
--- a/src/main/java/com/bbangle/bbangle/BbangleApplication.java
+++ b/src/main/java/com/bbangle/bbangle/BbangleApplication.java
@@ -7,7 +7,6 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
-@EnableCaching
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class BbangleApplication {

--- a/src/main/java/com/bbangle/bbangle/BbangleApplication.java
+++ b/src/main/java/com/bbangle/bbangle/BbangleApplication.java
@@ -3,9 +3,11 @@ package com.bbangle.bbangle;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
+@EnableCaching
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class BbangleApplication {

--- a/src/main/java/com/bbangle/bbangle/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/BoardResponseDto.java
@@ -6,26 +6,29 @@ import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.List;
 import java.util.Objects;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class BoardResponseDto {
 
-    private final Long boardId;
-    private final Long storeId;
-    private final String storeName;
-    private final String thumbnail;
-    private final String title;
-    private final int price;
+    private Long boardId;
+    private Long storeId;
+    private String storeName;
+    private String thumbnail;
+    private String title;
+    private int price;
     private Boolean isWished;
-    private final Boolean isBundled;
-    private final List<String> tags;
-    private final Double reviewRate;
-    private final Long reviewCount;
-    private final Boolean isBbangcketing;
-    private final Boolean isSoldOut;
-    private final Integer discountRate;
+    private Boolean isBundled;
+    private List<String> tags;
+    private Double reviewRate;
+    private Long reviewCount;
+    private Boolean isBbangcketing;
+    private Boolean isSoldOut;
+    private Integer discountRate;
 
     @Builder
     public BoardResponseDto(

--- a/src/main/java/com/bbangle/bbangle/board/repository/util/BoardPageGenerator.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/util/BoardPageGenerator.java
@@ -64,8 +64,13 @@ public class BoardPageGenerator {
 
         boardResponseDaoList = removeDuplicatesByBoardId(boardResponseDaoList);
 
-        return getBoardResponseDtos(boardResponseDaoList, isInFolder, isBundled, tagMapByBoardId,
+        List<BoardResponseDto> boardResponseDtos = getBoardResponseDtos(boardResponseDaoList,
+            isInFolder, isBundled, tagMapByBoardId,
             isSoldOut, isBbangcketing);
+
+        clearLinkedHashMap(tagMapByBoardId, isBundled, isSoldOut, isBbangcketing);
+
+        return boardResponseDtos;
     }
 
     private static Map<Long, Boolean> getIsBbangcketing(List<BoardResponseDao> boardResponseDaoList) {
@@ -224,6 +229,18 @@ public class BoardPageGenerator {
         if (condition) {
             tags.add(tag);
         }
+    }
+
+    private static void clearLinkedHashMap(
+        Map<Long, List<String>> tagMapByBoardId,
+        Map<Long, Boolean> isBundled,
+        Map<Long, Boolean> isSoldOut,
+        Map<Long, Boolean> isBbangcketing
+    ) {
+        tagMapByBoardId.clear();
+        isBundled.clear();
+        isSoldOut.clear();
+        isBbangcketing.clear();
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/util/BoardPageGenerator.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/util/BoardPageGenerator.java
@@ -204,9 +204,12 @@ public class BoardPageGenerator {
                 LinkedHashMap::new
             ));
 
-        return uniqueBoardMap.values()
+        List<BoardResponseDao> resultList = uniqueBoardMap.values()
             .stream()
             .toList();
+
+        uniqueBoardMap.clear();
+        return resultList;
     }
 
     private static List<String> extractTags(List<TagsDao> tagsDaoList) {

--- a/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/BoardService.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,7 +54,12 @@ public class BoardService {
     private String cdnDomain;
 
 
-    @Transactional(readOnly = true)
+    @Cacheable(
+        value = "recommendContents",
+        key = "'defaultRecommendCache'",
+        cacheManager = "contentCacheManager",
+        condition = "#filterRequest.glutenFreeTag == null && #filterRequest.highProteinTag == null && #filterRequest.sugarFreeTag == null && #filterRequest.veganTag == null && #filterRequest.ketogenicTag == null && #filterRequest.category == null && #filterRequest.minPrice == null && #filterRequest.maxPrice == null && #filterRequest.orderAvailableToday == null && #sort == T(com.bbangle.bbangle.board.sort.SortType).RECOMMEND && #cursorId == null && #memberId == null"
+    )
     public BoardCustomPage<List<BoardResponseDto>> getBoardList(
         FilterRequest filterRequest,
         SortType sort,
@@ -122,7 +128,8 @@ public class BoardService {
 
         boardStatisticService.updateViewCount(boardId);
         if (viewCountKey != null) {
-            redisTemplate.opsForValue().set(viewCountKey, "true");
+            redisTemplate.opsForValue()
+                .set(viewCountKey, "true");
         }
 
         return BoardImageDetailResponse.from(

--- a/src/main/java/com/bbangle/bbangle/boardstatistic/ranking/UpdateBoardStatistic.java
+++ b/src/main/java/com/bbangle/bbangle/boardstatistic/ranking/UpdateBoardStatistic.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -26,6 +27,7 @@ public class UpdateBoardStatistic {
     private final BoardStatisticService boardStatisticService;
 
     @Scheduled(cron = "0 0 * * * *")
+    @CacheEvict(value = "recommendContents", key = "'defaultRecommendCache'", cacheManager = "contentCacheManager")
     public void updateStatistic() {
         log.info("start update ranking");
 

--- a/src/main/java/com/bbangle/bbangle/config/RedisCacheConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/RedisCacheConfig.java
@@ -1,0 +1,29 @@
+package com.bbangle.bbangle.config;
+
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager contentCacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+            .entryTtl(Duration.ofMinutes(30));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/page/BoardCustomPage.java
+++ b/src/main/java/com/bbangle/bbangle/page/BoardCustomPage.java
@@ -4,19 +4,18 @@ import com.bbangle.bbangle.board.dto.BoardResponseDto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Collections;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class BoardCustomPage<T> extends CustomPage<T> {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long boardCount;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long storeCount;
-
-    public BoardCustomPage(T content, Long requestCursor, Double cursorScore, Boolean hasNext) {
-        super(content, requestCursor, hasNext);
-    }
 
     public BoardCustomPage(
         T content,

--- a/src/main/java/com/bbangle/bbangle/page/CustomPage.java
+++ b/src/main/java/com/bbangle/bbangle/page/CustomPage.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 public class CustomPage<T> {
 
     private T content;
-    private final Long nextCursor;
-    private final Boolean hasNext;
+    private Long nextCursor;
+    private Boolean hasNext;
 
 }


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History
- 과거 힙메모리가 터지는 이슈가 있었음
- 성능 테스트 중 가장 빈번하게 호출되는 요청에 대해 (/api/v1/boards) 성능 확인 후 캐싱 적용 필요 확인


<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations

### 1. LinkedHashMap heap 메모리 차지하는 문제 해결
- 게시글 조회 시 추출한 데이터를 정재하기 위해 LinkedHashMap이 다수 사용되는 것을 확인
- LinkedHashMap은 서로 참조가 강하게 묶여있어 GC로 잘 사라지지 않는 객체이다.
- 사용이 끝난 LinkedHashMap에 대하여 map.clear()메서드를 사용하여 그 즉시 객체를 비워줌
<img width="504" alt="스크린샷 2024-10-12 오후 2 57 45" src="https://github.com/user-attachments/assets/ee2a90f7-6e77-4969-ae60-142f4a950e19">

- 부하테스트 후 남아있던 LinkedHashmap 객체가 사라짐을 확인 가능

before(약 10분간 LinkedHashMap 객체가 Heap 영역에 남아있음을 확인)
<img width="1904" alt="스크린샷 2024-10-11 오전 10 58 35" src="https://github.com/user-attachments/assets/9cd6b528-be1d-4090-9e00-6a1eadcf52da">
<img width="1904" alt="스크린샷 2024-10-11 오후 1 23 22" src="https://github.com/user-attachments/assets/f0478cbf-9261-4931-9068-1ce495ee6089">

After(부하테스트 요청 후 바로 객체가 사라짐을 확인)
<img width="1904" alt="스크린샷 2024-10-11 오후 1 22 01" src="https://github.com/user-attachments/assets/ae9e858d-c844-4ddb-8aef-4b1558c1d9b8">
<img width="1904" alt="스크린샷 2024-10-11 오후 1 23 03" src="https://github.com/user-attachments/assets/ac21aa6a-7d81-4c20-9c82-8bdbabb0a235">


### 2. 매번 호출되는 요청에 대해 캐싱 도입
- api/v1/boards 는 페이지에 접속하면 나타나는 요청으로 가장 빈번히 호출되는 요청(비로그인 추천순 게시글 보내기 요청)
- 트래픽이 몰릴 시 가장 많이 호출되는 api다

캐싱 적용 전
<img width="1545" alt="스크린샷 2024-10-12 오후 3 26 38" src="https://github.com/user-attachments/assets/a00f3a9e-814d-49b8-a30a-2020440cb953">
<img width="1545" alt="스크린샷 2024-10-12 오후 3 26 42" src="https://github.com/user-attachments/assets/9a59fb83-10fa-48fa-bd03-cf81c031aad2">


캐싱 적용 후
<img width="1545" alt="스크린샷 2024-10-12 오후 5 07 02" src="https://github.com/user-attachments/assets/6598a269-96f7-4b79-9705-72d8f46e0742">
<img width="1545" alt="스크린샷 2024-10-12 오후 5 07 06" src="https://github.com/user-attachments/assets/51f7544c-d068-4922-8d5f-8a8621b52dda">

성능 약 10배 이상 향상 확인

- 1시간 마다 랭킹 업데이트 시 정렬 순서가 같이 업데이트 되게 설정
<img width="962" alt="스크린샷 2024-10-12 오후 5 25 41" src="https://github.com/user-attachments/assets/7608e06b-e3ed-4d0e-8bdf-a73f3e98f973">
- 업데이트가 시작될 때 키가 사라지고 다시 같은 요청을 날리면 캐시에 들어가는 걸 확인
<img width="347" alt="스크린샷 2024-10-12 오후 5 25 25" src="https://github.com/user-attachments/assets/5f2c23ee-5ff4-4f4c-9fe1-e74ad507e3cb">

* 업데이트가 안되는 경우를 위해 캐싱 시간을 30분으로 설정(랭킹 업데이트 시 CacheEvict가 모종의 이유로 제대로 작동 안할 가능성)

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
