### PR TITLE
[Refactor] Board 이미지 테이블 리팩토링: ERD 개선 및 데이터 일관성 강화

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/domain/Board.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Board.java
@@ -56,9 +56,6 @@ public class Board extends BaseEntity {
     @Column(name = "is_soldout", columnDefinition = "tinyint")
     private Boolean status;
 
-    @Column(name = "profile")
-    private String profile;
-
     @Column(name = "purchase_url")
     private String purchaseUrl;
 
@@ -83,12 +80,6 @@ public class Board extends BaseEntity {
 
     @OneToOne(mappedBy = "board", fetch = FetchType.LAZY, cascade = CascadeType.ALL ) // Board가 더 많이 호출되므로 연관관계 주인을 board로 하는게 더 적합해 보임
     private BoardStatistic boardStatistic;
-
-
-    public Board updateProfile(String profile) {
-        this.profile = profile;
-        return this;
-    }
 
     public void addProducts(List<Product> products) {
         this.products.addAll(products);

--- a/src/main/java/com/bbangle/bbangle/board/domain/Board.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Board.java
@@ -72,6 +72,9 @@ public class Board extends BaseEntity {
     private List<Product> products = new ArrayList<>();
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
+    private List<ProductImg> productImgs = new ArrayList<>();
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
     private List<BoardDetail> boardDetails = new ArrayList<>();
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)

--- a/src/main/java/com/bbangle/bbangle/board/domain/Board.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Board.java
@@ -140,4 +140,12 @@ public class Board extends BaseEntity {
             .distinct()
             .count() > 1;
     }
+
+    public String getThumbnail() {
+        return productImgs.stream()
+                .filter(ProductImg::isThumbnail)
+                .findFirst()
+                .orElseThrow(() -> new BbangleException(BbangleErrorCode.BOARD_WITH_IMAGE_NOTFOUND))
+                .getUrl();
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/board/domain/ProductImg.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/ProductImg.java
@@ -36,6 +36,8 @@ public class ProductImg {
     @Column(name = "url")
     private String url;
 
+    private String imgIndex;
+
     public void updateBoard(Board board) {
         this.board = board;
     }

--- a/src/main/java/com/bbangle/bbangle/board/domain/ProductImg.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/ProductImg.java
@@ -25,6 +25,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductImg {
 
+    private static final int THUMBNAIL_ORDER = 0;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -43,6 +44,6 @@ public class ProductImg {
     }
 
     public boolean isThumbnail() {
-        return this.imgOrder==0;
+        return this.imgOrder == THUMBNAIL_ORDER;
     }
 }

--- a/src/main/java/com/bbangle/bbangle/board/domain/ProductImg.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/ProductImg.java
@@ -36,7 +36,7 @@ public class ProductImg {
     @Column(name = "url")
     private String url;
 
-    private String imgIndex;
+    private int imgIndex;
 
     public void updateBoard(Board board) {
         this.board = board;

--- a/src/main/java/com/bbangle/bbangle/board/domain/ProductImg.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/ProductImg.java
@@ -36,9 +36,13 @@ public class ProductImg {
     @Column(name = "url")
     private String url;
 
-    private int imgIndex;
+    private int imgOrder;
 
     public void updateBoard(Board board) {
         this.board = board;
+    }
+
+    public boolean isThumbnail() {
+        return this.imgOrder==0;
     }
 }

--- a/src/main/java/com/bbangle/bbangle/board/dto/BoardAndImageDto.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/BoardAndImageDto.java
@@ -4,14 +4,16 @@ public record BoardAndImageDto(
     Long boardId,
     Long storeId,
     String profile,
+    Integer imgOrder,
     String title,
     Integer price,
     String purchaseUrl,
     Boolean status,
     Integer deliveryFee,
     Integer freeShippingConditions,
-    int discountRate,
-    String url
+    int discountRate
 ) {
-
+    public boolean isWithThumbNailImage() {
+        return imgOrder == 0;
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/board/dto/BoardAndImageResponses.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/BoardAndImageResponses.java
@@ -1,0 +1,60 @@
+package com.bbangle.bbangle.board.dto;
+
+import java.util.List;
+
+public record BoardAndImageResponses(
+        Long boardId,
+        Long storeId,
+        String profile,
+        String title,
+        Integer price,
+        String purchaseUrl,
+        Boolean status,
+        Integer deliveryFee,
+        Integer freeShippingConditions,
+        int discountRate,
+        List<String> boardImagesWithoutThumbnail
+) {
+    public static BoardAndImageResponses createFromDtos(List<BoardAndImageDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) {
+            throw new IllegalArgumentException("DTO 리스트가 비어 있습니다.");
+        }
+
+        BoardAndImageDto first = extractCommonInfo(dtos);
+        String profile = extractThumbnailImages(dtos);
+        List<String> boardImagesWithoutThumbnail = extractNonThumbnailImages(dtos);
+
+        return new BoardAndImageResponses(
+                first.boardId(),
+                first.storeId(),
+                profile,
+                first.title(),
+                first.price(),
+                first.purchaseUrl(),
+                first.status(),
+                first.deliveryFee(),
+                first.freeShippingConditions(),
+                first.discountRate(),
+                boardImagesWithoutThumbnail
+        );
+    }
+
+    private static BoardAndImageDto extractCommonInfo(List<BoardAndImageDto> dtos) {
+        return dtos.get(0);
+    }
+
+    private static String extractThumbnailImages(List<BoardAndImageDto> dtos) {
+        return dtos.stream()
+                .filter(dto -> dto.isWithThumbNailImage())
+                .map(BoardAndImageDto::profile)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static List<String> extractNonThumbnailImages(List<BoardAndImageDto> dtos) {
+        return dtos.stream()
+                .filter(dto -> !dto.isWithThumbNailImage())
+                .map(BoardAndImageDto::profile)
+                .toList();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/board/dto/BoardImageDetailResponse.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/BoardImageDetailResponse.java
@@ -22,27 +22,26 @@ public class BoardImageDetailResponse {
     private List<String> boardImages;
     private String boardDetail;
 
-    public static BoardImageDetailResponse from(
-        BoardDto boardDto,
-        Boolean isWished,
-        String boardProfileUrl,
-        List<String> boardImageDtos,
-        String boardDetai
+    public static BoardImageDetailResponse of(
+            BoardAndImageResponses boardResponses,
+            Boolean isWished,
+            String boardDetail
     ) {
+
         return BoardImageDetailResponse.builder()
-            .boardId(boardDto.getBoardId())
-            .storeId(boardDto.getStoreId())
-            .profile(boardProfileUrl)
-            .title(boardDto.getTitle())
-            .price(boardDto.getPrice())
-            .purchaseUrl(boardDto.getPurchaseUrl())
-            .status(boardDto.getStatus())
-            .deliveryFee(boardDto.getDeliveryFee())
-            .freeShippingConditions(boardDto.getFreeShippingConditions())
-            .discountRate(boardDto.getDiscountRate())
-            .isWished(isWished)
-            .boardImages(boardImageDtos)
-            .boardDetail(boardDetai)
-            .build();
+                .boardId(boardResponses.boardId())
+                .storeId(boardResponses.storeId())
+                .profile(boardResponses.profile())
+                .title(boardResponses.title())
+                .price(boardResponses.price())
+                .purchaseUrl(boardResponses.purchaseUrl())
+                .status(boardResponses.status())
+                .deliveryFee(boardResponses.deliveryFee())
+                .freeShippingConditions(boardResponses.freeShippingConditions())
+                .discountRate(boardResponses.discountRate())
+                .isWished(isWished)
+                .boardImages(boardResponses.boardImagesWithoutThumbnail())
+                .boardDetail(boardDetail)
+                .build();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/board/dto/BoardInfoDto.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/BoardInfoDto.java
@@ -55,7 +55,7 @@ public class BoardInfoDto {
     public static BoardInfoDto create(Board board) {
         return new BoardInfoDto(
             board.getId(),
-            board.getProfile(),
+            board.getThumbnail(),
             board.getTitle(),
             board.getPrice(),
             board.getDiscountRate(),

--- a/src/main/java/com/bbangle/bbangle/board/repository/BoardDetailRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/BoardDetailRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.bbangle.bbangle.board.repository;
 
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
+
 import com.bbangle.bbangle.board.domain.QBoard;
 import com.bbangle.bbangle.board.domain.QBoardDetail;
 import com.bbangle.bbangle.board.domain.QProduct;
@@ -68,7 +70,7 @@ public class BoardDetailRepositoryImpl implements BoardDetailQueryDSLRepository 
                                 new QSimilarityBoardDto(
                                         board.id,
                                         store.id,
-                                        board.profile,
+                                        productImg.url,
                                         store.name,
                                         board.title,
                                         board.discountRate,
@@ -88,6 +90,8 @@ public class BoardDetailRepositoryImpl implements BoardDetailQueryDSLRepository 
                         .join(product).on(board.id.eq(product.board.id))
                         .join(store).on(board.store.id.eq(store.id))
                         .join(board.boardStatistic, boardStatistic)
+                        .join(productImg).on(productImg.board.id.eq(board.id))
+                        .where(productImg.imgOrder.eq(0))
                         .where(board.id.in(boardIds))
         ).fetch();
     }

--- a/src/main/java/com/bbangle/bbangle/board/repository/BoardRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/BoardRepository.java
@@ -10,58 +10,32 @@ import org.springframework.data.repository.query.Param;
 public interface BoardRepository extends JpaRepository<Board, Long>, BoardQueryDSLRepository {
 
     @Query("SELECT new com.bbangle.bbangle.board.dto.BoardInfoDto(" +
-        "b.id, " +
-        "MIN(b.profile), " +
-        "MIN(b.title), " +
-        "MIN(b.price), " +
-        "MIN(b.discountRate), " +
-        "MIN(s.boardReviewGrade), " +
-        "MIN(s.boardReviewCount), " +
-        "MAX(CASE WHEN p.soldout = false THEN 0 ELSE 1 END), " +
-        "CASE WHEN COUNT(p.orderStartDate) > 0 THEN true ELSE false END, " +
-        "MAX(CASE WHEN p.glutenFreeTag = true THEN 1 ELSE 0 END), " +
-        "MAX(CASE WHEN p.highProteinTag = true THEN 1 ELSE 0 END), " +
-        "MAX(CASE WHEN p.sugarFreeTag = true THEN 1 ELSE 0 END), " +
-        "MAX(CASE WHEN p.veganTag = true THEN 1 ELSE 0 END), " +
-        "MAX(CASE WHEN p.ketogenicTag = true THEN 1 ELSE 0 END), " +
-        "CASE WHEN COUNT(DISTINCT p.category) > 1 THEN true ELSE false END, " +
-        "CASE WHEN w.wishlistFolderId IS NOT NULL THEN true ELSE false END) " +
-        "FROM Product p " +
-        "JOIN Board b ON b.store.id = :storeId AND p.board.id = b.id " +
-        "JOIN BoardStatistic s ON s.board = b " +
-        "LEFT JOIN WishListBoard w ON b.id = w.boardId AND w.memberId = :memberId " +
-        "WHERE b.id <= :cursorId " +
-        "GROUP BY b.id " +
-        "ORDER BY b.id desc " +
-        "LIMIT 11")
-    List<BoardInfoDto> findBoardsByStoreWithCursor(@Param("storeId") Long storeId,
-        @Param("memberId") Long memberId, @Param("cursorId") Long cursorId);
-
-    @Query("SELECT new com.bbangle.bbangle.board.dto.BoardInfoDto(" +
-        "b.id, " +
-        "MIN(b.profile), " +
-        "MIN(b.title), " +
-        "MIN(b.price), " +
-        "MIN(b.discountRate), " +
-        "MIN(s.boardReviewGrade), " +
-        "MIN(s.boardReviewCount), " +
-        "MAX(CASE WHEN p.soldout = false THEN 0 ELSE 1 END), " +
-        "CASE WHEN COUNT(p.orderStartDate) > 0 THEN true ELSE false END, " +
-        "MAX(CASE WHEN p.glutenFreeTag = true THEN 1 ELSE 0 END), " +
-        "MAX(CASE WHEN p.highProteinTag = true THEN 1 ELSE 0 END), " +
-        "MAX(CASE WHEN p.sugarFreeTag = true THEN 1 ELSE 0 END), " +
-        "MAX(CASE WHEN p.veganTag = true THEN 1 ELSE 0 END), " +
-        "MAX(CASE WHEN p.ketogenicTag = true THEN 1 ELSE 0 END), " +
-        "CASE WHEN COUNT(DISTINCT p.category) > 1 THEN true ELSE false END, " +
-        "CASE WHEN w.wishlistFolderId IS NOT NULL THEN true ELSE false END) " +
-        "FROM Product p " +
-        "JOIN Board b ON p.board.id = b.id AND b.store.id = :storeId " +
-        "JOIN BoardStatistic s ON s.board = b " +
-        "LEFT JOIN WishListBoard w ON b.id = w.boardId AND w.memberId = :memberId " +
-        "GROUP BY s.basicScore, b.id " +
-        "ORDER BY s.basicScore desc " +
-        "LIMIT 3")
+            "b.id, " +
+            "MIN(CASE WHEN pi.imgOrder = 0 THEN pi.url ELSE NULL END), " + // profile 대신 첫 번째 이미지
+            "MIN(b.title), " +
+            "MIN(b.price), " +
+            "MIN(b.discountRate), " +
+            "MIN(s.boardReviewGrade), " +
+            "MIN(s.boardReviewCount), " +
+            "MAX(CASE WHEN p.soldout = false THEN 0 ELSE 1 END), " +
+            "CASE WHEN COUNT(p.orderStartDate) > 0 THEN true ELSE false END, " +
+            "MAX(CASE WHEN p.glutenFreeTag = true THEN 1 ELSE 0 END), " +
+            "MAX(CASE WHEN p.highProteinTag = true THEN 1 ELSE 0 END), " +
+            "MAX(CASE WHEN p.sugarFreeTag = true THEN 1 ELSE 0 END), " +
+            "MAX(CASE WHEN p.veganTag = true THEN 1 ELSE 0 END), " +
+            "MAX(CASE WHEN p.ketogenicTag = true THEN 1 ELSE 0 END), " +
+            "CASE WHEN COUNT(DISTINCT p.category) > 1 THEN true ELSE false END, " +
+            "CASE WHEN w.wishlistFolderId IS NOT NULL THEN true ELSE false END) " +
+            "FROM Product p " +
+            "JOIN Board b ON p.board.id = b.id AND b.store.id = :storeId " +
+            "JOIN BoardStatistic s ON s.board = b " +
+            "LEFT JOIN WishListBoard w ON b.id = w.boardId AND w.memberId = :memberId " +
+            "LEFT JOIN ProductImg pi ON pi.board = b " +  // ProductImg 조인 추가
+            "GROUP BY s.basicScore, b.id " +
+            "ORDER BY s.basicScore desc " +
+            "LIMIT 3")
     List<BoardInfoDto> findBestBoards(@Param("memberId") Long memberId,
-        @Param("storeId") Long storeId);
+                                      @Param("storeId") Long storeId);
+
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/query/HighPriceBoardQueryProviderResolver.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/query/HighPriceBoardQueryProviderResolver.java
@@ -1,5 +1,7 @@
 package com.bbangle.bbangle.board.repository.basic.query;
 
+import static com.bbangle.bbangle.board.domain.QBoard.board;
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
 import static com.bbangle.bbangle.board.repository.BoardRepositoryImpl.BOARD_PAGE_SIZE;
 
 import com.bbangle.bbangle.board.dao.BoardResponseDao;
@@ -17,7 +19,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class HighPriceBoardQueryProviderResolver implements BoardQueryProvider{
+public class HighPriceBoardQueryProviderResolver implements BoardQueryProvider {
 
     private static final QBoard board = QBoard.board;
     private static final QBoardStatistic boardStatistic = QBoardStatistic.boardStatistic;
@@ -28,49 +30,50 @@ public class HighPriceBoardQueryProviderResolver implements BoardQueryProvider{
 
     @Override
     public List<BoardResponseDao> findBoards(
-        BooleanBuilder filter,
-        BooleanBuilder cursorInfo,
-        OrderSpecifier<?>[] orderCondition
+            BooleanBuilder filter,
+            BooleanBuilder cursorInfo,
+            OrderSpecifier<?>[] orderCondition
     ) {
         List<Long> boardIds = jpaQueryFactory.select(board.id)
-            .distinct()
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .where(cursorInfo.and(filter))
-            .orderBy(orderCondition)
-            .limit(BOARD_PAGE_SIZE + 1)
-            .fetch();
+                .distinct()
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .where(cursorInfo.and(filter))
+                .orderBy(orderCondition)
+                .limit(BOARD_PAGE_SIZE + 1)
+                .fetch();
 
         return jpaQueryFactory.select(
-                new QBoardResponseDao(
-                    board.id,
-                    store.id,
-                    store.name,
-                    board.profile,
-                    board.title,
-                    board.price,
-                    product.category,
-                    product.glutenFreeTag,
-                    product.highProteinTag,
-                    product.sugarFreeTag,
-                    product.veganTag,
-                    product.ketogenicTag,
-                    boardStatistic.boardReviewGrade,
-                    boardStatistic.boardReviewCount,
-                    product.orderEndDate,
-                    product.soldout,
-                    board.discountRate
-                ))
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(store)
-            .on(board.store.id.eq(store.id))
-            .join(board.boardStatistic, boardStatistic)
-            .where(board.id.in(boardIds))
-            .orderBy(orderCondition)
-            .fetch();
+                        new QBoardResponseDao(
+                                board.id,
+                                store.id,
+                                store.name,
+                                productImg.url,
+                                board.title,
+                                board.price,
+                                product.category,
+                                product.glutenFreeTag,
+                                product.highProteinTag,
+                                product.sugarFreeTag,
+                                product.veganTag,
+                                product.ketogenicTag,
+                                boardStatistic.boardReviewGrade,
+                                boardStatistic.boardReviewCount,
+                                product.orderEndDate,
+                                product.soldout,
+                                board.discountRate
+                        ))
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(store)
+                .on(board.store.id.eq(store.id))
+                .join(board.boardStatistic, boardStatistic)
+                .innerJoin(productImg).on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
+                .where(board.id.in(boardIds))
+                .orderBy(orderCondition)
+                .fetch();
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/query/HighRatedBoardQueryProviderResolver.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/query/HighRatedBoardQueryProviderResolver.java
@@ -1,5 +1,7 @@
 package com.bbangle.bbangle.board.repository.basic.query;
 
+import static com.bbangle.bbangle.board.domain.QBoard.board;
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
 import static com.bbangle.bbangle.board.repository.BoardRepositoryImpl.BOARD_PAGE_SIZE;
 
 import com.bbangle.bbangle.board.dao.BoardResponseDao;
@@ -17,7 +19,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class HighRatedBoardQueryProviderResolver implements BoardQueryProvider{
+public class HighRatedBoardQueryProviderResolver implements BoardQueryProvider {
 
     private static final QBoard board = QBoard.board;
     private static final QProduct product = QProduct.product;
@@ -28,50 +30,51 @@ public class HighRatedBoardQueryProviderResolver implements BoardQueryProvider{
 
     @Override
     public List<BoardResponseDao> findBoards(
-        BooleanBuilder filter,
-        BooleanBuilder cursorInfo,
-        OrderSpecifier<?>[] orderCondition
+            BooleanBuilder filter,
+            BooleanBuilder cursorInfo,
+            OrderSpecifier<?>[] orderCondition
     ) {
         List<Long> boardIds = jpaQueryFactory.select(board.id)
-            .distinct()
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(board.boardStatistic, boardStatistic)
-            .where(cursorInfo.and(filter))
-            .orderBy(orderCondition)
-            .limit(BOARD_PAGE_SIZE + 1)
-            .fetch();
+                .distinct()
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(board.boardStatistic, boardStatistic)
+                .where(cursorInfo.and(filter))
+                .orderBy(orderCondition)
+                .limit(BOARD_PAGE_SIZE + 1)
+                .fetch();
 
         return jpaQueryFactory.select(
-                new QBoardResponseDao(
-                    board.id,
-                    store.id,
-                    store.name,
-                    board.profile,
-                    board.title,
-                    board.price,
-                    product.category,
-                    product.glutenFreeTag,
-                    product.highProteinTag,
-                    product.sugarFreeTag,
-                    product.veganTag,
-                    product.ketogenicTag,
-                    boardStatistic.boardReviewGrade,
-                    boardStatistic.boardReviewCount,
-                    product.orderEndDate,
-                    product.soldout,
-                    board.discountRate
-                ))
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(store)
-            .on(board.store.id.eq(store.id))
-            .join(board.boardStatistic, boardStatistic)
-            .where(board.id.in(boardIds))
-            .orderBy(orderCondition)
-            .fetch();
+                        new QBoardResponseDao(
+                                board.id,
+                                store.id,
+                                store.name,
+                                productImg.url,
+                                board.title,
+                                board.price,
+                                product.category,
+                                product.glutenFreeTag,
+                                product.highProteinTag,
+                                product.sugarFreeTag,
+                                product.veganTag,
+                                product.ketogenicTag,
+                                boardStatistic.boardReviewGrade,
+                                boardStatistic.boardReviewCount,
+                                product.orderEndDate,
+                                product.soldout,
+                                board.discountRate
+                        ))
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(store)
+                .on(board.store.id.eq(store.id))
+                .join(board.boardStatistic, boardStatistic)
+                .innerJoin(productImg).on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
+                .where(board.id.in(boardIds))
+                .orderBy(orderCondition)
+                .fetch();
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/query/LowPriceBoardQueryProviderResolver.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/query/LowPriceBoardQueryProviderResolver.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.board.repository.basic.query;
 
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
 import static com.bbangle.bbangle.board.repository.BoardRepositoryImpl.BOARD_PAGE_SIZE;
 
 import com.bbangle.bbangle.board.dao.BoardResponseDao;
@@ -17,7 +18,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class LowPriceBoardQueryProviderResolver  implements BoardQueryProvider{
+public class LowPriceBoardQueryProviderResolver implements BoardQueryProvider {
 
     private static final QBoard board = QBoard.board;
     private static final QProduct product = QProduct.product;
@@ -28,49 +29,52 @@ public class LowPriceBoardQueryProviderResolver  implements BoardQueryProvider{
 
     @Override
     public List<BoardResponseDao> findBoards(
-        BooleanBuilder filter,
-        BooleanBuilder cursorInfo,
-        OrderSpecifier<?>[] orderCondition
+            BooleanBuilder filter,
+            BooleanBuilder cursorInfo,
+            OrderSpecifier<?>[] orderCondition
     ) {
         List<Long> boardIds = jpaQueryFactory.select(board.id)
-            .distinct()
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .where(cursorInfo.and(filter))
-            .orderBy(orderCondition)
-            .limit(BOARD_PAGE_SIZE + 1)
-            .fetch();
+                .distinct()
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .where(cursorInfo.and(filter))
+                .orderBy(orderCondition)
+                .limit(BOARD_PAGE_SIZE + 1)
+                .fetch();
 
         return jpaQueryFactory.select(
-                new QBoardResponseDao(
-                    board.id,
-                    store.id,
-                    store.name,
-                    board.profile,
-                    board.title,
-                    board.price,
-                    product.category,
-                    product.glutenFreeTag,
-                    product.highProteinTag,
-                    product.sugarFreeTag,
-                    product.veganTag,
-                    product.ketogenicTag,
-                    boardStatistic.boardReviewGrade,
-                    boardStatistic.boardReviewCount,
-                    product.orderEndDate,
-                    product.soldout,
-                    board.discountRate
-                ))
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(store)
-            .on(board.store.id.eq(store.id))
-            .join(board.boardStatistic, boardStatistic)
-            .where(board.id.in(boardIds))
-            .orderBy(orderCondition)
-            .fetch();
+                        new QBoardResponseDao(
+                                board.id,
+                                store.id,
+                                store.name,
+                                productImg.url,
+                                board.title,
+                                board.price,
+                                product.category,
+                                product.glutenFreeTag,
+                                product.highProteinTag,
+                                product.sugarFreeTag,
+                                product.veganTag,
+                                product.ketogenicTag,
+                                boardStatistic.boardReviewGrade,
+                                boardStatistic.boardReviewCount,
+                                product.orderEndDate,
+                                product.soldout,
+                                board.discountRate
+                        ))
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(store)
+                .on(board.store.id.eq(store.id))
+                .join(board.boardStatistic, boardStatistic)
+                .join(productImg.board, board)
+                .where(productImg.imgOrder.eq(0))
+                .innerJoin(productImg).on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
+                .where(board.id.in(boardIds))
+                .orderBy(orderCondition)
+                .fetch();
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/query/MostReviewedBoardQueryProviderResolver.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/query/MostReviewedBoardQueryProviderResolver.java
@@ -1,5 +1,7 @@
 package com.bbangle.bbangle.board.repository.basic.query;
 
+import static com.bbangle.bbangle.board.domain.QBoard.board;
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
 import static com.bbangle.bbangle.board.repository.BoardRepositoryImpl.BOARD_PAGE_SIZE;
 
 import com.bbangle.bbangle.board.dao.BoardResponseDao;
@@ -17,7 +19,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class MostReviewedBoardQueryProviderResolver  implements BoardQueryProvider{
+public class MostReviewedBoardQueryProviderResolver implements BoardQueryProvider {
 
     private static final QBoard board = QBoard.board;
     private static final QProduct product = QProduct.product;
@@ -28,50 +30,51 @@ public class MostReviewedBoardQueryProviderResolver  implements BoardQueryProvid
 
     @Override
     public List<BoardResponseDao> findBoards(
-        BooleanBuilder filter,
-        BooleanBuilder cursorInfo,
-        OrderSpecifier<?>[] orderCondition
+            BooleanBuilder filter,
+            BooleanBuilder cursorInfo,
+            OrderSpecifier<?>[] orderCondition
     ) {
         List<Long> boardIds = jpaQueryFactory.select(board.id)
-            .distinct()
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(board.boardStatistic, boardStatistic)
-            .where(cursorInfo.and(filter))
-            .orderBy(orderCondition)
-            .limit(BOARD_PAGE_SIZE + 1)
-            .fetch();
+                .distinct()
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(board.boardStatistic, boardStatistic)
+                .where(cursorInfo.and(filter))
+                .orderBy(orderCondition)
+                .limit(BOARD_PAGE_SIZE + 1)
+                .fetch();
 
         return jpaQueryFactory.select(
-                new QBoardResponseDao(
-                    board.id,
-                    store.id,
-                    store.name,
-                    board.profile,
-                    board.title,
-                    board.price,
-                    product.category,
-                    product.glutenFreeTag,
-                    product.highProteinTag,
-                    product.sugarFreeTag,
-                    product.veganTag,
-                    product.ketogenicTag,
-                    boardStatistic.boardReviewGrade,
-                    boardStatistic.boardReviewCount,
-                    product.orderEndDate,
-                    product.soldout,
-                    board.discountRate
-                ))
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(store)
-            .on(board.store.id.eq(store.id))
-            .join(board.boardStatistic, boardStatistic)
-            .where(board.id.in(boardIds))
-            .orderBy(orderCondition)
-            .fetch();
+                        new QBoardResponseDao(
+                                board.id,
+                                store.id,
+                                store.name,
+                                productImg.url,
+                                board.title,
+                                board.price,
+                                product.category,
+                                product.glutenFreeTag,
+                                product.highProteinTag,
+                                product.sugarFreeTag,
+                                product.veganTag,
+                                product.ketogenicTag,
+                                boardStatistic.boardReviewGrade,
+                                boardStatistic.boardReviewCount,
+                                product.orderEndDate,
+                                product.soldout,
+                                board.discountRate
+                        ))
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(store)
+                .on(board.store.id.eq(store.id))
+                .join(board.boardStatistic, boardStatistic)
+                .innerJoin(productImg).on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
+                .where(board.id.in(boardIds))
+                .orderBy(orderCondition)
+                .fetch();
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/query/MostWishedBoardQueryProviderResolver.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/query/MostWishedBoardQueryProviderResolver.java
@@ -1,5 +1,7 @@
 package com.bbangle.bbangle.board.repository.basic.query;
 
+import static com.bbangle.bbangle.board.domain.QBoard.board;
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
 import static com.bbangle.bbangle.board.repository.BoardRepositoryImpl.BOARD_PAGE_SIZE;
 
 import com.bbangle.bbangle.board.dao.BoardResponseDao;
@@ -17,7 +19,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class MostWishedBoardQueryProviderResolver  implements BoardQueryProvider{
+public class MostWishedBoardQueryProviderResolver implements BoardQueryProvider {
 
     private static final QBoard board = QBoard.board;
     private static final QProduct product = QProduct.product;
@@ -28,50 +30,51 @@ public class MostWishedBoardQueryProviderResolver  implements BoardQueryProvider
 
     @Override
     public List<BoardResponseDao> findBoards(
-        BooleanBuilder filter,
-        BooleanBuilder cursorInfo,
-        OrderSpecifier<?>[] orderCondition
+            BooleanBuilder filter,
+            BooleanBuilder cursorInfo,
+            OrderSpecifier<?>[] orderCondition
     ) {
         List<Long> boardIds = jpaQueryFactory.select(board.id)
-            .distinct()
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(board.boardStatistic, boardStatistic)
-            .where(cursorInfo.and(filter))
-            .orderBy(orderCondition)
-            .limit(BOARD_PAGE_SIZE + 1)
-            .fetch();
+                .distinct()
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(board.boardStatistic, boardStatistic)
+                .where(cursorInfo.and(filter))
+                .orderBy(orderCondition)
+                .limit(BOARD_PAGE_SIZE + 1)
+                .fetch();
 
         return jpaQueryFactory.select(
-                new QBoardResponseDao(
-                    board.id,
-                    store.id,
-                    store.name,
-                    board.profile,
-                    board.title,
-                    board.price,
-                    product.category,
-                    product.glutenFreeTag,
-                    product.highProteinTag,
-                    product.sugarFreeTag,
-                    product.veganTag,
-                    product.ketogenicTag,
-                    boardStatistic.boardReviewGrade,
-                    boardStatistic.boardReviewCount,
-                    product.orderEndDate,
-                    product.soldout,
-                    board.discountRate
-                ))
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(store)
-            .on(board.store.id.eq(store.id))
-            .join(board.boardStatistic, boardStatistic)
-            .where(board.id.in(boardIds))
-            .orderBy(orderCondition)
-            .fetch();
+                        new QBoardResponseDao(
+                                board.id,
+                                store.id,
+                                store.name,
+                                productImg.url,
+                                board.title,
+                                board.price,
+                                product.category,
+                                product.glutenFreeTag,
+                                product.highProteinTag,
+                                product.sugarFreeTag,
+                                product.veganTag,
+                                product.ketogenicTag,
+                                boardStatistic.boardReviewGrade,
+                                boardStatistic.boardReviewCount,
+                                product.orderEndDate,
+                                product.soldout,
+                                board.discountRate
+                        ))
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(store)
+                .on(board.store.id.eq(store.id))
+                .join(board.boardStatistic, boardStatistic)
+                .innerJoin(productImg).on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
+                .where(board.id.in(boardIds))
+                .orderBy(orderCondition)
+                .fetch();
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/query/PreferenceRecommendBoardQueryProviderResolver.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/query/PreferenceRecommendBoardQueryProviderResolver.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.board.repository.basic.query;
 
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
 import static com.bbangle.bbangle.board.repository.BoardRepositoryImpl.BOARD_PAGE_SIZE;
 
 import com.bbangle.bbangle.board.dao.BoardResponseDao;
@@ -8,12 +9,7 @@ import com.bbangle.bbangle.board.domain.QBoard;
 import com.bbangle.bbangle.board.domain.QProduct;
 import com.bbangle.bbangle.boardstatistic.domain.QBoardPreferenceStatistic;
 import com.bbangle.bbangle.boardstatistic.domain.QBoardStatistic;
-import com.bbangle.bbangle.exception.BbangleErrorCode;
-import com.bbangle.bbangle.exception.BbangleException;
-import com.bbangle.bbangle.preference.domain.Preference;
 import com.bbangle.bbangle.preference.domain.PreferenceType;
-import com.bbangle.bbangle.preference.domain.QMemberPreference;
-import com.bbangle.bbangle.preference.domain.QPreference;
 import com.bbangle.bbangle.store.domain.QStore;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
@@ -24,7 +20,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class PreferenceRecommendBoardQueryProviderResolver{
+public class PreferenceRecommendBoardQueryProviderResolver {
 
     private static final QBoard board = QBoard.board;
     private static final QProduct product = QProduct.product;
@@ -35,56 +31,57 @@ public class PreferenceRecommendBoardQueryProviderResolver{
     private final JPAQueryFactory queryFactory;
 
     public List<BoardResponseDao> findBoards(
-        BooleanBuilder filter,
-        BooleanBuilder cursorInfo,
-        OrderSpecifier<?>[] orderCondition,
-        Long memberId,
-        PreferenceType selectedPreference
+            BooleanBuilder filter,
+            BooleanBuilder cursorInfo,
+            OrderSpecifier<?>[] orderCondition,
+            Long memberId,
+            PreferenceType selectedPreference
     ) {
         List<Long> boardIds = queryFactory.select(board.id)
-            .distinct()
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(preferenceBoardStatistic)
-            .on(preferenceBoardStatistic.boardId.eq(board.id))
-            .where(cursorInfo.and(filter).and(preferenceBoardStatistic.preferenceType.eq(selectedPreference)))
-            .orderBy(orderCondition)
-            .limit(BOARD_PAGE_SIZE + 1)
-            .fetch();
+                .distinct()
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(preferenceBoardStatistic)
+                .on(preferenceBoardStatistic.boardId.eq(board.id))
+                .where(cursorInfo.and(filter).and(preferenceBoardStatistic.preferenceType.eq(selectedPreference)))
+                .orderBy(orderCondition)
+                .limit(BOARD_PAGE_SIZE + 1)
+                .fetch();
 
         return queryFactory.select(
-                new QBoardResponseDao(
-                    board.id,
-                    store.id,
-                    store.name,
-                    board.profile,
-                    board.title,
-                    board.price,
-                    product.category,
-                    product.glutenFreeTag,
-                    product.highProteinTag,
-                    product.sugarFreeTag,
-                    product.veganTag,
-                    product.ketogenicTag,
-                    boardStatistic.boardReviewGrade,
-                    boardStatistic.boardReviewCount,
-                    product.orderEndDate,
-                    product.soldout,
-                    board.discountRate
-                ))
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(store)
-            .on(board.store.id.eq(store.id))
-            .join(board.boardStatistic, boardStatistic)
-            .join(preferenceBoardStatistic)
-            .on(board.id.eq(preferenceBoardStatistic.boardId))
-            .where(board.id.in(boardIds))
-            .where(preferenceBoardStatistic.preferenceType.eq(selectedPreference))
-            .orderBy(orderCondition)
-            .fetch();
+                        new QBoardResponseDao(
+                                board.id,
+                                store.id,
+                                store.name,
+                                productImg.url,
+                                board.title,
+                                board.price,
+                                product.category,
+                                product.glutenFreeTag,
+                                product.highProteinTag,
+                                product.sugarFreeTag,
+                                product.veganTag,
+                                product.ketogenicTag,
+                                boardStatistic.boardReviewGrade,
+                                boardStatistic.boardReviewCount,
+                                product.orderEndDate,
+                                product.soldout,
+                                board.discountRate
+                        ))
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(store)
+                .on(board.store.id.eq(store.id))
+                .join(board.boardStatistic, boardStatistic)
+                .join(preferenceBoardStatistic)
+                .on(board.id.eq(preferenceBoardStatistic.boardId))
+                .innerJoin(productImg).on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
+                .where(board.id.in(boardIds))
+                .where(preferenceBoardStatistic.preferenceType.eq(selectedPreference))
+                .orderBy(orderCondition)
+                .fetch();
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/query/RecentBoardQueryProviderResolver.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/query/RecentBoardQueryProviderResolver.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.board.repository.basic.query;
 
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
 import static com.bbangle.bbangle.board.repository.BoardRepositoryImpl.BOARD_PAGE_SIZE;
 
 import com.bbangle.bbangle.board.dao.BoardResponseDao;
@@ -17,7 +18,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class RecentBoardQueryProviderResolver  implements BoardQueryProvider{
+public class RecentBoardQueryProviderResolver implements BoardQueryProvider {
 
     private static final QBoard board = QBoard.board;
     private static final QProduct product = QProduct.product;
@@ -28,49 +29,50 @@ public class RecentBoardQueryProviderResolver  implements BoardQueryProvider{
 
     @Override
     public List<BoardResponseDao> findBoards(
-        BooleanBuilder filter,
-        BooleanBuilder cursorInfo,
-        OrderSpecifier<?>[] orderCondition
+            BooleanBuilder filter,
+            BooleanBuilder cursorInfo,
+            OrderSpecifier<?>[] orderCondition
     ) {
         List<Long> boardIds = jpaQueryFactory.select(board.id)
-            .distinct()
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .where(cursorInfo.and(filter))
-            .orderBy(orderCondition)
-            .limit(BOARD_PAGE_SIZE + 1)
-            .fetch();
+                .distinct()
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .where(cursorInfo.and(filter))
+                .orderBy(orderCondition)
+                .limit(BOARD_PAGE_SIZE + 1)
+                .fetch();
 
         return jpaQueryFactory.select(
-                new QBoardResponseDao(
-                    board.id,
-                    store.id,
-                    store.name,
-                    board.profile,
-                    board.title,
-                    board.price,
-                    product.category,
-                    product.glutenFreeTag,
-                    product.highProteinTag,
-                    product.sugarFreeTag,
-                    product.veganTag,
-                    product.ketogenicTag,
-                    boardStatistic.boardReviewGrade,
-                    boardStatistic.boardReviewCount,
-                    product.orderEndDate,
-                    product.soldout,
-                    board.discountRate
-                ))
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(store)
-            .on(board.store.id.eq(store.id))
-            .join(board.boardStatistic, boardStatistic)
-            .where(board.id.in(boardIds))
-            .orderBy(orderCondition)
-            .fetch();
+                        new QBoardResponseDao(
+                                board.id,
+                                store.id,
+                                store.name,
+                                productImg.url,
+                                board.title,
+                                board.price,
+                                product.category,
+                                product.glutenFreeTag,
+                                product.highProteinTag,
+                                product.sugarFreeTag,
+                                product.veganTag,
+                                product.ketogenicTag,
+                                boardStatistic.boardReviewGrade,
+                                boardStatistic.boardReviewCount,
+                                product.orderEndDate,
+                                product.soldout,
+                                board.discountRate
+                        ))
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(store)
+                .on(board.store.id.eq(store.id))
+                .join(board.boardStatistic, boardStatistic)
+                .innerJoin(productImg).on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
+                .where(board.id.in(boardIds))
+                .orderBy(orderCondition)
+                .fetch();
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/basic/query/RecommendBoardQueryProviderResolver.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/basic/query/RecommendBoardQueryProviderResolver.java
@@ -1,5 +1,7 @@
 package com.bbangle.bbangle.board.repository.basic.query;
 
+import static com.bbangle.bbangle.board.domain.QBoard.board;
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
 import static com.bbangle.bbangle.board.repository.BoardRepositoryImpl.BOARD_PAGE_SIZE;
 
 import com.bbangle.bbangle.board.dao.BoardResponseDao;
@@ -17,7 +19,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class RecommendBoardQueryProviderResolver  implements BoardQueryProvider{
+public class RecommendBoardQueryProviderResolver implements BoardQueryProvider {
 
     private static final QBoard board = QBoard.board;
     private static final QProduct product = QProduct.product;
@@ -28,50 +30,51 @@ public class RecommendBoardQueryProviderResolver  implements BoardQueryProvider{
 
     @Override
     public List<BoardResponseDao> findBoards(
-        BooleanBuilder filter,
-        BooleanBuilder cursorInfo,
-        OrderSpecifier<?>[] orderCondition
+            BooleanBuilder filter,
+            BooleanBuilder cursorInfo,
+            OrderSpecifier<?>[] orderCondition
     ) {
         List<Long> boardIds = jpaQueryFactory.select(board.id)
-            .distinct()
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(board.boardStatistic, boardStatistic)
-            .where(cursorInfo.and(filter))
-            .orderBy(orderCondition)
-            .limit(BOARD_PAGE_SIZE + 1)
-            .fetch();
+                .distinct()
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(board.boardStatistic, boardStatistic)
+                .where(cursorInfo.and(filter))
+                .orderBy(orderCondition)
+                .limit(BOARD_PAGE_SIZE + 1)
+                .fetch();
 
         return jpaQueryFactory.select(
-                new QBoardResponseDao(
-                    board.id,
-                    store.id,
-                    store.name,
-                    board.profile,
-                    board.title,
-                    board.price,
-                    product.category,
-                    product.glutenFreeTag,
-                    product.highProteinTag,
-                    product.sugarFreeTag,
-                    product.veganTag,
-                    product.ketogenicTag,
-                    boardStatistic.boardReviewGrade,
-                    boardStatistic.boardReviewCount,
-                    product.orderEndDate,
-                    product.soldout,
-                    board.discountRate
-                ))
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(store)
-            .on(board.store.id.eq(store.id))
-            .join(board.boardStatistic, boardStatistic)
-            .where(board.id.in(boardIds))
-            .orderBy(orderCondition)
-            .fetch();
+                        new QBoardResponseDao(
+                                board.id,
+                                store.id,
+                                store.name,
+                                productImg.url,
+                                board.title,
+                                board.price,
+                                product.category,
+                                product.glutenFreeTag,
+                                product.highProteinTag,
+                                product.sugarFreeTag,
+                                product.veganTag,
+                                product.ketogenicTag,
+                                boardStatistic.boardReviewGrade,
+                                boardStatistic.boardReviewCount,
+                                product.orderEndDate,
+                                product.soldout,
+                                board.discountRate
+                        ))
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(store)
+                .on(board.store.id.eq(store.id))
+                .join(board.boardStatistic, boardStatistic)
+                .innerJoin(productImg).on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
+                .where(board.id.in(boardIds))
+                .orderBy(orderCondition)
+                .fetch();
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/folder/query/LowPriceBoardQueryProvider.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/folder/query/LowPriceBoardQueryProvider.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.board.repository.folder.query;
 
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
 import static com.bbangle.bbangle.board.repository.BoardRepositoryImpl.BOARD_PAGE_SIZE;
 
 import com.bbangle.bbangle.board.dao.BoardResponseDao;
@@ -17,7 +18,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class LowPriceBoardQueryProvider implements QueryGenerator{
+public class LowPriceBoardQueryProvider implements QueryGenerator {
 
     private static final QBoard board = QBoard.board;
     private static final QProduct product = QProduct.product;
@@ -33,46 +34,47 @@ public class LowPriceBoardQueryProvider implements QueryGenerator{
     @Override
     public List<BoardResponseDao> getBoards() {
         List<Long> fetch = queryFactory
-            .select(board.id)
-            .from(board)
-            .join(wishListBoard)
-            .on(board.id.eq(wishListBoard.boardId))
-            .where(wishListBoard.wishlistFolderId.eq(folder.getId())
-                .and(cursorBuilder))
-            .orderBy(order, wishListBoard.id.desc())
-            .limit(BOARD_PAGE_SIZE + 1L)
-            .fetch();
+                .select(board.id)
+                .from(board)
+                .join(wishListBoard)
+                .on(board.id.eq(wishListBoard.boardId))
+                .where(wishListBoard.wishlistFolderId.eq(folder.getId())
+                        .and(cursorBuilder))
+                .orderBy(order, wishListBoard.id.desc())
+                .limit(BOARD_PAGE_SIZE + 1L)
+                .fetch();
 
         return queryFactory.select(
-                new QBoardResponseDao(
-                    board.id,
-                    store.id,
-                    store.name,
-                    board.profile,
-                    board.title,
-                    board.price,
-                    product.category,
-                    product.glutenFreeTag,
-                    product.highProteinTag,
-                    product.sugarFreeTag,
-                    product.veganTag,
-                    product.ketogenicTag,
-                    boardStatistic.boardReviewGrade,
-                    boardStatistic.boardReviewCount,
-                    product.orderEndDate,
-                    product.soldout,
-                    board.discountRate
-                )).from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(store)
-            .on(board.store.id.eq(store.id))
-            .join(wishListBoard)
-            .on(board.id.eq(wishListBoard.boardId))
-            .join(board.boardStatistic, boardStatistic)
-            .where(board.id.in(fetch))
-            .orderBy(order, wishListBoard.id.desc())
-            .fetch();
+                        new QBoardResponseDao(
+                                board.id,
+                                store.id,
+                                store.name,
+                                productImg.url,
+                                board.title,
+                                board.price,
+                                product.category,
+                                product.glutenFreeTag,
+                                product.highProteinTag,
+                                product.sugarFreeTag,
+                                product.veganTag,
+                                product.ketogenicTag,
+                                boardStatistic.boardReviewGrade,
+                                boardStatistic.boardReviewCount,
+                                product.orderEndDate,
+                                product.soldout,
+                                board.discountRate
+                        )).from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(store)
+                .on(board.store.id.eq(store.id))
+                .join(wishListBoard)
+                .on(board.id.eq(wishListBoard.boardId))
+                .join(board.boardStatistic, boardStatistic)
+                .innerJoin(productImg).on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
+                .where(board.id.in(fetch))
+                .orderBy(order, wishListBoard.id.desc())
+                .fetch();
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/folder/query/PopularBoardQueryProvider.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/folder/query/PopularBoardQueryProvider.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.board.repository.folder.query;
 
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
 import static com.bbangle.bbangle.board.repository.BoardRepositoryImpl.BOARD_PAGE_SIZE;
 
 import com.bbangle.bbangle.board.dao.BoardResponseDao;
@@ -17,7 +18,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class PopularBoardQueryProvider implements QueryGenerator{
+public class PopularBoardQueryProvider implements QueryGenerator {
 
     private static final QBoard board = QBoard.board;
     private static final QProduct product = QProduct.product;
@@ -33,47 +34,48 @@ public class PopularBoardQueryProvider implements QueryGenerator{
     @Override
     public List<BoardResponseDao> getBoards() {
         List<Long> fetch = queryFactory
-            .select(board.id)
-            .from(board)
-            .join(wishListBoard)
-            .on(board.id.eq(wishListBoard.boardId))
-            .join(board.boardStatistic, boardStatistic)
-            .where(wishListBoard.wishlistFolderId.eq(folder.getId())
-                .and(cursorBuilder))
-            .orderBy(order, wishListBoard.id.desc())
-            .limit(BOARD_PAGE_SIZE + 1L)
-            .fetch();
+                .select(board.id)
+                .from(board)
+                .join(wishListBoard)
+                .on(board.id.eq(wishListBoard.boardId))
+                .join(board.boardStatistic, boardStatistic)
+                .where(wishListBoard.wishlistFolderId.eq(folder.getId())
+                        .and(cursorBuilder))
+                .orderBy(order, wishListBoard.id.desc())
+                .limit(BOARD_PAGE_SIZE + 1L)
+                .fetch();
 
         return queryFactory.select(
-                new QBoardResponseDao(
-                    board.id,
-                    store.id,
-                    store.name,
-                    board.profile,
-                    board.title,
-                    board.price,
-                    product.category,
-                    product.glutenFreeTag,
-                    product.highProteinTag,
-                    product.sugarFreeTag,
-                    product.veganTag,
-                    product.ketogenicTag,
-                    boardStatistic.boardReviewGrade,
-                    boardStatistic.boardReviewCount,
-                    product.orderEndDate,
-                    product.soldout,
-                    board.discountRate
-                )).from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(store)
-            .on(board.store.id.eq(store.id))
-            .join(wishListBoard)
-            .on(board.id.eq(wishListBoard.boardId))
-            .join(board.boardStatistic, boardStatistic)
-            .where(board.id.in(fetch).and(wishListBoard.wishlistFolderId.eq(folder.getId())))
-            .orderBy(order, wishListBoard.id.desc())
-            .fetch();
+                        new QBoardResponseDao(
+                                board.id,
+                                store.id,
+                                store.name,
+                                productImg.url,
+                                board.title,
+                                board.price,
+                                product.category,
+                                product.glutenFreeTag,
+                                product.highProteinTag,
+                                product.sugarFreeTag,
+                                product.veganTag,
+                                product.ketogenicTag,
+                                boardStatistic.boardReviewGrade,
+                                boardStatistic.boardReviewCount,
+                                product.orderEndDate,
+                                product.soldout,
+                                board.discountRate
+                        )).from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(store)
+                .on(board.store.id.eq(store.id))
+                .join(wishListBoard)
+                .on(board.id.eq(wishListBoard.boardId))
+                .join(board.boardStatistic, boardStatistic)
+                .innerJoin(productImg).on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
+                .where(board.id.in(fetch).and(wishListBoard.wishlistFolderId.eq(folder.getId())))
+                .orderBy(order, wishListBoard.id.desc())
+                .fetch();
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/folder/query/WishListRecentBoardQueryProvider.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/folder/query/WishListRecentBoardQueryProvider.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.board.repository.folder.query;
 
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
 import static com.bbangle.bbangle.board.repository.BoardRepositoryImpl.BOARD_PAGE_SIZE;
 
 import com.bbangle.bbangle.board.dao.BoardResponseDao;
@@ -17,7 +18,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class WishListRecentBoardQueryProvider implements QueryGenerator{
+public class WishListRecentBoardQueryProvider implements QueryGenerator {
 
     private static final QBoard board = QBoard.board;
     private static final QProduct product = QProduct.product;
@@ -33,47 +34,48 @@ public class WishListRecentBoardQueryProvider implements QueryGenerator{
     @Override
     public List<BoardResponseDao> getBoards() {
         List<Long> fetch = queryFactory
-            .select(board.id)
-            .from(board)
-            .join(wishListBoard)
-            .on(board.id.eq(wishListBoard.boardId))
-            .where(wishListBoard.wishlistFolderId.eq(folder.getId())
-                .and(cursorBuilder))
-            .orderBy(order)
-            .limit(BOARD_PAGE_SIZE + 1L)
-            .fetch();
+                .select(board.id)
+                .from(board)
+                .join(wishListBoard)
+                .on(board.id.eq(wishListBoard.boardId))
+                .where(wishListBoard.wishlistFolderId.eq(folder.getId())
+                        .and(cursorBuilder))
+                .orderBy(order)
+                .limit(BOARD_PAGE_SIZE + 1L)
+                .fetch();
 
         return queryFactory.select(
-                new QBoardResponseDao(
-                    board.id,
-                    store.id,
-                    store.name,
-                    board.profile,
-                    board.title,
-                    board.price,
-                    product.category,
-                    product.glutenFreeTag,
-                    product.highProteinTag,
-                    product.sugarFreeTag,
-                    product.veganTag,
-                    product.ketogenicTag,
-                    boardStatistic.boardReviewGrade,
-                    boardStatistic.boardReviewCount,
-                    product.orderEndDate,
-                    product.soldout,
-                    board.discountRate
-                ))
-            .from(product)
-            .join(board)
-            .on(product.board.id.eq(board.id))
-            .join(store)
-            .on(board.store.id.eq(store.id))
-            .join(wishListBoard)
-            .on(board.id.eq(wishListBoard.boardId))
-            .join(board.boardStatistic, boardStatistic)
-            .where(board.id.in(fetch))
-            .orderBy(order)
-            .fetch();
+                        new QBoardResponseDao(
+                                board.id,
+                                store.id,
+                                store.name,
+                                productImg.url,
+                                board.title,
+                                board.price,
+                                product.category,
+                                product.glutenFreeTag,
+                                product.highProteinTag,
+                                product.sugarFreeTag,
+                                product.veganTag,
+                                product.ketogenicTag,
+                                boardStatistic.boardReviewGrade,
+                                boardStatistic.boardReviewCount,
+                                product.orderEndDate,
+                                product.soldout,
+                                board.discountRate
+                        ))
+                .from(product)
+                .join(board)
+                .on(product.board.id.eq(board.id))
+                .join(store)
+                .on(board.store.id.eq(store.id))
+                .join(wishListBoard)
+                .on(board.id.eq(wishListBoard.boardId))
+                .join(board.boardStatistic, boardStatistic)
+                .innerJoin(productImg).on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
+                .where(board.id.in(fetch))
+                .orderBy(order)
+                .fetch();
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -62,7 +62,7 @@ public enum BbangleErrorCode {
     INVALID_PRODUCT_DELIVERY_DAY(-47, "가능한 발송 요일이 하나라도 있어야 합니다. ", BAD_REQUEST),
     INVALID_PRODUCT_NAME(-48, "상품 이름은 3글자 이상 50글자 이하여야 합니다.", BAD_REQUEST),
     INVALID_PRODUCT_INFO_NOTICE_NAME(-49, "상품 정보 제공 이름은 3글자 이상 50글자 이하여야 합니다.", BAD_REQUEST),
-
+    BOARD_WITH_IMAGE_NOTFOUND(-50, "상품 이미지가 없는 게시글이 존재합니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     UPLOAD_STREAM_CLOSE_ERROR(-51, "파일 업로드 중 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     NULL_INPUT_STREAM(-52, "파일이 유효하지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/push/repository/PushQueryDSLRepositoryImpl.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import static com.bbangle.bbangle.board.domain.QBoard.board;
 import static com.bbangle.bbangle.board.domain.QProduct.product;
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
 import static com.bbangle.bbangle.member.domain.QMember.member;
 import static com.bbangle.bbangle.push.domain.QPush.push;
 import static com.bbangle.bbangle.store.domain.QStore.store;
@@ -39,13 +40,14 @@ public class PushQueryDSLRepositoryImpl implements PushQueryDSLRepository {
                         product.id,
                         store.name,
                         product.title,
-                        board.profile,
+                        productImg.url,
                         push.isActive
                 ))
                 .from(push)
                 .join(product).on(push.productId.eq(product.id))
                 .join(board).on(product.board.id.eq(board.id))
                 .join(store).on(board.store.id.eq(store.id))
+                .innerJoin(productImg).on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
                 .where(commonFilter(memberId, null, pushCategory))
                 .fetch();
     }

--- a/src/main/java/com/bbangle/bbangle/search/dto/SearchBoardResponseDto.java
+++ b/src/main/java/com/bbangle/bbangle/search/dto/SearchBoardResponseDto.java
@@ -24,10 +24,11 @@ public class SearchBoardResponseDto {
     Boolean isWished;
 
     public SearchBoardResponseDto(Board board) {
+
         this.boardId = board.getId();
         this.storeId = board.getStore().getId();
         this.storeName = board.getStore().getName();
-        this.thumbnail = board.getProfile();
+        this.thumbnail = board.getThumbnail();
         this.title = board.getTitle();
         this.price = board.getPrice();
         this.isBundled = board.isBundled();

--- a/src/main/java/com/bbangle/bbangle/wishlist/repository/impl/WishListFolderRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/repository/impl/WishListFolderRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.bbangle.bbangle.wishlist.repository.impl;
 
 
+import static com.bbangle.bbangle.board.domain.QProductImg.productImg;
+
 import com.bbangle.bbangle.board.domain.QBoard;
 import com.bbangle.bbangle.wishlist.domain.QWishListBoard;
 import com.bbangle.bbangle.wishlist.domain.QWishListFolder;
@@ -34,51 +36,53 @@ public class WishListFolderRepositoryImpl implements WishListFolderQueryDSLRepos
     @Override
     public List<FolderResponseDto> findMemberFolderList(Member member) {
         List<Tuple> fetch = queryFactory.select(
-                wishListFolder.id,
-                wishListFolder.folderName,
-                board.profile)
-            .from(wishListFolder)
-            .leftJoin(wishedBoard)
-            .on(wishedBoard.wishlistFolderId.eq(wishListFolder.id))
-            .leftJoin(board)
-            .on(wishedBoard.boardId.eq(board.id))
-            .where(wishListFolder.member.eq(member)
-                .and(wishListFolder.isDeleted.eq(false)))
-            .fetch();
+                        wishListFolder.id,
+                        wishListFolder.folderName,
+                        productImg.url)
+                .from(wishListFolder)
+                .leftJoin(wishedBoard)
+                .on(wishedBoard.wishlistFolderId.eq(wishListFolder.id))
+                .leftJoin(board)
+                .on(wishedBoard.boardId.eq(board.id))
+                .innerJoin(productImg)
+                .on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
+                .where(wishListFolder.member.eq(member)
+                        .and(wishListFolder.isDeleted.eq(false)))
+                .fetch();
 
         Map<Long, List<Tuple>> groupedByFolderId = fetch.stream()
-            .collect(Collectors.groupingBy(tuple -> tuple.get(wishListFolder.id)));
+                .collect(Collectors.groupingBy(tuple -> tuple.get(wishListFolder.id)));
 
         List<FolderResponseDto> response = groupedByFolderId.entrySet()
-            .stream()
-            .map(entry -> {
-                Long folderId = entry.getKey();
-                List<Tuple> tuples = entry.getValue();
+                .stream()
+                .map(entry -> {
+                    Long folderId = entry.getKey();
+                    List<Tuple> tuples = entry.getValue();
 
-                String title = tuples.get(0)
-                    .get(wishListFolder.folderName);
+                    String title = tuples.get(0)
+                            .get(wishListFolder.folderName);
 
-                List<String> productImages = tuples.stream()
-                    .map(tuple -> tuple.get(board.profile))
-                    .filter(Objects::nonNull)
-                    .limit(4)
-                    .toList();
+                    List<String> productImages = tuples.stream()
+                            .map(tuple -> tuple.get(productImg.url))
+                            .filter(Objects::nonNull)
+                            .limit(4)
+                            .toList();
 
-                int count = productImages.isEmpty() ? 0 : (int) tuples.stream()
-                    .map(tuple -> tuple.get(board.profile))
-                    .filter(Objects::nonNull)
-                    .count();
+                    int count = productImages.isEmpty() ? 0 : (int) tuples.stream()
+                            .map(tuple -> tuple.get(productImg.url))
+                            .filter(Objects::nonNull)
+                            .count();
 
-                return new FolderResponseDto(folderId, title, count, productImages);
-            })
-            .sorted(Comparator.comparing(FolderResponseDto::folderId)
-                .reversed())
-            .collect(Collectors.toList());
+                    return new FolderResponseDto(folderId, title, count, productImages);
+                })
+                .sorted(Comparator.comparing(FolderResponseDto::folderId)
+                        .reversed())
+                .collect(Collectors.toList());
 
         FolderResponseDto defaultFolder = response.stream()
-            .filter(folderResponse -> DEFAULT_FOLDER_NAME.equals(folderResponse.title()))
-            .findFirst()
-            .orElse(null);
+                .filter(folderResponse -> DEFAULT_FOLDER_NAME.equals(folderResponse.title()))
+                .findFirst()
+                .orElse(null);
 
         if (defaultFolder != null) {
             response.remove(defaultFolder);
@@ -92,9 +96,9 @@ public class WishListFolderRepositoryImpl implements WishListFolderQueryDSLRepos
     public List<WishListFolder> findByMemberId(Long memberId) {
 
         return queryFactory.selectFrom(wishListFolder)
-            .where(wishListFolder.member.id.eq(memberId)
-                .and(wishListFolder.isDeleted.eq(false)))
-            .fetch();
+                .where(wishListFolder.member.id.eq(memberId)
+                        .and(wishListFolder.isDeleted.eq(false)))
+                .fetch();
     }
 
 }


### PR DESCRIPTION
### Task1

**문제점**

- 대표 썸네일은 board.profile에
- 나머지 썸네일은 prodct_img 테이블에
- 위 방식은 이미지를 한  테이블에 관리하지 않아 데이터 관리 및 개발 복잡성이 늘어남
    - `product_img`에는 대표 썸네일이 없고, `board.profile`에는 일반 썸네일이 없음. 데이터를 조작할 때 일관성을 유지하기 어려움.

**개선 방향**

- board.profile을 없애고
- product_img 테이블에 상품 이미지(상품 상세 페이지 이미지 x)들을 모두 저장

**개선 후 **

- 20여개 쿼리문 변경(board.profile → product_img.url  join product_img on img_index = 0으로)


### Task2

**문제점**
- BoardDetailService.getBoardDtos() 함수에서 쿼리 반환값인 DTO에서 최종 Response로 변하는 과정이 직관적이지 않음

**개선 결과물 과정**

1. BoardDTOS -> BoardResponses
  - 위 과정에서 썸네일과 썸네일 아닌 이미지 구분
  - 서비스 코드에서는 이과정을 몰라도 됨
 
2. Responses와 다른 부가적인 정보들(위시리스트유무, 상세페이지 내용)을 합쳐서 최종 Response로 만듬


---
pr 보실 때 파일 양이 많아 커밋 별로 나눠서 보시는 것을 추천합니다
