### PR TITLE
Fix/review race condition

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -1,14 +1,13 @@
 package com.bbangle.bbangle.exception;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-
-import java.util.stream.Stream;
-
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import java.util.stream.Stream;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 
 @Getter
@@ -59,12 +58,14 @@ public enum BbangleErrorCode {
     DEFAULT_FOLDER_NAME_USED(-39, "폴더 이름을 기본 폴더로 수정할 수 없습니다.", BAD_REQUEST),
     REVIEW_ALREADY_LIKED(-40, "이미 도움돼요를 누른 게시글입니다.", BAD_REQUEST),
     INVALID_TOKEN_TYPE(-41, "유효하지 않은 형태소 타입입니다.", NOT_FOUND),
+    AlREADY_ON_REVIEWLIKE(-42, "이미 좋아요를 누른 리뷰 댓글입니다.", NOT_FOUND),
     GOOGLE_AUTHENTICATION_ERROR(-995, "구글 인증 토큰 발행 중 에러가 발생했습니다.",
         HttpStatus.INTERNAL_SERVER_ERROR),
     JSON_SERIALIZATION_ERROR(-996, "json 변환 중 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     FCM_INITIALIZATION_ERROR(-997, "Firebase 초기화 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     FCM_CONNECTION_ERROR(-998, "FCM 서버 요청 중 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    INTERNAL_SERVER_ERROR(-999, "서버 내부 에러입니다", HttpStatus.INTERNAL_SERVER_ERROR);
+    INTERNAL_SERVER_ERROR(-999, "서버 내부 에러입니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    ;
 
     private final int code;
     private final String message;

--- a/src/main/java/com/bbangle/bbangle/review/domain/Review.java
+++ b/src/main/java/com/bbangle/bbangle/review/domain/Review.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 @Table(name = "review")
 @Entity
 @Getter

--- a/src/main/java/com/bbangle/bbangle/review/domain/ReviewLike.java
+++ b/src/main/java/com/bbangle/bbangle/review/domain/ReviewLike.java
@@ -4,9 +4,14 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+@Table(
+        name = "review_like",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"member_id", "review_id"})
+        }
+)
 @Entity
 @Getter
-@Table(name = "review_like")
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/bbangle/bbangle/review/service/ReviewService.java
+++ b/src/main/java/com/bbangle/bbangle/review/service/ReviewService.java
@@ -1,5 +1,11 @@
 package com.bbangle.bbangle.review.service;
 
+import static com.bbangle.bbangle.exception.BbangleErrorCode.IMAGE_NOT_FOUND;
+import static com.bbangle.bbangle.exception.BbangleErrorCode.REVIEW_MEMBER_NOT_PROPER;
+import static com.bbangle.bbangle.exception.BbangleErrorCode.REVIEW_NOT_FOUND;
+import static com.bbangle.bbangle.image.domain.ImageCategory.REVIEW;
+import static java.util.Locale.ROOT;
+
 import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.repository.BoardRepository;
 import com.bbangle.bbangle.boardstatistic.service.BoardStatisticService;
@@ -13,24 +19,36 @@ import com.bbangle.bbangle.member.domain.Member;
 import com.bbangle.bbangle.member.repository.MemberRepository;
 import com.bbangle.bbangle.page.ImageCustomPage;
 import com.bbangle.bbangle.page.ReviewCustomPage;
-import com.bbangle.bbangle.review.domain.*;
-import com.bbangle.bbangle.review.dto.*;
+import com.bbangle.bbangle.review.domain.Badge;
+import com.bbangle.bbangle.review.domain.Review;
+import com.bbangle.bbangle.review.domain.ReviewCursor;
+import com.bbangle.bbangle.review.domain.ReviewLike;
+import com.bbangle.bbangle.review.domain.ReviewManager;
+import com.bbangle.bbangle.review.dto.ReviewBadgeDto;
+import com.bbangle.bbangle.review.dto.ReviewDto;
+import com.bbangle.bbangle.review.dto.ReviewImageUploadRequest;
+import com.bbangle.bbangle.review.dto.ReviewImageUploadResponse;
+import com.bbangle.bbangle.review.dto.ReviewImagesResponse;
+import com.bbangle.bbangle.review.dto.ReviewInfoResponse;
+import com.bbangle.bbangle.review.dto.ReviewRateResponse;
+import com.bbangle.bbangle.review.dto.ReviewRequest;
+import com.bbangle.bbangle.review.dto.ReviewSingleDto;
+import com.bbangle.bbangle.review.dto.SummarizedReviewResponse;
 import com.bbangle.bbangle.review.repository.ReviewLikeRepository;
 import com.bbangle.bbangle.review.repository.ReviewRepository;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
-
-import java.math.BigDecimal;
-import java.util.*;
-
-import static com.bbangle.bbangle.exception.BbangleErrorCode.IMAGE_NOT_FOUND;
-import static com.bbangle.bbangle.exception.BbangleErrorCode.REVIEW_MEMBER_NOT_PROPER;
-import static com.bbangle.bbangle.exception.BbangleErrorCode.REVIEW_NOT_FOUND;
-import static com.bbangle.bbangle.image.domain.ImageCategory.REVIEW;
-import static java.util.Locale.ROOT;
 
 @Service
 @RequiredArgsConstructor
@@ -117,15 +135,15 @@ public class ReviewService {
 
     @Transactional
     public void insertLike(Long reviewId, Long memberId) {
-        reviewLikeRepository.findByMemberIdAndReviewId(memberId, reviewId)
-                .ifPresent(reviewLike -> {
-                    throw new BbangleException(BbangleErrorCode.REVIEW_ALREADY_LIKED);
-                });
-
-        reviewLikeRepository.save(ReviewLike.builder()
+        ReviewLike reviewLike = ReviewLike.builder()
                 .memberId(memberId)
                 .reviewId(reviewId)
-                .build());
+                .build();
+        try {
+            reviewLikeRepository.save(reviewLike);
+        } catch (DataIntegrityViolationException e) {
+            throw new BbangleException(BbangleErrorCode.AlREADY_ON_REVIEWLIKE);
+        }
     }
 
     @Transactional

--- a/src/test/java/com/bbangle/bbangle/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/review/service/ReviewServiceTest.java
@@ -42,6 +42,10 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -241,6 +245,39 @@ class ReviewServiceTest extends AbstractIntegrationTest {
 
         // then
         assertThat(reviewLikes).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("동시에 한 리뷰에 대해 좋아요를 할 경우 한번만 요청에 성공해 데이터를 저장한다")
+    void concurrentLike() {
+        //given
+        Member member = memberRepository.save(FixtureMonkeyConfig.fixtureMonkey
+                .giveMeOne(Member.class));
+
+        Review review = reviewRepository.save(FixtureMonkeyConfig.fixtureMonkey
+                .giveMeBuilder(Review.class)
+                .set("memberId", member.getId())
+                .sample());
+
+        final int threadCount = 2;
+        final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+
+        //when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    reviewService.insertLike(review.getId(), member.getId());
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+
+        //then
+        Assertions.assertThatCode(() ->
+                        reviewLikeRepository.findByMemberIdAndReviewId(member.getId(), review.getId()))
+                 .doesNotThrowAnyException();
     }
 
     @DisplayName("리뷰 좋아요 해제에 성공한다")


### PR DESCRIPTION
# **1. 문제**

---

![image](https://github.com/user-attachments/assets/e731a27d-5b86-4fdd-9efd-3608654fdc30)

![image](https://github.com/user-attachments/assets/c364a26b-baa2-46a5-9822-f0eb51bc47db)


리뷰삭제 요청에서 단일결과를 예상했지만, 9개의 결과를 리턴한다고 합니다. 예상대로라면 리뷰좋아요는 member당 하나씩 밖에 갖지 못합니다. 

## 1-1. 문제 원인

---

리뷰를 저장할 때 동시성 이슈가 발생해서 그렇습니다.

![image](https://github.com/user-attachments/assets/e0ef8128-a3d3-46b7-aeef-8acc122aef50)


![image](https://github.com/user-attachments/assets/33c71774-d8ac-411b-9220-4c2baae351ce)


1. Transaction1과 Transaction2가 거의 동시에 시작되어 각각 BEGIN을 합니다.
2. 두 트랜잭션 모두 memberId=1, reviewId=1인 데이터를 찾기 위해 findByMemberIdAndReviewId를 호출합니다.
3. 빨간색 박스로 표시된 Race Condition 구간에서:
    - Transaction1이 조회했을 때 "결과 없음"을 받습니다 (아직 좋아요가 없으므로)
    - Transaction2도 조회했을 때 "결과 없음"을 받습니다 (Transaction1이 아직 커밋하지 않았으므로)
    - 두 트랜잭션 모두 데이터가 없다고 판단하여 각각 ReviewLike를 생성합니다
4. 두 트랜잭션이 모두 COMMIT에 성공하면서 결과적으로 같은 (memberId, reviewId) 조합의 좋아요 데이터가 두 번 저장됩니다.

# 2. 해결 방법

---

처음에 고유 제약 조건, Upsert, 낙관적/비관적 잠금, 트랜잭션 격리 수준 높임, 네임드락, **Synchronized들을** 해결방법으로 생각하였습니다.

**Upsert**는 삽입과 갱신을 단일 쿼리로 처리하여 코드 단순화와 성능 향상을 기대할 수 있는 방법입니다. 하지만 데이터베이스 종류나 버전에 따라 지원 여부와 성능 최적화 정도가 달라질 수 있습니다. 특정 DBMS에 종속적일 가능성이 있으므로, 시스템의 이식성을 고려해야 합니다.

**낙관적 잠금**은 충돌 가능성이 낮은 환경에서 유용하며, 잠금 없이 데이터 갱신을 시도하고 충돌이 발생했을 때만 재처리합니다. 이는 성능에 유리하지만, 충돌 발생 시 복잡한 재시도 로직이 필요하며 트랜잭션이 길어질 수 있습니다. 반면 **비관적 잠금**은 충돌 가능성이 높은 경우 효과적이지만, 리소스를 오래 점유해 시스템의 전체 성능에 부정적인 영향을 미칠 수 있습니다.

**네임드 락**은 특정 키를 기준으로 락을 설정합니다. 이는 애플리케이션 레벨에서의 제어를 가능하게 하며, 분산 시스템 환경에서도 효과적입니다. 그러나 락 오버헤드와 잠금 유지 시간에 따른 성능 저하 가능성을 고려해야 합니다.

**트랜잭션 격리 수준을 높이는 방법**은 간단하게 동시성을 제어할 수 있는 방법이지만, 성능 저하와 잠금 대기가 길어지는 문제가 발생할 수 있습니다. 이로 인해 실시간 처리 요구사항이 있는 시스템에서는 적합하지 않을 수 있습니다.

**Synchronized**는 단일 애플리케이션 서버에서만 사용 가능하며, 멀티스레드 환경에서의 동시성 제어에 효과적입니다. 하지만 분산 환경에서는 적용할 수 없으며, Synchronized는 스레드가 락을 점유하는 동안 다른 스레드가 대기해야 하므로 병목 현상이 발생할 수 있습니다.

**이러한 트레이드오프를 종합적으로 분석한 결과, `유니크 제약 조건`을 선택했습니다. 데이터베이스에서 무결성을 보장하고, 트랜잭션 수준에서 동시성을 간단히 관리할 수 있기 때문입니다.**

![image](https://github.com/user-attachments/assets/4b2ec1eb-e2f5-4e5f-b606-d8e60ee2ac6f)

```java
 @Test
    @DisplayName("동시에 한 리뷰에 대해 좋아요를 할 경우 한번만 요청에 성공해 데이터를 저장한다")
    void concurrentLike() {
        //given
        Member member = memberRepository.save(FixtureMonkeyConfig.fixtureMonkey
                .giveMeOne(Member.class));

        Review review = reviewRepository.save(FixtureMonkeyConfig.fixtureMonkey
                .giveMeBuilder(Review.class)
                .set("memberId", member.getId())
                .sample());

        final int threadCount = 2;
        final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
        final CountDownLatch countDownLatch = new CountDownLatch(threadCount);

        //when
        for (int i = 0; i < threadCount; i++) {
            executorService.submit(() -> {
                try {
                    reviewService.insertLike(review.getId(), member.getId());
                } finally {
                    countDownLatch.countDown();
                }
            });
        }

        //then
        Assertions.assertThatCode(() ->
                        reviewLikeRepository.findByMemberIdAndReviewId(member.getId(), review.getId()))
                 .doesNotThrowAnyException();
    }
```

![image](https://github.com/user-attachments/assets/2cdaa3e3-999f-4929-9205-e29a6e2b993a)