### PR TITLE
✅ 정적메서드로 인해 발생하는 에러 수정 및 인기 상품 가져오는 쿼리 수정

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/service/BoardDetailService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/BoardDetailService.java
@@ -80,7 +80,8 @@ public class BoardDetailService {
         int insufficientNumber = RECOMMENDATION_ITEM_COUNT - similarityOrderByBoardIds.size();
         if (insufficientNumber > ZERO_INSUFFICIENT) {
             List<Long> popularBoardIds = boardStatisticRepository.findPopularBoardIds(30).stream()
-                .filter(id -> !similarityOrderByBoardIds.contains(id)).toList();
+                .filter(id -> !similarityOrderByBoardIds.contains(id))
+                .collect(Collectors.toCollection(ArrayList::new));
 
             Collections.shuffle(popularBoardIds);
 


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History
- 인기 검색을 셔플하는 과정에서 에러발생

## 🚀 Major Changes & Explanations
- 셔플하는 리스트가 정적 리스트라 에러 발생
- 정적 리스트에서 동적 리스트로 변경
- 서브쿼리에서 Limit이 안되는 버그가 있어 쿼리 분할

## 📷 Test Image
![image](https://github.com/user-attachments/assets/0ceb8522-53cb-4b63-adb4-b38aa900c170)

## 💡 ETC

