### PR TITLE
위시리스트에 게시글 추가할 시 발생하는 동시성 문제 제어

### DIFF
--- a/src/main/java/com/bbangle/bbangle/wishlist/domain/WishListBoard.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/domain/WishListBoard.java
@@ -7,13 +7,17 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "wishlist_product")
+@Table(name = "wishlist_product",
+    uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"product_board_id", "member_id"})
+})
 @Entity
 @Getter
 @Builder

--- a/src/main/java/com/bbangle/bbangle/wishlist/repository/WishListFolderRepository.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/repository/WishListFolderRepository.java
@@ -18,8 +18,10 @@ public interface WishListFolderRepository extends JpaRepository<WishListFolder, 
     @Query(value = "select folder from WishListFolder folder where folder.id = :folderId and folder.member.id = :memberId")
     Optional<WishListFolder> findByMemberIdAndId(@Param("memberId") Long memberId, @Param("folderId") Long folderId);
 
-    Optional<WishListFolder> findByMemberAndId(Member member, Long folderId);
+    @Query(value = "select folder from WishListFolder folder where folder.member.id = :memberId and folder.id = :folderId")
+    Optional<WishListFolder> findByMemberAndId(Long memberId, Long folderId);
 
-    Optional<WishListFolder> findByMemberAndFolderName(Member member, String folderName);
+    @Query(value = "select folder from WishListFolder folder where folder.member.id = :memberId and folder.folderName = :folderName")
+    Optional<WishListFolder> findByMemberAndFolderName(Long memberId, String folderName);
 
 }

--- a/src/main/java/com/bbangle/bbangle/wishlist/service/WishListBoardService.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/service/WishListBoardService.java
@@ -15,6 +15,7 @@ import com.bbangle.bbangle.wishlist.repository.WishListFolderRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,9 +40,12 @@ public class WishListBoardService {
         Board board = boardRepository.findById(boardId)
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.BOARD_NOT_FOUND));
 
-        validateIsWishAvailable(board.getId(), member.getId());
+        try {
+            makeNewWish(board, wishlistFolder, member);
+        } catch (DataIntegrityViolationException e){
+            throw new BbangleException(BbangleErrorCode.ALREADY_ON_WISHLIST);
+        }
 
-        makeNewWish(board, wishlistFolder, member);
         boardStatisticService.updateWishCount(boardId);
     }
 

--- a/src/main/java/com/bbangle/bbangle/wishlist/service/WishListBoardService.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/service/WishListBoardService.java
@@ -38,11 +38,7 @@ public class WishListBoardService {
         Board board = boardRepository.findById(boardId)
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.BOARD_NOT_FOUND));
 
-        try {
-            makeNewWish(board, wishlistFolder, memberId);
-        } catch (DataIntegrityViolationException e){
-            throw new BbangleException(BbangleErrorCode.ALREADY_ON_WISHLIST);
-        }
+        makeNewWish(board, wishlistFolder, memberId);
 
         boardStatisticService.updateWishCount(boardId);
     }
@@ -52,7 +48,8 @@ public class WishListBoardService {
     public void cancel(Long memberId, Long boardId) {
         Member member = memberRepository.findMemberById(memberId);
 
-        WishListBoard wishedBoard = wishlistBoardRepository.findByBoardIdAndMemberId(boardId, member.getId())
+        WishListBoard wishedBoard = wishlistBoardRepository.findByBoardIdAndMemberId(boardId,
+                member.getId())
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.WISHLIST_BOARD_NOT_FOUND));
 
         wishlistBoardRepository.delete(wishedBoard);
