### PR TITLE
Badge Repository Method 변경

### DIFF
--- a/src/main/java/com/bbangle/bbangle/review/dto/ReviewBadgeDto.java
+++ b/src/main/java/com/bbangle/bbangle/review/dto/ReviewBadgeDto.java
@@ -1,0 +1,13 @@
+package com.bbangle.bbangle.review.dto;
+
+import com.bbangle.bbangle.review.domain.Badge;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReviewBadgeDto {
+    private Badge badgeTaste;
+    private Badge badgeBrix;
+    private Badge badgeTexture;
+}

--- a/src/main/java/com/bbangle/bbangle/review/repository/ReviewQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/review/repository/ReviewQueryDSLRepository.java
@@ -9,6 +9,7 @@ import com.bbangle.bbangle.review.domain.ReviewCursor;
 import com.bbangle.bbangle.review.domain.ReviewLike;
 import com.bbangle.bbangle.image.dto.ImageDto;
 import com.bbangle.bbangle.review.dto.LikeCountPerReviewIdDto;
+import com.bbangle.bbangle.review.dto.ReviewBadgeDto;
 import com.bbangle.bbangle.review.dto.ReviewCountPerBoardIdDto;
 import com.bbangle.bbangle.review.dto.ReviewDto;
 import com.bbangle.bbangle.review.dto.ReviewSingleDto;
