### PR TITLE
공통 커서 페이지 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/repository/util/BoardPageGenerator.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/util/BoardPageGenerator.java
@@ -22,12 +22,27 @@ import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+/**
+ *
+ */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class BoardPageGenerator {
 
     private static final Long NO_NEXT_CURSOR = -1L;
     private static final Long HAS_NEXT_PAGE_SIZE = BOARD_PAGE_SIZE + 1L;
 
+    /**
+     *
+     * 책임:
+     *          1. list가 비었다면 빈 페이지를 반환함     -> 공통 CustomPage에서 커버가능
+     *          2. Dao -> DTO 변환
+     *          3. 커서 조절 및 DTO리스트 하나 삭제       -> 공통 CustomPage에서 커버가능
+     *
+     * 거슬리는 점:
+     *              1. 플래그를 전달받음
+     *              2. 함수가 20줄을 넘는다(아주 사소)
+     *              3. 나머지는 쿼리로 한 번에 받지 않았기에 함수가 복잡하다(중요)
+     */
     public static BoardCustomPage<List<BoardResponseDto>> getBoardPage(
         List<BoardResponseDao> boardDaos, Boolean isInFolder
     ) {

--- a/src/main/java/com/bbangle/bbangle/page/CursorPageResponse.java
+++ b/src/main/java/com/bbangle/bbangle/page/CursorPageResponse.java
@@ -1,0 +1,32 @@
+package com.bbangle.bbangle.page;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.function.ToLongFunction;
+
+@Getter
+@RequiredArgsConstructor
+public class CursorPageResponse<T> {
+
+    private final List<T> data;
+    private final Long nextCursor;
+    private final Boolean hasNext;
+
+    /**
+     * 요청 성공 시, 응답 dto 객체를 파라미터로 받음
+     */
+    public static <T> CursorPageResponse<T> of(List<T> data, int pageSize, ToLongFunction<T> idExtractor) {
+        boolean hasNext = data.size() > pageSize;
+        Long nextCursor = -1L;
+
+        if (hasNext) {
+            T lastReponse = data.get(pageSize - 1);
+            nextCursor = idExtractor.applyAsLong(lastReponse);
+            data = data.subList(0, pageSize);
+        }
+
+        return new CursorPageResponse<>(data, nextCursor, hasNext);
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/page/CursorPageResponseTest.java
+++ b/src/test/java/com/bbangle/bbangle/page/CursorPageResponseTest.java
@@ -1,0 +1,111 @@
+package com.bbangle.bbangle.page;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class CursorPageResponseTest {
+    private static final Long NO_NEXT_CURSOR = -1L;
+
+    @Test
+    @DisplayName("데이터 사이즈가 페이지 사이즈보다 클때 성공한다")
+    void testIdExtraction_WithMoreDataThanPageSize() {
+        // Given
+        List<TestItem> items = Arrays.asList(
+                new TestItem(1L),
+                new TestItem(2L),
+                new TestItem(3L),
+                new TestItem(4L) // Extra item
+        );
+        int pageSize = 3;
+
+        // When
+        CursorPageResponse<TestItem> response = CursorPageResponse.of(
+                items, pageSize, TestItem::getId
+        );
+
+        // Then
+        assertEquals(3, response.getData().size());
+        assertEquals(3L, response.getNextCursor());
+        assertTrue(response.getHasNext());
+    }
+
+    @Test
+    @DisplayName("데이터 사이즈가 페이지 사이즈보다 같을 때 hasNext는 false이다")
+    void testIdExtraction_WithExactPageSize() {
+        // Given
+        List<TestItem> items = Arrays.asList(
+                new TestItem(1L),
+                new TestItem(2L),
+                new TestItem(3L)
+        );
+        int pageSize = 3;
+
+        // When
+        CursorPageResponse<TestItem> response = CursorPageResponse.of(
+                items, pageSize, TestItem::getId
+        );
+
+        // Then
+        assertEquals(3, response.getData().size());
+        assertEquals(NO_NEXT_CURSOR, response.getNextCursor());
+        assertFalse(response.getHasNext());
+    }
+
+    @Test
+    @DisplayName("데이터 사이즈가 페이지 사이즈보다 작을 때 hasNext는 false이다")
+    void testIdExtraction_WithLessDataThanPageSize() {
+        // Given
+        List<TestItem> items = Arrays.asList(
+                new TestItem(1L),
+                new TestItem(2L)
+        );
+        int pageSize = 3;
+
+        // When
+        CursorPageResponse<TestItem> response = CursorPageResponse.of(
+                items, pageSize, TestItem::getId
+        );
+
+        // Then
+        assertEquals(2, response.getData().size());
+        assertEquals(NO_NEXT_CURSOR, response.getNextCursor());
+        assertFalse(response.getHasNext());
+    }
+
+    @Test
+    @DisplayName("데이터 사이즈가 비었을 때 hasNext는 false이다")
+    void testIdExtraction_WithEmptyList() {
+        // Given
+        List<TestItem> items = List.of();
+        int pageSize = 3;
+
+        // When
+        CursorPageResponse<TestItem> response = CursorPageResponse.of(
+                items, pageSize, TestItem::getId
+        );
+
+        // Then
+        assertTrue(response.getData().isEmpty());
+        assertEquals(NO_NEXT_CURSOR, response.getNextCursor());
+        assertFalse(response.getHasNext());
+    }
+
+    // 테스트를 위한 내부 클래스
+    private static class TestItem {
+        private final Long id;
+
+        TestItem(Long id) {
+            this.id = id;
+        }
+
+        Long getId() {
+            return id;
+        }
+    }
+}


### PR DESCRIPTION

## History

- 공통 커서 페이지를 구현


## 📷 Test Image

![image](https://github.com/user-attachments/assets/9008122b-156e-426e-83e1-5395d30e84aa)

## 💡 ETC

service 코드에서  아래와 같이 호출하면 됩니다

`CursorPageResponse.of(memberBookResponses, PAGE_SIZE, MemberBookResponse::getMemberBookId)`