### PR TITLE
🚀 유사도 측정한 추천 상품 조회 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/controller/BoardDetailController.java
+++ b/src/main/java/com/bbangle/bbangle/board/controller/BoardDetailController.java
@@ -1,0 +1,38 @@
+package com.bbangle.bbangle.board.controller;
+
+import com.bbangle.bbangle.board.dto.SimilarityBoardResponse;
+import com.bbangle.bbangle.board.service.BoardDetailService;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/boards")
+@Tag(name = "BoardDetail", description = "게시판 상세정보 API")
+@RequiredArgsConstructor
+public class BoardDetailController {
+
+    private final BoardDetailService boardDetailService;
+    private final ResponseService responseService;
+
+    @GetMapping("/{boardId}/similar_board")
+    public CommonResult getCount(
+        @PathVariable(value = "boardId")
+        Long boardId,
+        @AuthenticationPrincipal
+        Long memberId
+    ) {
+        List<SimilarityBoardResponse> similarityBoardResponses = boardDetailService.getSimilarityBoardResponses(
+            memberId, boardId);
+        return responseService.getSingleResult(similarityBoardResponses);
+    }
+
+}
+

--- a/src/main/java/com/bbangle/bbangle/board/domain/RecommendationSimilarBoard.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/RecommendationSimilarBoard.java
@@ -28,14 +28,18 @@ import lombok.ToString;
 public class RecommendationSimilarBoard extends CreatedAtBaseEntity {
 
     @Id
+    @Column(name = "query_item")
     private Long queryItem;
 
+    @Id
+    @Column(name = "rank")
+    private Integer rank;
+
+    @Column(name = "recommendation_item")
     private Long recommendationItem;
 
+    @Column(name = "score")
     private BigDecimal score;
-
-    @Id
-    private Integer rank;
 
     @Column(length = 30, columnDefinition = "varchar")
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/com/bbangle/bbangle/board/domain/RecommendationSimilarBoard.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/RecommendationSimilarBoard.java
@@ -1,0 +1,49 @@
+package com.bbangle.bbangle.board.domain;
+
+import com.bbangle.bbangle.board.domain.composityKey.RecommendationSimilarBoardComposityKey;
+import com.bbangle.bbangle.common.domain.CreatedAtBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Table(name = "recommendation_similar_board")
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@IdClass(RecommendationSimilarBoardComposityKey.class)
+@ToString
+public class RecommendationSimilarBoard extends CreatedAtBaseEntity {
+
+    @Id
+    @Column(name = "query_item")
+    Long queryItem;
+
+    @Column(name = "recommendation_item")
+    Long recommendationItem;
+
+    BigDecimal score;
+
+    @Id
+    Integer rank;
+
+    @Column(name = "recommendation_theme")
+    @Enumerated(EnumType.STRING)
+    SimilarityTypeEnum recommendationTheme;
+
+    @Column(name = "model_version")
+    @Enumerated(EnumType.STRING)
+    SimilarityModelVerEnum modelVersion;
+}

--- a/src/main/java/com/bbangle/bbangle/board/domain/RecommendationSimilarBoard.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/RecommendationSimilarBoard.java
@@ -28,22 +28,20 @@ import lombok.ToString;
 public class RecommendationSimilarBoard extends CreatedAtBaseEntity {
 
     @Id
-    @Column(name = "query_item")
-    Long queryItem;
+    private Long queryItem;
 
-    @Column(name = "recommendation_item")
-    Long recommendationItem;
+    private Long recommendationItem;
 
-    BigDecimal score;
+    private BigDecimal score;
 
     @Id
-    Integer rank;
+    private Integer rank;
 
-    @Column(name = "recommendation_theme")
-    @Enumerated(EnumType.STRING)
-    SimilarityTypeEnum recommendationTheme;
+    @Column(length = 30, columnDefinition = "varchar")
+    @Enumerated(value = EnumType.STRING)
+    private SimilarityTypeEnum recommendationTheme;
 
-    @Column(name = "model_version")
+    @Column(length = 30, columnDefinition = "varchar")
     @Enumerated(EnumType.STRING)
-    SimilarityModelVerEnum modelVersion;
+    private SimilarityModelVerEnum modelVersion;
 }

--- a/src/main/java/com/bbangle/bbangle/board/domain/RecommendationSimilarBoard.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/RecommendationSimilarBoard.java
@@ -41,11 +41,11 @@ public class RecommendationSimilarBoard extends CreatedAtBaseEntity {
     @Column(name = "score")
     private BigDecimal score;
 
-    @Column(length = 30, columnDefinition = "varchar")
+    @Column(name = "recommendation_theme", length = 30, columnDefinition = "varchar")
     @Enumerated(value = EnumType.STRING)
     private SimilarityTypeEnum recommendationTheme;
 
-    @Column(length = 30, columnDefinition = "varchar")
+    @Column(name = "model_version", length = 30, columnDefinition = "varchar")
     @Enumerated(EnumType.STRING)
     private SimilarityModelVerEnum modelVersion;
 }

--- a/src/main/java/com/bbangle/bbangle/board/domain/SimilarityModelVerEnum.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/SimilarityModelVerEnum.java
@@ -1,0 +1,6 @@
+package com.bbangle.bbangle.board.domain;
+
+public enum SimilarityModelVerEnum {
+    DEFAULT,
+    V1
+}

--- a/src/main/java/com/bbangle/bbangle/board/domain/SimilarityTypeEnum.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/SimilarityTypeEnum.java
@@ -1,0 +1,6 @@
+package com.bbangle.bbangle.board.domain;
+
+public enum SimilarityTypeEnum {
+    DEFAULT,
+    SIMILARITY
+}

--- a/src/main/java/com/bbangle/bbangle/board/domain/composityKey/RecommendationSimilarBoardComposityKey.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/composityKey/RecommendationSimilarBoardComposityKey.java
@@ -1,0 +1,36 @@
+package com.bbangle.bbangle.board.domain.composityKey;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class RecommendationSimilarBoardComposityKey implements Serializable {
+
+    private Long queryItem;
+    private Integer rank;
+
+    public RecommendationSimilarBoardComposityKey() {
+    }
+
+    public RecommendationSimilarBoardComposityKey(Long queryItem, Integer rank) {
+        this.queryItem = queryItem;
+        this.rank = rank;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RecommendationSimilarBoardComposityKey that = (RecommendationSimilarBoardComposityKey) o;
+        return Objects.equals(queryItem, that.queryItem) &&
+            Objects.equals(rank, that.rank);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(queryItem, rank);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/board/dto/BoardInfo.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/BoardInfo.java
@@ -1,0 +1,61 @@
+package com.bbangle.bbangle.board.dto;
+
+import com.bbangle.bbangle.board.dao.TagsDao;
+import com.bbangle.bbangle.board.domain.Category;
+import com.bbangle.bbangle.board.domain.SimilarityTypeEnum;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.Getter;
+
+@Getter
+public class BoardInfo {
+    private Long boardId;
+    private Long storeId;
+    private String thumbnail;
+    private String storeName;
+    private String title;
+    private Integer discountRate;
+    private Integer price;
+    private BigDecimal reviewRate;
+    private Long reviewCount;
+    private Boolean isWished;
+    private SimilarityTypeEnum similarityType;
+
+    private List<TagsDao> tags;
+    private Set<Category> categories;
+    private Set<Boolean> isSoldOut;
+
+    public BoardInfo(SimilarityBoardDto dto) {
+        this.boardId = dto.getBoardId();
+        this.storeId = dto.getStoreId();
+        this.thumbnail = dto.getThumbnail();
+        this.storeName = dto.getStoreName();
+        this.title = dto.getTitle();
+        this.discountRate = dto.getDiscountRate();
+        this.price = dto.getPrice();
+        this.reviewRate = dto.getReviewRate();
+        this.reviewCount = dto.getReviewCount();
+        this.isWished = dto.getIsWished();
+        this.similarityType = dto.getSimilarityType();
+
+        this.tags = new ArrayList<>();
+        this.categories = new HashSet<>();
+        this.isSoldOut = new HashSet<>();
+    }
+
+    public void addTag(TagsDao tag) {
+        this.tags.add(tag);
+    }
+
+    public void addCategory(Category category) {
+        this.categories.add(category);
+    }
+
+    public void addIsSoldOut(Boolean isSoldOut) {
+        this.isSoldOut.add(isSoldOut);
+    }
+}
+

--- a/src/main/java/com/bbangle/bbangle/board/dto/SimilarityBoardDto.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/SimilarityBoardDto.java
@@ -1,0 +1,70 @@
+package com.bbangle.bbangle.board.dto;
+
+import com.bbangle.bbangle.board.dao.TagsDao;
+import com.bbangle.bbangle.board.domain.Category;
+import com.bbangle.bbangle.board.domain.SimilarityTypeEnum;
+import com.querydsl.core.annotations.QueryProjection;
+import java.math.BigDecimal;
+import lombok.Getter;
+
+@Getter
+public class SimilarityBoardDto {
+
+    Long boardId;
+    Long storeId;
+    String thumbnail;
+    String storeName;
+    String title;
+    Integer discountRate;
+    Integer price;
+    BigDecimal reviewRate;
+    Long reviewCount;
+    TagsDao tagsDao;
+    Boolean isSoldOut;
+    Category category;
+    Boolean isWished;
+    SimilarityTypeEnum similarityType;
+
+    @QueryProjection
+    public SimilarityBoardDto(
+        Long boardId,
+        Long storeId,
+        String thumbnail,
+        String storeName,
+        String title,
+        Integer discountRate,
+        Integer price,
+        BigDecimal reviewRate,
+        Long reviewCount,
+        Boolean glutenFreeTag,
+        Boolean highProteinTag,
+        Boolean sugarFreeTag,
+        Boolean veganTag,
+        Boolean ketogenicTag,
+        Boolean isSoldOut,
+        Category category,
+        SimilarityTypeEnum similarityType,
+        Boolean isWished
+    ) {
+        this.boardId = boardId;
+        this.storeId = storeId;
+        this.thumbnail = thumbnail;
+        this.storeName = storeName;
+        this.title = title;
+        this.discountRate = discountRate;
+        this.price = price;
+        this.reviewRate = reviewRate;
+        this.reviewCount = reviewCount;
+        this.isSoldOut = isSoldOut;
+        this.category = category;
+        this.similarityType = similarityType;
+        this.isWished = isWished;
+        this.tagsDao = TagsDao.builder()
+            .glutenFreeTag(glutenFreeTag)
+            .highProteinTag(highProteinTag)
+            .sugarFreeTag(sugarFreeTag)
+            .veganTag(veganTag)
+            .ketogenicTag(ketogenicTag)
+            .build();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/board/dto/SimilarityBoardResponse.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/SimilarityBoardResponse.java
@@ -1,0 +1,27 @@
+package com.bbangle.bbangle.board.dto;
+
+import com.bbangle.bbangle.board.domain.SimilarityTypeEnum;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SimilarityBoardResponse {
+
+    Long boardId;
+    Long storeId;
+    String thumbnail;
+    String storeName;
+    String title;
+    Integer discountRate;
+    Integer price;
+    BigDecimal reviewRate;
+    Long reviewCount;
+    List<String> tags;
+    Boolean isWished;
+    Boolean isBundled;
+    Boolean isSoldOut;
+    SimilarityTypeEnum similarityType;
+}

--- a/src/main/java/com/bbangle/bbangle/board/repository/BoardDetailQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/BoardDetailQueryDSLRepository.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.board.repository;
 
+import com.bbangle.bbangle.board.dto.SimilarityBoardDto;
 import java.util.List;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface BoardDetailQueryDSLRepository {
 
     List<String> findByBoardId(Long boardId);
+
+    List<SimilarityBoardDto> findSimilarityBoardByBoardId(Long memberId, Long boardId);
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/BoardDetailRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/BoardDetailRepositoryImpl.java
@@ -2,8 +2,19 @@ package com.bbangle.bbangle.board.repository;
 
 import com.bbangle.bbangle.board.domain.QBoard;
 import com.bbangle.bbangle.board.domain.QBoardDetail;
+import com.bbangle.bbangle.board.domain.QProduct;
+import com.bbangle.bbangle.board.domain.QRecommendationSimilarBoard;
+import com.bbangle.bbangle.board.dto.QSimilarityBoardDto;
+import com.bbangle.bbangle.board.dto.SimilarityBoardDto;
+import com.bbangle.bbangle.boardstatistic.domain.QBoardStatistic;
+import com.bbangle.bbangle.store.domain.QStore;
+import com.bbangle.bbangle.wishlist.domain.QWishListBoard;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -13,17 +24,74 @@ public class BoardDetailRepositoryImpl implements BoardDetailQueryDSLRepository 
 
     private final JPAQueryFactory queryFactory;
     private static final QBoardDetail boardDetail = QBoardDetail.boardDetail;
+    private static final QStore store = QStore.store;
     private static final QBoard board = QBoard.board;
+    private static final QProduct product = QProduct.product;
+    private static final QWishListBoard wishListBoard = QWishListBoard.wishListBoard;
+    private static final QBoardStatistic boardStatistic = QBoardStatistic.boardStatistic;
+    private static final QRecommendationSimilarBoard similarBoard = QRecommendationSimilarBoard.recommendationSimilarBoard;
 
     @Override
     public List<String> findByBoardId(Long boardId) {
         return queryFactory.select(
-                    boardDetail.url
+                boardDetail.url
             ).from(board)
             .join(boardDetail)
             .on(boardDetail.board.eq(board))
             .where(board.id.eq(boardId))
             .orderBy(boardDetail.imgIndex.asc())
             .fetch();
+    }
+
+    @Override
+    public List<SimilarityBoardDto> findSimilarityBoardByBoardId(Long memberId, Long boardId) {
+        BooleanExpression isWished =
+            Objects.isNull(memberId) ? Expressions.asBoolean(false) : wishListBoard.id.isNotNull();
+
+        return buildWishList(
+            boardId,
+            memberId,
+            queryFactory.select(
+                    new QSimilarityBoardDto(
+                        board.id,
+                        store.id,
+                        board.profile,
+                        store.name,
+                        board.title,
+                        board.discountRate,
+                        board.price,
+                        boardStatistic.boardReviewGrade,
+                        boardStatistic.boardReviewCount,
+                        product.glutenFreeTag,
+                        product.highProteinTag,
+                        product.sugarFreeTag,
+                        product.veganTag,
+                        product.ketogenicTag,
+                        product.soldout,
+                        product.category,
+                        similarBoard.recommendationTheme,
+                        isWished
+                    )
+                ).from(similarBoard)
+                .join(board)
+                .on(similarBoard.recommendationItem.eq(board.id))
+                .join(store)
+                .on(board.store.id.eq(store.id))
+                .join(boardStatistic)
+                .on(board.id.eq(boardStatistic.boardId))
+                .join(product)
+                .on(board.id.eq(product.board.id))
+                .where(similarBoard.queryItem.eq(boardId))
+                .orderBy(similarBoard.rank.asc())
+        ).fetch();
+    }
+
+    private <T> JPAQuery<T> buildWishList(Long boardId, Long memberId, JPAQuery<T> query) {
+        if (Objects.isNull(memberId)) {
+            return query;
+        }
+
+        return query.join(wishListBoard)
+            .on(wishListBoard.boardId.eq(boardId).and(wishListBoard.memberId.eq(memberId)));
     }
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/RecommendationSimilarBoardRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/RecommendationSimilarBoardRepository.java
@@ -1,0 +1,11 @@
+package com.bbangle.bbangle.board.repository;
+
+import com.bbangle.bbangle.board.domain.RecommendationSimilarBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecommendationSimilarBoardRepository extends
+    JpaRepository<RecommendationSimilarBoard, Long> {
+
+}

--- a/src/main/java/com/bbangle/bbangle/board/service/BoardDetailService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/BoardDetailService.java
@@ -1,15 +1,13 @@
 package com.bbangle.bbangle.board.service;
 
 import com.bbangle.bbangle.board.common.TagUtils;
-import com.bbangle.bbangle.board.dao.TagsDao;
-import com.bbangle.bbangle.board.domain.Category;
+import com.bbangle.bbangle.board.dto.BoardInfo;
 import com.bbangle.bbangle.board.dto.SimilarityBoardDto;
 import com.bbangle.bbangle.board.dto.SimilarityBoardResponse;
 import com.bbangle.bbangle.board.repository.BoardDetailRepository;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,68 +18,42 @@ public class BoardDetailService {
     private final BoardDetailRepository boardDetailRepository;
 
     public List<SimilarityBoardResponse> getSimilarityBoardResponses(Long memberId, Long boardId) {
-        List<SimilarityBoardDto> similarityBoardDtos = boardDetailRepository.findSimilarityBoardByBoardId(
-            memberId,
-            boardId);
+        List<SimilarityBoardDto> similarityBoardDtos = boardDetailRepository.findSimilarityBoardByBoardId(memberId, boardId);
 
-        Map<Long, List<TagsDao>> categorizedTagByBoardId = similarityBoardDtos.stream()
-            .collect(Collectors.groupingBy(
-                SimilarityBoardDto::getBoardId,
-                Collectors.mapping(SimilarityBoardDto::getTagsDao,
-                    Collectors.toList())
-            ));
+        Map<Long, BoardInfo> boardInfoMap = new HashMap<>();
+        for (SimilarityBoardDto dto : similarityBoardDtos) {
+            Long currentBoardId = dto.getBoardId();
 
-        Map<Long, Set<Category>> categorizedCategoryByBoardId = similarityBoardDtos.stream()
-            .collect(Collectors.groupingBy(
-                SimilarityBoardDto::getBoardId,
-                Collectors.mapping(SimilarityBoardDto::getCategory,
-                    Collectors.toSet())
-            ));
+            BoardInfo boardInfo = boardInfoMap.computeIfAbsent(currentBoardId, id -> new BoardInfo(dto));
 
-        Map<Long, Set<Boolean>> categorizedIsSoldOutByBoardId = similarityBoardDtos.stream()
-            .collect(Collectors.groupingBy(
-                SimilarityBoardDto::getBoardId,
-                Collectors.mapping(SimilarityBoardDto::getIsSoldOut,
-                    Collectors.toSet())
-            ));
+            boardInfo.addTag(dto.getTagsDao());
+            boardInfo.addCategory(dto.getCategory());
+            boardInfo.addIsSoldOut(dto.getIsSoldOut());
+        }
 
-        return similarityBoardDtos.stream()
-            .collect(Collectors.toMap(
-                SimilarityBoardDto::getBoardId, // 키는 getBoardId 값
-                dto -> dto,                      // 값은 원래 dto 객체
-                (existing, replacement) -> existing // 중복 키가 있을 경우 기존 값 유지
-            ))
-            .values()
-            .stream()
-            .map(similarityBoardDto -> {
-                Long boardId1 = similarityBoardDto.getBoardId();
-
-                List<TagsDao> tagsDaos = categorizedTagByBoardId.get(boardId1);
-                Set<Category> categories = categorizedCategoryByBoardId.get(boardId1);
-                Set<Boolean> soldout = categorizedIsSoldOutByBoardId.get(boardId1);
-
-                List<String> tags = TagUtils.convertToStrings(tagsDaos);
-                Boolean isBundled = categories.size() > 1;
-                Boolean isSoldOut = soldout.size() == 1 && soldout.iterator().next() == true;
+        return boardInfoMap.values().stream()
+            .map(boardInfo -> {
+                List<String> tags = TagUtils.convertToStrings(boardInfo.getTags());
+                Boolean isBundled = boardInfo.getCategories().size() > 1;
+                Boolean isSoldOut = !boardInfo.getIsSoldOut().contains(false);
 
                 return SimilarityBoardResponse.builder()
-                    .boardId(similarityBoardDto.getBoardId())
-                    .storeId(similarityBoardDto.getStoreId())
-                    .thumbnail(similarityBoardDto.getThumbnail())
-                    .storeName(similarityBoardDto.getStoreName())
-                    .title(similarityBoardDto.getTitle())
-                    .discountRate(similarityBoardDto.getDiscountRate())
-                    .price(similarityBoardDto.getPrice())
-                    .reviewRate(similarityBoardDto.getReviewRate())
-                    .reviewCount(similarityBoardDto.getReviewCount())
+                    .boardId(boardInfo.getBoardId())
+                    .storeId(boardInfo.getStoreId())
+                    .thumbnail(boardInfo.getThumbnail())
+                    .storeName(boardInfo.getStoreName())
+                    .title(boardInfo.getTitle())
+                    .discountRate(boardInfo.getDiscountRate())
+                    .price(boardInfo.getPrice())
+                    .reviewRate(boardInfo.getReviewRate())
+                    .reviewCount(boardInfo.getReviewCount())
                     .tags(tags)
-                    .isWished(similarityBoardDto.getIsWished())
+                    .isWished(boardInfo.getIsWished())
                     .isBundled(isBundled)
                     .isSoldOut(isSoldOut)
-                    .similarityType(similarityBoardDto.getSimilarityType())
+                    .similarityType(boardInfo.getSimilarityType())
                     .build();
             }).toList();
     }
-
 }
 

--- a/src/main/java/com/bbangle/bbangle/board/service/BoardDetailService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/BoardDetailService.java
@@ -1,0 +1,87 @@
+package com.bbangle.bbangle.board.service;
+
+import com.bbangle.bbangle.board.common.TagUtils;
+import com.bbangle.bbangle.board.dao.TagsDao;
+import com.bbangle.bbangle.board.domain.Category;
+import com.bbangle.bbangle.board.dto.SimilarityBoardDto;
+import com.bbangle.bbangle.board.dto.SimilarityBoardResponse;
+import com.bbangle.bbangle.board.repository.BoardDetailRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardDetailService {
+
+    private final BoardDetailRepository boardDetailRepository;
+
+    public List<SimilarityBoardResponse> getSimilarityBoardResponses(Long memberId, Long boardId) {
+        List<SimilarityBoardDto> similarityBoardDtos = boardDetailRepository.findSimilarityBoardByBoardId(
+            memberId,
+            boardId);
+
+        Map<Long, List<TagsDao>> categorizedTagByBoardId = similarityBoardDtos.stream()
+            .collect(Collectors.groupingBy(
+                SimilarityBoardDto::getBoardId,
+                Collectors.mapping(SimilarityBoardDto::getTagsDao,
+                    Collectors.toList())
+            ));
+
+        Map<Long, Set<Category>> categorizedCategoryByBoardId = similarityBoardDtos.stream()
+            .collect(Collectors.groupingBy(
+                SimilarityBoardDto::getBoardId,
+                Collectors.mapping(SimilarityBoardDto::getCategory,
+                    Collectors.toSet())
+            ));
+
+        Map<Long, Set<Boolean>> categorizedIsSoldOutByBoardId = similarityBoardDtos.stream()
+            .collect(Collectors.groupingBy(
+                SimilarityBoardDto::getBoardId,
+                Collectors.mapping(SimilarityBoardDto::getIsSoldOut,
+                    Collectors.toSet())
+            ));
+
+        return similarityBoardDtos.stream()
+            .collect(Collectors.toMap(
+                SimilarityBoardDto::getBoardId, // 키는 getBoardId 값
+                dto -> dto,                      // 값은 원래 dto 객체
+                (existing, replacement) -> existing // 중복 키가 있을 경우 기존 값 유지
+            ))
+            .values()
+            .stream()
+            .map(similarityBoardDto -> {
+                Long boardId1 = similarityBoardDto.getBoardId();
+
+                List<TagsDao> tagsDaos = categorizedTagByBoardId.get(boardId1);
+                Set<Category> categories = categorizedCategoryByBoardId.get(boardId1);
+                Set<Boolean> soldout = categorizedIsSoldOutByBoardId.get(boardId1);
+
+                List<String> tags = TagUtils.convertToStrings(tagsDaos);
+                Boolean isBundled = categories.size() > 1;
+                Boolean isSoldOut = soldout.size() == 1 && soldout.iterator().next() == true;
+
+                return SimilarityBoardResponse.builder()
+                    .boardId(similarityBoardDto.getBoardId())
+                    .storeId(similarityBoardDto.getStoreId())
+                    .thumbnail(similarityBoardDto.getThumbnail())
+                    .storeName(similarityBoardDto.getStoreName())
+                    .title(similarityBoardDto.getTitle())
+                    .discountRate(similarityBoardDto.getDiscountRate())
+                    .price(similarityBoardDto.getPrice())
+                    .reviewRate(similarityBoardDto.getReviewRate())
+                    .reviewCount(similarityBoardDto.getReviewCount())
+                    .tags(tags)
+                    .isWished(similarityBoardDto.getIsWished())
+                    .isBundled(isBundled)
+                    .isSoldOut(isSoldOut)
+                    .similarityType(similarityBoardDto.getSimilarityType())
+                    .build();
+            }).toList();
+    }
+
+}
+

--- a/src/main/java/com/bbangle/bbangle/common/domain/CreatedAtBaseEntity.java
+++ b/src/main/java/com/bbangle/bbangle/common/domain/CreatedAtBaseEntity.java
@@ -3,14 +3,12 @@ package com.bbangle.bbangle.common.domain;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
-import org.hibernate.annotations.UpdateTimestamp;
-
+import org.hibernate.annotations.CreationTimestamp;
 @Getter
 @MappedSuperclass
-public class BaseEntity extends CreatedAtBaseEntity {
+public class CreatedAtBaseEntity {
 
-    @UpdateTimestamp
-    private LocalDateTime modifiedAt;
-
+    @CreationTimestamp
+    private LocalDateTime createdAt;
 }
 

--- a/src/test/java/com/bbangle/bbangle/AbstractIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/AbstractIntegrationTest.java
@@ -9,6 +9,7 @@ import com.bbangle.bbangle.board.repository.BoardDetailRepository;
 import com.bbangle.bbangle.board.repository.BoardImgRepository;
 import com.bbangle.bbangle.board.repository.BoardRepository;
 import com.bbangle.bbangle.board.repository.ProductRepository;
+import com.bbangle.bbangle.board.repository.RecommendationSimilarBoardRepository;
 import com.bbangle.bbangle.board.service.BoardService;
 import com.bbangle.bbangle.board.service.ProductService;
 import com.bbangle.bbangle.boardstatistic.domain.BoardStatistic;
@@ -109,6 +110,8 @@ public abstract class AbstractIntegrationTest {
     protected WishListStoreRepository wishListStoreRepository;
     @Autowired
     protected BoardDetailRepository boardDetailRepository;
+    @Autowired
+    protected RecommendationSimilarBoardRepository recommendationSimilarBoardRepository;
     @Autowired
     protected NotificationRepository notificationRepository;
     @Autowired

--- a/src/test/java/com/bbangle/bbangle/fixture/RecommendationSimilarBoardFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/RecommendationSimilarBoardFixture.java
@@ -1,0 +1,75 @@
+package com.bbangle.bbangle.fixture;
+
+import com.bbangle.bbangle.board.domain.RecommendationSimilarBoard;
+import com.bbangle.bbangle.board.domain.SimilarityModelVerEnum;
+import com.bbangle.bbangle.board.domain.SimilarityTypeEnum;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.logging.Logger;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RecommendationSimilarBoardFixture {
+
+    private static final int LIMIT_SIMILAR_BOARD_COUNT = 3;
+
+    public static List<RecommendationSimilarBoard> getRandom(
+        Long boardId,
+        List<Long> recommandationItems
+    ) {
+        Random random = new Random();
+        BigDecimal[] randomScores = new BigDecimal[LIMIT_SIMILAR_BOARD_COUNT];
+        List<RecommendationSimilarBoard> recommendationSimilarBoards = new ArrayList<>(3);
+
+        for (int i = 0; i < LIMIT_SIMILAR_BOARD_COUNT; i++) {
+            randomScores[i] = BigDecimal.valueOf(random.nextDouble(0, 1));
+        }
+
+        for (int i = 0; i < LIMIT_SIMILAR_BOARD_COUNT; i++) {
+            int rank = findRank(randomScores, randomScores[i]);
+
+            RecommendationSimilarBoard recommendationSimilarBoard = RecommendationSimilarBoard.builder()
+                .queryItem(boardId)
+                .recommendationItem(recommandationItems.get(i))
+                .score(randomScores[i])
+                .rank(rank)
+                .recommendationTheme(random.nextInt() % 2 == 0 ? SimilarityTypeEnum.SIMILARITY
+                    : SimilarityTypeEnum.DEFAULT) // TODO - Enum이 3개 이상일 때 random으로 값을 가져올 수 있는 방법 고민
+                .modelVersion(random.nextInt() % 2 == 0 ? SimilarityModelVerEnum.V1
+                    : SimilarityModelVerEnum.DEFAULT)
+                .build();
+            recommendationSimilarBoards.add(recommendationSimilarBoard);
+            logging(recommendationSimilarBoard);
+        }
+
+        return recommendationSimilarBoards;
+    }
+
+    private static int findRank(BigDecimal[] scores, BigDecimal targetScore) {
+        BigDecimal[] sortedScores = scores.clone();
+        Arrays.sort(sortedScores, Comparator.reverseOrder());
+
+        // 각 점수의 첫 번째 등장 순위 저장
+        Map<BigDecimal, Integer> rankMap = new HashMap<>();
+        for (int j = 0; j < sortedScores.length; j++) {
+            rankMap.putIfAbsent(sortedScores[j], j + 1);
+        }
+
+        // 대상 점수의 순위 반환
+        return rankMap.get(targetScore);
+    }
+
+    private static void logging(RecommendationSimilarBoard recommendationSimilarBoard) {
+        log.info(recommendationSimilarBoard.toString());
+    }
+}


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History
https://github.com/eco-dessert-platform/backend/issues/302

## 🚀 Major Changes & Explanations
- 요청된 boardId 정보를 recommendation_similar_board 테이블에서 recommend_item(추천 상품)을 가져옴(추천 상품 3개)
- board, product, boardStatistic, wishlist 조인
    - 옵티마이저에 의해 효율적으로 인덱스 타는 것을 확인
- 위 데이터를 묶음 상품, 품절 유무, 찜 여부 등을 가공하여 새로운 DTO에 담아서 프론트에 전달 

## 📷 Test Image
![image](https://github.com/user-attachments/assets/a154051f-be87-4371-b953-f97c38504f53)
![image](https://github.com/user-attachments/assets/cc47d4b0-fac2-4e65-bfaf-1c72a5db43d5)
![image](https://github.com/user-attachments/assets/56eb52b6-6a9b-48d9-9878-240534380509)
- fixtureMonkey 에러인 것 같음

## 💡 ETC
- 다소 급하게 진행 되다보니, 코드 개선은 이후 진행해야할 것 같습니다.
    - 양해 부탁드립니다!
- 구현하고 있는 화면은 아래 화면 입니다. 
![image](https://github.com/user-attachments/assets/eb26ef3c-131a-486d-a471-423bffc26837)

