### PR TITLE
profile 업데이트 메서드에서 전화번호 대신 성별 노출

### DIFF
--- a/src/main/java/com/bbangle/bbangle/member/controller/ProfileController.java
+++ b/src/main/java/com/bbangle/bbangle/member/controller/ProfileController.java
@@ -9,6 +9,7 @@ import com.bbangle.bbangle.member.service.ProfileService;
 import com.bbangle.bbangle.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.MediaType;
 import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -58,7 +59,7 @@ public class ProfileController {
         return responseService.getSingleResult(new MessageDto(AVAILABLE_NICKNAME, true));
     }
 
-    @PutMapping
+    @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public CommonResult update(
         @RequestPart(required = false)
         InfoUpdateRequest infoUpdateRequest,

--- a/src/main/java/com/bbangle/bbangle/member/domain/Member.java
+++ b/src/main/java/com/bbangle/bbangle/member/domain/Member.java
@@ -151,9 +151,8 @@ public class Member extends BaseEntity implements UserDetails {
             this.birth = request.birthDate();
         }
 
-        if (request.phoneNumber() != null) {
-            UserValidator.validatePhoneNumber(request.phoneNumber());
-            this.phone = request.phoneNumber();
+        if (request.sex() != null) {
+            this.sex = request.sex();
         }
 
         if (request.nickname() != null) {

--- a/src/main/java/com/bbangle/bbangle/member/dto/InfoUpdateRequest.java
+++ b/src/main/java/com/bbangle/bbangle/member/dto/InfoUpdateRequest.java
@@ -1,8 +1,10 @@
 package com.bbangle.bbangle.member.dto;
 
+import com.bbangle.bbangle.member.domain.Sex;
+
 public record InfoUpdateRequest(
     String nickname,
-    String phoneNumber,
+    Sex sex,
     String birthDate
 ) {
 


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History
- 프론트 요청으로 인한 업데이트 진행
- 전화번호 -> 성별로 프로필 업데이트 변경
<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations
- 내부 Dto, update 로직을 전화번호에서 성별 변경으로 바꿈
- 스웨거에 MultipartFile과 RequestDto 구분될 수 있게 컨트롤러 옵션 변경
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image
정상 작동 확인(스웨거)
![스크린샷 2024-10-14 오후 5 54 44](https://github.com/user-attachments/assets/95c623d6-2fad-429e-be78-90c314fb8760)
![스크린샷 2024-10-14 오후 5 54 48](https://github.com/user-attachments/assets/e9f411c8-c827-4564-aad2-e99ab2ac3a74)


<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
