### PR TITLE
리뷰 좋아요를 누를 시 이미 좋아요를 눌렀는지 확인하는 로직 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -57,6 +57,7 @@ public enum BbangleErrorCode {
     SURVEY_NOT_FOUND(-37, "수정하고자 하는 설문 정보가 존재하지 않습니다.", NOT_FOUND),
     IMAGE_URL_NULL(-37, "Image URL이 Null입니다.", NOT_FOUND),
     DEFAULT_FOLDER_NAME_USED(-38, "폴더 이름을 기본 폴더로 수정할 수 없습니다.", BAD_REQUEST),
+    REVIEW_ALREADY_LIKED(-39, "이미 도움돼요를 누른 게시글입니다.", BAD_REQUEST),
     GOOGLE_AUTHENTICATION_ERROR(-995, "구글 인증 토큰 발행 중 에러가 발생했습니다.",
         HttpStatus.INTERNAL_SERVER_ERROR),
     JSON_SERIALIZATION_ERROR(-996, "json 변환 중 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/bbangle/bbangle/review/controller/ReviewController.java
+++ b/src/main/java/com/bbangle/bbangle/review/controller/ReviewController.java
@@ -96,7 +96,7 @@ public class ReviewController {
     }
 
     @Operation(summary = "도움되요 추가")
-    @GetMapping(value = "/like/{reviewId}")
+    @PostMapping(value = "/like/{reviewId}")
     public CommonResult insertLike(
             @PathVariable("reviewId")
             Long reviewId,

--- a/src/main/java/com/bbangle/bbangle/review/service/ReviewService.java
+++ b/src/main/java/com/bbangle/bbangle/review/service/ReviewService.java
@@ -117,11 +117,13 @@ public class ReviewService {
 
     @Transactional
     public void insertLike(Long reviewId, Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BbangleException(BbangleErrorCode.NOTFOUND_MEMBER));
+        reviewLikeRepository.findByMemberIdAndReviewId(memberId, reviewId)
+                .ifPresent(reviewLike -> {
+                    throw new BbangleException(BbangleErrorCode.REVIEW_ALREADY_LIKED);
+                });
 
         reviewLikeRepository.save(ReviewLike.builder()
-                .memberId(member.getId())
+                .memberId(memberId)
                 .reviewId(reviewId)
                 .build());
     }

--- a/src/main/java/com/bbangle/bbangle/wishlist/validator/WishListFolderValidator.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/validator/WishListFolderValidator.java
@@ -14,9 +14,9 @@ public class WishListFolderValidator {
             throw new BbangleException(BbangleErrorCode.INVALID_FOLDER_TITLE);
         }
 
-        if(title.equals(DEFAULT_FOLDER_NAME)){
-            throw new BbangleException(BbangleErrorCode.DEFAULT_FOLDER_NAME_USED);
-        }
+//        if(title.equals(DEFAULT_FOLDER_NAME)){
+//            throw new BbangleException(BbangleErrorCode.DEFAULT_FOLDER_NAME_USED);
+//        }
     }
 
     public static void validateMember(Member member) {


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History
- 도움돼요를 누를 때 이미 도움돼요를 누른 내용인지 확인하지 못해 예외가 발생
- DB에 한 리뷰에 대해 한 사람이 여러 번 도움돼요를 누른 것으로 기록이 됨
- 로직 상 한 사람 한 리뷰에 대하여 하나의 도움돼요만을 누를 수 있어야 함
- 여러 개의 도움돼요를 눌러 쿼리 상 도움 돼요 하나만 조회되어야 하는 로직에 여러 개가 검색되어 쿼리 Exception이 발생
![스크린샷 2024-10-21 오후 4 03 37](https://github.com/user-attachments/assets/108003de-8672-41d5-9a7f-9422a0739d6a)
<img width="566" alt="스크린샷 2024-10-21 오후 4 26 59" src="https://github.com/user-attachments/assets/88d78308-6a9d-422d-a9f0-b38b4f147f11">


<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations
- 리뷰 도움돼요를 누를 때 이미 도움돼요를 누른 리뷰인지 확인하는 로직 추가
``` java
    @Transactional
    public void insertLike(Long reviewId, Long memberId) {
        reviewLikeRepository.findByMemberIdAndReviewId(memberId, reviewId)
                .ifPresent(reviewLike -> {
                    throw new BbangleException(BbangleErrorCode.REVIEW_ALREADY_LIKED);
                });

        reviewLikeRepository.save(ReviewLike.builder()
                .memberId(memberId)
                .reviewId(reviewId)
                .build());
    }
```

- 추가로 리뷰 도움돼요를 누르는 API가 GET 요청으로 되어 있어 POST 요청으로 변경
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->


## 📷 Test Image
- 도움돼요를 두 번 누를 시 예외처리가 되는 것 확인
<img width="847" alt="스크린샷 2024-10-21 오후 4 21 48" src="https://github.com/user-attachments/assets/8990b3bc-695f-486e-93b8-df27b717e53f">


<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