@@ -34,6 +35,8 @@ public interface ReviewQueryDSLRepository {
     List<DateAndCountDto> countReviewCreatedBetweenPeriod(LocalDate startLocalDate, LocalDate endLocalDate);
     List<AnalyticsCumulationResponseDto> countCumulatedReviewBeforeEndDate(LocalDate startLocalDate, LocalDate endLocalDate);
     List<ReviewDto> findByBoardId(Long boardId);
+
+    List<ReviewBadgeDto> findReviewBadgeByBoardId(Long boardId);
 
     List<ReviewStatisticDao> getReviewStatisticByBoardIds(List<Long> boardReviewUpdateId);
 

--- a/src/main/java/com/bbangle/bbangle/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/review/repository/ReviewRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.bbangle.bbangle.review.domain.ReviewLike;
 import com.bbangle.bbangle.review.domain.QReviewLike;
 import com.bbangle.bbangle.image.dto.ImageDto;
 import com.bbangle.bbangle.review.dto.QReviewSingleDto;
+import com.bbangle.bbangle.review.dto.ReviewBadgeDto;
 import com.bbangle.bbangle.review.dto.ReviewDto;
 import com.bbangle.bbangle.review.dto.ReviewSingleDto;
 import com.bbangle.bbangle.review.dto.ReviewCountPerBoardIdDto;
@@ -354,6 +355,22 @@ public class ReviewRepositoryImpl implements ReviewQueryDSLRepository {
                     ReviewDto.class,
                     review.badgeTaste,
                     review.badgeBrix,
+                    review.badgeTexture,
+                    review.rate
+                )
+            )
+            .from(review)
+            .where(review.boardId.eq(boardId).and(notDeleted()))
+            .fetch();
+    }
+
+    @Override
+    public List<ReviewBadgeDto> findReviewBadgeByBoardId(Long boardId) {
+        return queryFactory.select(
+                Projections.constructor(
+                    ReviewBadgeDto.class,
+                    review.badgeTaste,
+                    review.badgeBrix,
                     review.badgeTexture
                 )
             )
@@ -361,6 +378,7 @@ public class ReviewRepositoryImpl implements ReviewQueryDSLRepository {
             .where(review.boardId.eq(boardId).and(notDeleted()))
             .fetch();
     }
+
 
     @Override
     public List<ReviewStatisticDao> getReviewStatisticByBoardIds(List<Long> boardReviewUpdateId) {

--- a/src/main/java/com/bbangle/bbangle/review/service/ReviewService.java
+++ b/src/main/java/com/bbangle/bbangle/review/service/ReviewService.java
@@ -283,7 +283,7 @@ public class ReviewService {
 
     @Transactional
     public SummarizedReviewResponse getSummarizedReview(Long boardId) {
-        List<ReviewDto> reviews = reviewRepository.findByBoardId(boardId);
+        List<ReviewBadgeDto> reviews = reviewRepository.findReviewBadgeByBoardId(boardId);
 
         if (reviews.isEmpty()) {
             return SummarizedReviewResponse.getEmpty();

--- a/src/main/java/com/bbangle/bbangle/review/service/ReviewStatistics.java
+++ b/src/main/java/com/bbangle/bbangle/review/service/ReviewStatistics.java
@@ -9,12 +9,11 @@ import static com.bbangle.bbangle.review.domain.Badge.SWEET;
 
 import com.bbangle.bbangle.boardstatistic.repository.BoardStatisticRepository;
 import com.bbangle.bbangle.review.domain.Badge;
-import com.bbangle.bbangle.review.dto.ReviewDto;
+import com.bbangle.bbangle.review.dto.ReviewBadgeDto;
 import java.math.BigDecimal;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -34,11 +33,11 @@ public class ReviewStatistics {
         return boardStatisticRepository.findBoardReviewGradeByBoardId(boardId);
     }
 
-    public int count(List<ReviewDto> reviews) {
+    public int count(List<ReviewBadgeDto> reviews) {
         return reviews.size();
     }
 
-    public List<String> getPopularBadgeList(List<ReviewDto> reviews) {
+    public List<String> getPopularBadgeList(List<ReviewBadgeDto> reviews) {
         return Stream.of(
                 getPopularTasteBadge(reviews),
                 getPopularBrixBadge(reviews),
@@ -48,21 +47,21 @@ public class ReviewStatistics {
             .toList();
     }
 
-    private String getPopularTasteBadge(List<ReviewDto> reviews) {
-        return calculatePopularBadge(reviews, ReviewDto::getBadgeTaste, GOOD, BAD);
+    private String getPopularTasteBadge(List<ReviewBadgeDto> reviews) {
+        return calculatePopularBadge(reviews, ReviewBadgeDto::getBadgeTaste, GOOD, BAD);
     }
 
-    private String getPopularBrixBadge(List<ReviewDto> reviews) {
-        return calculatePopularBadge(reviews, ReviewDto::getBadgeBrix, SWEET, PLAIN);
+    private String getPopularBrixBadge(List<ReviewBadgeDto> reviews) {
+        return calculatePopularBadge(reviews, ReviewBadgeDto::getBadgeBrix, SWEET, PLAIN);
     }
 
-    private String getPopularTextureBadge(List<ReviewDto> reviews) {
-        return calculatePopularBadge(reviews, ReviewDto::getBadgeTexture, SOFT, DRY);
+    private String getPopularTextureBadge(List<ReviewBadgeDto> reviews) {
+        return calculatePopularBadge(reviews, ReviewBadgeDto::getBadgeTexture, SOFT, DRY);
     }
 
     private String calculatePopularBadge(
-        List<ReviewDto> reviews,
-        Function<ReviewDto, Badge> badgeFunction,
+        List<ReviewBadgeDto> reviews,
+        Function<ReviewBadgeDto, Badge> badgeFunction,
         Badge positiveBadge,
         Badge nagativeBadge) {
 


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History
**공통 메서드 사용**
- findByBoardId 메서드를 여러 곳에서 공통으로 사용 중이었음.
- 이를 모르고 사용하다가, 해당 필드를 삭제하고 rate 필드를 제거했더니 예상치 못한 곳에서 버그가 발생. (에러는 발생하지 않았으나, rate 값이 누락되어 결과에 반영되지 않는 문제가 생김)
- 기존 findByBoardId를 원래 상태로 복구한 뒤, 뱃지 데이터를 가져오는 새로운 메서드 findReviewBadgeByBoardId를 생성하여 문제를 해결.

**공통 DTO 사용**
- 기존에 ReviewDto를 사용 중이었으며, 해당 DTO는 리뷰와 관련된 거의 모든 필드를 포함하고 있었음.
- 단순히 뱃지 데이터만 필요한 상황에서도 이를 사용하다 보니, DTO가 여러 용도로 활용되면서 혼란이 발생.
- 이를 해결하기 위해 ReviewBadgeDto를 새로 생성하여, 뱃지 데이터만 포함하는 명확한 DTO를 도입.

## 변경 사항
- findByBoardId 메서드 원상 복구
- findReviewBadgeByBoardId 뱃지를 가져오는 새로운 메서드 생성
- ReviewBadgeDto 클래스 생성

## 📷 Test Image
![image](https://github.com/user-attachments/assets/0f557f1b-909f-4368-8a6f-d277aafbea88)
![image](https://github.com/user-attachments/assets/2143d1a9-ac02-438c-8cf6-c22a30fdf604)
![image](https://github.com/user-attachments/assets/a215ee01-bb55-4220-9313-687017c13e41)
