### PR TITLE
🚀 Flyway 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,5 @@ redis/data/dump.rdb
 .jqwik-database
 !/.github/workflows/cd-pipeline-dev-aws.yml
 !/.github/workflows/cd-pipeline-aws-deploy.yml
+
+src/main/resources/docker/

--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,10 @@ dependencies {
 
     // CSV
     implementation 'org.apache.commons:commons-csv:1.10.0'
+
+    // flyway
+    implementation 'org.flywaydb:flyway-mysql'
+    implementation 'org.flywaydb:flyway-core'
 }
 
 // Querydsl 설정부


### PR DESCRIPTION
## 🚀 Major Changes & Explanations
1. sql 파일 경로는 "resources/docker/mariadb/db_dump"로 지정해주세요.
    - ![image](https://github.com/user-attachments/assets/58f3d649-2404-41b1-a0b2-a23e3ebc32e1)
    - 도커 파일은 빵그리 docker Repository에 있습니다.
2. 노션에서 yml을 받아주세요.

**사용방법**
- Docker Repository에 있는 폴더를 src/main/resources에 clone해주세요.
- 도커 컴포즈 해서 MariaDB 컨테이너 띄워주세요.
- 서버를 실행해주세요. 