### PR TITLE
위시리스트 폴더 이름 변경 시 '기본 폴더'로 변경하지 못하게 로직 수정, 랜덤 API 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/controller/RandomBoardController.java
+++ b/src/main/java/com/bbangle/bbangle/board/controller/RandomBoardController.java
@@ -1,0 +1,45 @@
+package com.bbangle.bbangle.board.controller;
+
+import com.bbangle.bbangle.board.dto.BoardResponseDto;
+import com.bbangle.bbangle.board.dto.FilterRequest;
+import com.bbangle.bbangle.board.service.RandomBoardService;
+import com.bbangle.bbangle.board.sort.SortType;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.page.BoardCustomPage;
+import com.bbangle.bbangle.redis.RedisService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@Tag(name = "Boards-Random", description = "실험에서 사용하기 위한 random data set을 내려주는 Controller")
+@RequiredArgsConstructor
+public class RandomBoardController {
+
+    private final RandomBoardService randomBoardService;
+    private final ResponseService responseService;
+    private final RedisService redisService;
+
+    @GetMapping("/boards-random")
+    public CommonResult getList(
+        @RequestParam(required = false, value = "cursorId")
+        Long cursorId,
+        @AuthenticationPrincipal
+        Long memberId
+    ) {
+        Integer setNumber = redisService.getSetNumber(memberId);
+        BoardCustomPage<List<BoardResponseDto>> boardResponseList = randomBoardService.getRandomBoardList(
+            cursorId,
+            memberId,
+            setNumber);
+        return responseService.getSingleResult(boardResponseList);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/board/domain/RandomBoard.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/RandomBoard.java
@@ -1,0 +1,44 @@
+package com.bbangle.bbangle.board.domain;
+
+import com.bbangle.bbangle.common.domain.BaseEntity;
+import com.bbangle.bbangle.store.domain.Store;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "random_board", indexes = @Index(name = "set_number_index", columnList = "set_number", unique = true))
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RandomBoard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "set_number")
+    private Integer setNumber;
+
+    @Column(name = "random_board_id")
+    private Long randomBoardId;
+
+}

--- a/src/main/java/com/bbangle/bbangle/board/repository/BoardQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/BoardQueryDSLRepository.java
@@ -39,5 +39,7 @@ public interface BoardQueryDSLRepository {
 
     Long getBoardCount(FilterRequest filterRequest);
 
+    List<BoardResponseDao> getRandomboardList(Long cursorId, Long memberId, Integer setNumber);
+
 }
 

--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/RandomBoardRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/RandomBoardRepository.java
@@ -1,0 +1,8 @@
+package com.bbangle.bbangle.board.repository.basic;
+
+import com.bbangle.bbangle.board.domain.RandomBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RandomBoardRepository extends JpaRepository<RandomBoard, Long> {
+
+}

--- a/src/main/java/com/bbangle/bbangle/board/service/RandomBoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/RandomBoardService.java
@@ -1,0 +1,29 @@
+package com.bbangle.bbangle.board.service;
+
+import com.bbangle.bbangle.board.dao.BoardResponseDao;
+import com.bbangle.bbangle.board.dto.BoardResponseDto;
+import com.bbangle.bbangle.board.repository.BoardRepository;
+import com.bbangle.bbangle.board.repository.util.BoardPageGenerator;
+import com.bbangle.bbangle.page.BoardCustomPage;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RandomBoardService {
+
+    private final BoardRepository boardRepository;
+
+    public BoardCustomPage<List<BoardResponseDto>> getRandomBoardList(
+        Long cursorId,
+        Long memberId,
+        Integer setNumber
+    ) {
+        List<BoardResponseDao> boardResponseDaoList = boardRepository.getRandomboardList(cursorId, memberId, setNumber);
+
+        return BoardPageGenerator.getBoardPage(boardResponseDaoList, false);
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/config/RedisConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/RedisConfig.java
@@ -46,4 +46,14 @@ public class RedisConfig {
         return redisTemplate;
     }
 
+    @Bean(name = "randomRedisTemplate")
+    public RedisTemplate<String, Integer> randomRedisTemplate() {
+        RedisTemplate<String, Integer> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+
 }

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -56,6 +56,7 @@ public enum BbangleErrorCode {
     EMPTY_PRODUCT_ITEM(-36, "게시판 아이디에 해당하는 상품이 없습니다", HttpStatus.INTERNAL_SERVER_ERROR),
     SURVEY_NOT_FOUND(-37, "수정하고자 하는 설문 정보가 존재하지 않습니다.", NOT_FOUND),
     IMAGE_URL_NULL(-37, "Image URL이 Null입니다.", NOT_FOUND),
+    DEFAULT_FOLDER_NAME_USED(-38, "폴더 이름을 기본 폴더로 수정할 수 없습니다.", BAD_REQUEST),
     GOOGLE_AUTHENTICATION_ERROR(-995, "구글 인증 토큰 발행 중 에러가 발생했습니다.",
         HttpStatus.INTERNAL_SERVER_ERROR),
     JSON_SERIALIZATION_ERROR(-996, "json 변환 중 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/bbangle/bbangle/redis/RedisService.java
+++ b/src/main/java/com/bbangle/bbangle/redis/RedisService.java
@@ -1,0 +1,31 @@
+package com.bbangle.bbangle.redis;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private static final String RANDOM_SET_PREFIX = "RANDOM:";
+    private final Random random = new Random();
+
+    @Qualifier("randomRedisTemplate")
+    private final RedisTemplate<String, Integer> redisTemplate;
+
+    public Integer getSetNumber(Long memberId) {
+        if(redisTemplate.hasKey(RANDOM_SET_PREFIX + memberId)){
+            return redisTemplate.opsForValue().get(RANDOM_SET_PREFIX + memberId);
+        }
+
+        int randomNumberSet = random.nextInt(1000) + 1;
+        redisTemplate.opsForValue().set(RANDOM_SET_PREFIX + memberId, randomNumberSet, 1, TimeUnit.DAYS);
+
+        return randomNumberSet;
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/wishlist/validator/WishListFolderValidator.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/validator/WishListFolderValidator.java
@@ -7,9 +7,15 @@ import java.util.Objects;
 
 public class WishListFolderValidator {
 
+    private static final String DEFAULT_FOLDER_NAME = "기본 폴더";
+
     public static void validateTitle(String title) {
         if (Objects.isNull(title) || title.isBlank() || title.length() > 12) {
             throw new BbangleException(BbangleErrorCode.INVALID_FOLDER_TITLE);
+        }
+
+        if(title.equals(DEFAULT_FOLDER_NAME)){
+            throw new BbangleException(BbangleErrorCode.DEFAULT_FOLDER_NAME_USED);
         }
     }
 


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History
- 폴더 이름 수정 시 기본 폴더를 수정 못하게는 막아놨지만 다른 폴더 이름을 기본 폴더로 변경이 가능한 상황 발생
<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations
- 기본 폴더 라는 이름을 사용하지 못하게 validation 추가
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
- 랜덤 게시글 내려주는 API 추가
![스크린샷 2024-10-17 오후 9 53 18](https://github.com/user-attachments/assets/0eb7e150-1a2a-417f-a4fb-d8c0b50c56b9)

## 📷 Test Image
<img width="947" alt="스크린샷 2024-10-18 오전 10 48 43" src="https://github.com/user-attachments/assets/09295168-1919-4ae5-99e2-458f93d65d98">

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
