### PR TITLE
[Fix] 위시리스트 최근순 조회 조인 누락 수정

### DIFF
--- a/src/main/java/com/bbangle/bbangle/wishlist/repository/sort/strategy/RecentBoardInFolderSortRepository.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/repository/sort/strategy/RecentBoardInFolderSortRepository.java
@@ -26,8 +26,11 @@ public class RecentBoardInFolderSortRepository implements BoardInFolderSortRepos
         return queryFactory.select(board.id)
                 .distinct()
                 .from(product)
-                .join(board)
-                .on(product.board.id.eq(board.id))
+                .join(board).on(product.board.id.eq(board.id))
+                .join(wishListBoard).on(
+                        board.id.eq(wishListBoard.boardId)
+                                .and(wishListBoard.wishlistFolderId.eq(folderId))
+                )
                 .where(getCursorCondition(cursorId))
                 .orderBy(getSortOrders())
                 .limit(BOARD_PAGE_SIZE + 1)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4982e384-77b1-4729-9ac7-2cab72426e24)


브랜치명은 무시해주세요! 