@@ -71,7 +68,8 @@ public class WishListBoardService {
         WishListBoardRequest wishRequest,
         Long memberId
     ) {
-        if (wishRequest.folderId().equals(0L)) {
+        if (wishRequest.folderId()
+            .equals(0L)) {
             return wishListFolderRepository.findByMemberAndFolderName(memberId, DEFAULT_FOLDER_NAME)
                 .orElseThrow(() -> new BbangleException(BbangleErrorCode.FOLDER_NOT_FOUND));
         }
@@ -85,14 +83,16 @@ public class WishListBoardService {
         WishListFolder wishlistFolder,
         Long memberId
     ) {
-
         WishListBoard wishlistBoard = WishListBoard.builder()
             .wishlistFolderId(wishlistFolder.getId())
             .boardId(board.getId())
             .memberId(memberId)
             .build();
-
-        wishlistBoardRepository.save(wishlistBoard);
+        try {
+            wishlistBoardRepository.save(wishlistBoard);
+        } catch (DataIntegrityViolationException e) {
+            throw new BbangleException(BbangleErrorCode.ALREADY_ON_WISHLIST);
+        }
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/wishlist/service/WishListFolderService.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/service/WishListFolderService.java
@@ -51,9 +51,7 @@ public class WishListFolderService {
 
     @Transactional
     public void delete(Long folderId, Long memberId) {
-        Member member = memberRepository.findMemberById(memberId);
-
-        WishListFolder wishlistFolder = wishListFolderRepository.findByMemberAndId(member, folderId)
+       WishListFolder wishlistFolder = wishListFolderRepository.findByMemberAndId(memberId, folderId)
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.FOLDER_NOT_FOUND));
 
         validateIsDeleteAvailable(wishlistFolder);
@@ -63,9 +61,7 @@ public class WishListFolderService {
 
     @Transactional
     public void update(Long memberId, Long folderId, FolderUpdateDto updateDto) {
-        Member member = memberRepository.findMemberById(memberId);
-
-        WishListFolder wishlistFolder = wishListFolderRepository.findByMemberAndId(member, folderId)
+        WishListFolder wishlistFolder = wishListFolderRepository.findByMemberAndId(memberId, folderId)
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.FOLDER_NOT_FOUND));
 
         validateWishListFolder(wishlistFolder);

--- a/src/test/java/com/bbangle/bbangle/wishlist/service/WishListBoardServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/wishlist/service/WishListBoardServiceTest.java
@@ -184,7 +184,7 @@ class WishListBoardServiceTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("동시에 한 게시글에 대해 wish를 할 경우 두 번째 요청은 실패해야 한다")
+    @DisplayName("동시에 한 게시글에 대해 wish를 할 경우 한번만 요청에 성공해 데이터를 저장한다")
     void concurrentWish() {
         //given
         WishListFolder wishListFolder = WishlistFolderFixture.createWishlistFolder(member);


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
* Resolves #322 
![스크린샷 2024-11-26 오전 9 48 06](https://github.com/user-attachments/assets/15f1ba22-adf5-4164-b42f-186eb5006a5c)
![race condition](https://github.com/user-attachments/assets/36cda0de-24c5-445d-b013-e86f022d45ec)

## 🚀 Major Changes & Explanations
- 한 유저가 한 개의 게시글을 두 번 찜할 수 없는 정책이 존재
- 그러나 위 사진의 로직 상 찜을 누르는 POST 요청이 커밋되기 전에 Validation 로직에서 DB에 존재하는지 확인하는 로직을 실행할 경우 한 유저가 한 게시글에 대해 두 번 찜한 데이터가 기록되는 문제가 발생
- 이를 해결하기 위해 NamedLock, 분산락, 유티크 제약 조건을 생각
- NamedLock의 경우, boardId, memberId를 기준으로 DB에 락을 걸고 로직이 끝날 때 락을 반납하는 식으로 구현 가능
`E.g. String lockName = "wishBoard:" + memberId + ":" + boardId;`
- 분산락도 비슷한 개념으로 락을 걸고 로직이 끝날 시 획득 가능
- unique 제약 조건의 경우 이미 DB에 데이터가 존재하는 경우 예외가 발생하게 만드는 것

### 최종 선택
- unique 제약 조건만을 거는 방식을 채택
### 선정 이유
validation 조회 로직이 사라지기 때문
-> 기존에는 DB에 데이터가 있는지 없는지 로직을 쿼리로 날려서 확인하였다.
그러나 unique 제약 조건을 거는 경우 DB에 조회해서 데이터가 있을 시 반드시 예외가 발생한다
그렇기에 원래 로직이 아래와 같았다면
```
select ... (존재하는지 확인하는 조회 로직)
insert ...(존재하지 않는다는 검증 후 데이터 삽입)
```

```
insert... (삽입, 만약 데이터가 있다면 예외발생하고 그걸 처리하면 됨)
```

이와 같이 변경함으로 DB 쿼리 횟수를 줄이는 효과가 있을 것으로 예상하였다.
그리고 실제 추가된 코드도
```java
    private void makeNewWish(
        Board board,
        WishListFolder wishlistFolder,
        Long memberId
    ) {
        WishListBoard wishlistBoard = WishListBoard.builder()
            .wishlistFolderId(wishlistFolder.getId())
            .boardId(board.getId())
            .memberId(memberId)
            .build();
        try {
            wishlistBoardRepository.save(wishlistBoard);
        } catch (DataIntegrityViolationException e) {
            throw new BbangleException(BbangleErrorCode.ALREADY_ON_WISHLIST);
        }
    }
```
실제 저장하는 부분에 try-catch를 걸어 중복데이터로 인한 예외가 발생 시 커스텀 예외를 다시 던져주는 방식을 채택

이것으로 조회를 한번 줄여주는 방식이 unique 제약조건으로 인해 생기는 인덱스 테이블보다 이득이 많을 것으로 판단하여 진행

다른 방식(락을 거는 방식)의 경우 기존 validation을 위해 조회하는 로직을 남겨둬야 하기에 unique 제약 조건만을 사용하는 방식으로 채택

추가로 토큰에서 memberId를 가져와 member를 조회하는 부분도 기존 코드 기조대로 memberId 직접 조회하는 방식으로 변경

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image
<img width="464" alt="스크린샷 2024-11-28 오후 12 10 17" src="https://github.com/user-attachments/assets/c769577a-c0da-48b5-95b4-dd2f96806dbb">
<img width="520" alt="스크린샷 2024-11-28 오후 12 19 59" src="https://github.com/user-attachments/assets/c5e48a37-a2a1-4088-bdc1-13da5dcb7b65">

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
<img width="826" alt="스크린샷 2024-11-28 오후 12 48 22" src="https://github.com/user-attachments/assets/04f68a4e-f185-4e61-b71a-c5f2cd978afd">


