### PR TITLE
쿼리 처리시간 측정 및 로깅 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,9 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok-mapstruct-binding:0.2.0"
     implementation 'org.mapstruct:mapstruct:1.5.3.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+
+    // database proxy
+    implementation 'net.ttddyy:datasource-proxy:1.10.1'
 }
 
 // Querydsl 설정부

--- a/src/main/java/com/bbangle/bbangle/common/querylistener/CustomQueryLoggingListener.java
+++ b/src/main/java/com/bbangle/bbangle/common/querylistener/CustomQueryLoggingListener.java
@@ -1,0 +1,41 @@
+package com.bbangle.bbangle.common.querylistener;
+
+import lombok.extern.slf4j.Slf4j;
+import net.ttddyy.dsproxy.ExecutionInfo;
+import net.ttddyy.dsproxy.QueryInfo;
+import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+
+import java.util.List;
+
+@Slf4j
+public class CustomQueryLoggingListener implements QueryExecutionListener {
+
+    @Override
+    public void beforeQuery(ExecutionInfo execInfo, List<QueryInfo> queryList) {
+
+    }
+
+    @Override
+    public void afterQuery(ExecutionInfo execInfo, List<QueryInfo> queryList) {
+        QueryTimerContext.addTime(execInfo.getElapsedTime());
+        long time = execInfo.getElapsedTime();
+        boolean success = execInfo.isSuccess();
+
+        for (QueryInfo query : queryList) {
+            String sql = query.getQuery();
+
+            List<List<String>> allParams = query.getParametersList().stream()
+                    .map(params -> params.stream()
+                            .map(p -> String.valueOf(p.getArgs()[1]))
+                            .toList())
+                    .toList();
+
+            log.debug("""
+                    
+                    - 쿼리문      : {}
+                    - 쿼리파라미터 : {}
+                    - 성공여부    : {}
+                    - 처리시간    : {}ms""", sql, allParams, success, time);
+        }
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/common/querylistener/QueryTimerContext.java
+++ b/src/main/java/com/bbangle/bbangle/common/querylistener/QueryTimerContext.java
@@ -1,0 +1,19 @@
+package com.bbangle.bbangle.common.querylistener;
+
+public class QueryTimerContext {
+
+    private static final ThreadLocal<Long> totalTime = ThreadLocal.withInitial(() -> 0L);
+
+    public static void addTime(long millis) {
+        totalTime.set(totalTime.get() + millis);
+    }
+
+    public static long getTotalTime() {
+        return totalTime.get();
+    }
+
+    public static void clear() {
+        totalTime.remove();
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/config/DataSourceProxyConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/DataSourceProxyConfig.java
@@ -1,0 +1,32 @@
+package com.bbangle.bbangle.config;
+
+import com.bbangle.bbangle.common.querylistener.CustomQueryLoggingListener;
+import com.zaxxer.hikari.HikariDataSource;
+import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import javax.sql.DataSource;
+
+@Configuration
+@Profile("!test")
+public class DataSourceProxyConfig {
+
+    @Bean
+    public DataSource dataSource(DataSourceProperties properties) {
+        HikariDataSource hikari = properties
+                .initializeDataSourceBuilder()
+                .type(HikariDataSource.class)
+                .build();
+
+        return ProxyDataSourceBuilder
+                .create(hikari)
+                .name("DB-Logger")
+                .listener(new CustomQueryLoggingListener())
+                .countQuery()
+                .multiline()
+                .build();
+    }
+}


### PR DESCRIPTION
### 🚀 Major Changes & Explanations

* **요청 단위 처리시간 측정 기능 추가**

  * `RequestTimeInterceptor`를 통해 HTTP 요청 시작 시점부터 종료까지의 시간을 측정
  * DB 쿼리 수행 시간을 합산한 `QueryTimerContext` 정보를 함께 로그로 출력
  * 슬랙 알림 메세지 수정

* **Datasource-proxy 도입**

  * `net.ttddyy:datasource-proxy` 라이브러리를 도입하여 JDBC 쿼리 실행 시간 측정 및 로깅
  * `CustomQueryLoggingListener`를 통해 쿼리문, 파라미터, 성공 여부, 소요 시간 등을 debug 로그로 출력
  * 쿼리 수행 시간은 `QueryTimerContext`에 누적되어 인터셉터에서 총 DB 처리 시간으로 활용됨

* **DataSource 프록시 설정**

  * `DataSourceProxyConfig`에서 `HikariDataSource`를 감싼 `ProxyDataSource`를 생성
  * 테스트 환경(`!test`) 제외

---

### 📦 Example Log (느린 요청 시)

```
- API           : GET /api/v1/board
- 총 DB 처리 시간 : 1850 ms
- 총 처리시간     : 3623 ms
```

쿼리별 debug 로그 예시:

```
- 쿼리문      : SELECT * FROM board WHERE id = ?
- 쿼리파라미터 : [[123]]
- 성공여부    : true
- 처리시간    : 87ms
```

---

### 💡 ETC

* 추후 슬로우 쿼리 기준을 설정해 별도 추적하거나, 특정 경로 필터링도 가능
* 테스트 환경 제외

---
