### PR TITLE
게시글 조회 기본 제한 값 변경

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/controller/BoardController.java
+++ b/src/main/java/com/bbangle/bbangle/board/controller/BoardController.java
@@ -13,10 +13,11 @@ import com.bbangle.bbangle.common.page.CursorPageResponse;
 import com.bbangle.bbangle.common.page.CursorPagination;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.search.controller.mapper.SearchMapper;
-import com.bbangle.bbangle.search.facade.SearchFacade;
 import com.bbangle.bbangle.search.service.dto.SearchCommand;
 import com.bbangle.bbangle.search.service.dto.SearchInfo;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,25 +46,31 @@ public class BoardController {
     }
 
 
-        @Operation(summary = "게시글 전체 조회")
-        @GetMapping
-        public CommonResult getList(
+    @Operation(summary = "게시글 전체 조회")
+    @GetMapping
+    public CommonResult getList(
             @ParameterObject
             FilterRequest filterRequest,
             @RequestParam(required = false, defaultValue = "RECOMMEND")
             SortType sort,
             @RequestParam(required = false)
             Long cursorId,
+            @Parameter(
+                    description = "최대 30까지 입력 가능합니다.",
+                    schema = @Schema(defaultValue = "30", maximum = "30")
+            )
+            @RequestParam(required = false, defaultValue = "30")
+            Long limitSize,
             @AuthenticationPrincipal
             Long memberId
-        ) {
-                SearchCommand.Main command = searchMapper.toSearchMain(filterRequest, sort, null, cursorId, memberId);
-                CursorPagination<SearchInfo.Select> searchBoardPage = boardFacade.getBoardList(command);
-                return responseService.getSingleResult(searchBoardPage);
-        }
+    ) {
+        SearchCommand.Main command = searchMapper.toSearchMain(filterRequest, sort, null, cursorId, memberId, limitSize);
+        CursorPagination<SearchInfo.Select> searchBoardPage = boardFacade.getBoardList(command);
+        return responseService.getSingleResult(searchBoardPage);
+    }
 
-        @GetMapping("/folders/{folderId}")
-        public CommonResult getPostInFolder(
+    @GetMapping("/folders/{folderId}")
+    public CommonResult getPostInFolder(
             @RequestParam(required = false, value = "sort")
             FolderBoardSortType sort,
             @PathVariable(value = "folderId")
@@ -72,13 +79,13 @@ public class BoardController {
             Long cursorId,
             @AuthenticationPrincipal
             Long memberId
-        ) {
-                if (sort == null) {
-                        sort = FolderBoardSortType.WISHLIST_RECENT;
-                }
-                CursorPageResponse<BoardResponse> boardResponseDto = boardService.getPostInFolder(
-                    memberId, sort, folderId, cursorId);
-                return responseService.getSingleResult(boardResponseDto);
+    ) {
+        if (sort == null) {
+            sort = FolderBoardSortType.WISHLIST_RECENT;
         }
+        CursorPageResponse<BoardResponse> boardResponseDto = boardService.getPostInFolder(
+                memberId, sort, folderId, cursorId);
+        return responseService.getSingleResult(boardResponseDto);
+    }
 }
 

--- a/src/main/java/com/bbangle/bbangle/board/facade/BoardFacade.java
+++ b/src/main/java/com/bbangle/bbangle/board/facade/BoardFacade.java
@@ -5,6 +5,7 @@ import com.bbangle.bbangle.search.service.SearchService;
 import com.bbangle.bbangle.search.service.dto.SearchCommand;
 import com.bbangle.bbangle.search.service.dto.SearchInfo;
 import com.bbangle.bbangle.wishlist.service.WishListBoardService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,13 +15,13 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class BoardFacade {
-        private final SearchService searchService;
-        private final WishListBoardService wishListBoardService;
+    private final SearchService searchService;
+    private final WishListBoardService wishListBoardService;
 
-        @Transactional(readOnly = true)
-        public CursorPagination<SearchInfo.Select> getBoardList(SearchCommand.Main command) {
-                SearchInfo.BoardsInfo boardsInfo = searchService.getBoardList(command);
-                Map<Long, Boolean> boardWishedMap = wishListBoardService.getBoardWishedMap(command.memberId(), boardsInfo.getBoards());
-                return searchService.convertBoardsToCursorPagination(boardsInfo, boardWishedMap);
-        }
+    @Transactional(readOnly = true)
+    public CursorPagination<SearchInfo.Select> getBoardList(@Valid SearchCommand.Main command) {
+        SearchInfo.BoardsInfo boardsInfo = searchService.getBoardList(command);
+        Map<Long, Boolean> boardWishedMap = wishListBoardService.getBoardWishedMap(command.memberId(), boardsInfo.getBoards());
+        return searchService.convertBoardsToCursorPagination(boardsInfo, boardWishedMap);
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/search/controller/SearchController.java
+++ b/src/main/java/com/bbangle/bbangle/search/controller/SearchController.java
@@ -1,7 +1,7 @@
 package com.bbangle.bbangle.search.controller;
 
-import com.bbangle.bbangle.board.dto.FilterRequest;
 import com.bbangle.bbangle.board.constant.SortType;
+import com.bbangle.bbangle.board.dto.FilterRequest;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.page.CursorPagination;
@@ -12,6 +12,8 @@ import com.bbangle.bbangle.search.facade.SearchFacade;
 import com.bbangle.bbangle.search.service.SearchService;
 import com.bbangle.bbangle.search.service.dto.SearchCommand;
 import com.bbangle.bbangle.search.service.dto.SearchInfo.Select;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
@@ -26,13 +28,13 @@ import java.util.List;
 @RequestMapping("api/v1/search")
 public class SearchController {
 
-        private final SearchService searchService;
-        private final ResponseService responseService;
-        private final SearchMapper searchMapper;
-        private final SearchFacade searchFacade;
+    private final SearchService searchService;
+    private final ResponseService responseService;
+    private final SearchMapper searchMapper;
+    private final SearchFacade searchFacade;
 
-        @GetMapping("/boards")
-        public SingleResult<CursorPagination<Select>> getList(
+    @GetMapping("/boards")
+    public SingleResult<CursorPagination<Select>> getList(
             @ParameterObject
             FilterRequest filterRequest,
             @RequestParam(required = false, defaultValue = "RECOMMEND", value = "sort")
@@ -41,59 +43,65 @@ public class SearchController {
             String keyword,
             @RequestParam(required = false, value = "cursorId")
             Long cursorId,
+            @Parameter(
+                    description = "최대 30까지 입력 가능합니다.",
+                    schema = @Schema(defaultValue = "30", maximum = "30")
+            )
+            @RequestParam(required = false, defaultValue = "30")
+            Long limitSize,
             @AuthenticationPrincipal
             Long memberId
-        ) {
-                SearchCommand.Main command = searchMapper.toSearchMain(filterRequest, sort, keyword, cursorId, memberId);
-                CursorPagination<Select> searchBoardPage = searchFacade.getBoardList(command);
-                return responseService.getSingleResult(searchBoardPage);
-        }
+    ) {
+        SearchCommand.Main command = searchMapper.toSearchMain(filterRequest, sort, keyword, cursorId, memberId, limitSize);
+        CursorPagination<Select> searchBoardPage = searchFacade.getBoardList(command);
+        return responseService.getSingleResult(searchBoardPage);
+    }
 
 
-        @PostMapping
-        public CommonResult saveKeyword(
+    @PostMapping
+    public CommonResult saveKeyword(
             @RequestParam("keyword")
             String keyword,
             @AuthenticationPrincipal
             Long memberId
-        ) {
-                searchService.saveKeyword(memberId, keyword);
-                return responseService.getSuccessResult();
-        }
+    ) {
+        searchService.saveKeyword(memberId, keyword);
+        return responseService.getSuccessResult();
+    }
 
-        @GetMapping("/recency")
-        public CommonResult getRecencyKeyword(
+    @GetMapping("/recency")
+    public CommonResult getRecencyKeyword(
             @AuthenticationPrincipal
             Long memberId
-        ) {
-                RecencySearchResponse recencyKeyword = searchService.getRecencyKeyword(memberId);
-                return responseService.getSingleResult(recencyKeyword);
-        }
+    ) {
+        RecencySearchResponse recencyKeyword = searchService.getRecencyKeyword(memberId);
+        return responseService.getSingleResult(recencyKeyword);
+    }
 
-        @DeleteMapping("/recency")
-        public CommonResult deleteRecencyKeyword(
+    @DeleteMapping("/recency")
+    public CommonResult deleteRecencyKeyword(
             @RequestParam(value = "keyword")
             String keyword,
             @AuthenticationPrincipal
             Long memberId
-        ) {
-                searchService.deleteRecencyKeyword(keyword, memberId);
+    ) {
+        searchService.deleteRecencyKeyword(keyword, memberId);
 
-                return responseService.getSuccessResult();
-        }
+        return responseService.getSuccessResult();
+    }
 
-        @GetMapping("/best-keyword")
-        public CommonResult getBestKeyword() {
-                List<String> bestKeywords = searchService.getBestKeyword();
-                return responseService.getListResult(bestKeywords);
-        }
+    @GetMapping("/best-keyword")
+    public CommonResult getBestKeyword() {
+        List<String> bestKeywords = searchService.getBestKeyword();
+        return responseService.getListResult(bestKeywords);
+    }
 
-        @GetMapping("/auto-keyword")
-        public CommonResult getAutoKeyword(
+    @GetMapping("/auto-keyword")
+    public CommonResult getAutoKeyword(
             @RequestParam("keyword")
             String keyword
-        ) {
-                List<String> autoKeywords = searchService.getAutoKeyword(keyword);
-                return responseService.getListResult(autoKeywords);
-        }
+    ) {
+        List<String> autoKeywords = searchService.getAutoKeyword(keyword);
+        return responseService.getListResult(autoKeywords);
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/search/controller/mapper/SearchMapper.java
+++ b/src/main/java/com/bbangle/bbangle/search/controller/mapper/SearchMapper.java
@@ -1,7 +1,7 @@
 package com.bbangle.bbangle.search.controller.mapper;
 
-import com.bbangle.bbangle.board.dto.FilterRequest;
 import com.bbangle.bbangle.board.constant.SortType;
+import com.bbangle.bbangle.board.dto.FilterRequest;
 import com.bbangle.bbangle.search.service.dto.SearchCommand;
 import org.mapstruct.*;
 
@@ -14,16 +14,22 @@ import java.util.Objects;
 )
 public interface SearchMapper {
 
+    @Mapping(target = "limitSize", source = "limitSize", qualifiedByName = "limitSize")
     @Mapping(target = "isExcludedProduct", expression = "java(isExcludedProduct(memberId, sort))")
     @Mapping(target = "sort", source = "sort")
     @Mapping(target = "keyword", source = "keyword")
     @Mapping(target = "filterRequest", source = "filterRequest")
     @Mapping(target = "cursorId", source = "cursorId")
     @Mapping(target = "memberId", source = "memberId")
-    SearchCommand.Main toSearchMain(FilterRequest filterRequest, SortType sort, String keyword, Long cursorId, Long memberId);
+    SearchCommand.Main toSearchMain(FilterRequest filterRequest, SortType sort, String keyword, Long cursorId, Long memberId, Long limitSize);
 
     @Named("isExcludedProduct")
     default Boolean isExcludedProduct(Long memberId, SortType sort) {
         return Objects.nonNull(memberId) && sort.equals(SortType.RECOMMEND);
+    }
+
+    @Named("limitSize")
+    default long limitSize(Long limitSize) {
+        return limitSize > 31 ? 30 : limitSize;
     }
 }

--- a/src/main/java/com/bbangle/bbangle/search/service/dto/SearchCommand.java
+++ b/src/main/java/com/bbangle/bbangle/search/service/dto/SearchCommand.java
@@ -1,7 +1,7 @@
 package com.bbangle.bbangle.search.service.dto;
 
-import com.bbangle.bbangle.board.dto.FilterRequest;
 import com.bbangle.bbangle.board.constant.SortType;
+import com.bbangle.bbangle.board.dto.FilterRequest;
 
 public class SearchCommand {
 
@@ -11,9 +11,9 @@ public class SearchCommand {
             String keyword,
             Long cursorId,
             Long memberId,
-            Boolean isExcludedProduct
+            Boolean isExcludedProduct,
+            Integer limitSize
     ) {
-
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/search/service/dto/SearchInfo.java
+++ b/src/main/java/com/bbangle/bbangle/search/service/dto/SearchInfo.java
@@ -15,70 +15,71 @@ import java.util.Map;
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 public class SearchInfo {
 
-        @Data
-        public static class BoardsInfo {
-                List<Board> boards;
-                Long boardCount;
-                Map<Long, Boolean> boardWishedMap;
+    @Data
+    public static class BoardsInfo {
+        List<Board> boards;
+        Long boardCount;
+        int boardLimitSize;
+        Map<Long, Boolean> boardWishedMap;
 
-                @Default
-                public BoardsInfo(
-                    List<Board> boards,
-                    Long boardCount
-                ) {
-                        this.boards = boards;
-                        this.boardCount = boardCount;
-                }
+        @Default
+        public BoardsInfo(
+                List<Board> boards,
+                Long boardCount
+        ) {
+            this.boards = boards;
+            this.boardCount = boardCount;
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class Select {
+        private Long boardId;
+        private Long storeId;
+        private String storeName;
+        private String thumbnail;
+        private String title;
+        private Integer price;
+        private Boolean isBundled;
+        private List<String> tags;
+        private BigDecimal reviewRate;
+        private Long reviewCount;
+        private Boolean isBbangcketing;
+        private Boolean isSoldOut;
+        private Integer discountRate;
+        private Boolean isWished;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class SearchBoardPage {
+        private List<SearchInfo.Select> boards;
+        private Long allItemCount;
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class CursorCondition {
+        private Long cursorId;
+        private Double boardBasicScore;
+        private Integer price;
+        private Long boardWishedCount;
+        private Long boardReviewCount;
+
+        @QueryProjection
+        public CursorCondition(Long cursorId, Double boardBasicScore, Integer price, Long boardWishedCount, Long boardReviewCount) {
+            this.cursorId = cursorId;
+            this.boardBasicScore = boardBasicScore;
+            this.price = price;
+            this.boardWishedCount = boardWishedCount;
+            this.boardReviewCount = boardReviewCount;
         }
 
-        @Data
-        @AllArgsConstructor
-        public static class Select {
-                private Long boardId;
-                private Long storeId;
-                private String storeName;
-                private String thumbnail;
-                private String title;
-                private Integer price;
-                private Boolean isBundled;
-                private List<String> tags;
-                private BigDecimal reviewRate;
-                private Long reviewCount;
-                private Boolean isBbangcketing;
-                private Boolean isSoldOut;
-                private Integer discountRate;
-                private Boolean isWished;
+        public static CursorCondition empty() {
+            return new CursorCondition(Long.MAX_VALUE, 0.0, 0, 0L, 0L);
         }
 
-        @Data
-        @AllArgsConstructor
-        public static class SearchBoardPage {
-                private List<SearchInfo.Select> boards;
-                private Long allItemCount;
-        }
-
-        @Data
-        @NoArgsConstructor
-        public static class CursorCondition {
-                private Long cursorId;
-                private Double boardBasicScore;
-                private Integer price;
-                private Long boardWishedCount;
-                private Long boardReviewCount;
-
-                @QueryProjection
-                public CursorCondition(Long cursorId, Double boardBasicScore, Integer price, Long boardWishedCount, Long boardReviewCount) {
-                        this.cursorId = cursorId;
-                        this.boardBasicScore = boardBasicScore;
-                        this.price = price;
-                        this.boardWishedCount = boardWishedCount;
-                        this.boardReviewCount = boardReviewCount;
-                }
-
-                public static CursorCondition empty() {
-                        return new CursorCondition(Long.MAX_VALUE, 0.0, 0, 0L, 0L);
-                }
-
-        }
+    }
 
 }

--- a/src/main/java/com/bbangle/bbangle/search/service/mapper/SearchInfoMapper.java
+++ b/src/main/java/com/bbangle/bbangle/search/service/mapper/SearchInfoMapper.java
@@ -32,7 +32,8 @@ public interface SearchInfoMapper {
     @Mapping(target = "discountRate", source = "board.discountRate")
     SearchInfo.Select toSearchSelectInfo(Board board, Boolean isWished);
 
+    @Mapping(target = "boardLimitSize", source = "limitSize")
     @Mapping(target = "boardWishedMap", ignore = true)
-    SearchInfo.BoardsInfo toBoardsInfo(List<Board> boards, Long boardCount);
+    SearchInfo.BoardsInfo toBoardsInfo(List<Board> boards, Long boardCount, int limitSize);
 
 }


### PR DESCRIPTION
**변경 배경**
- 기존 10개 단위 제한으로 인해 백엔드 요청이 과도하게 발생함
- API 호출 속도가 느린 상황에서 자주 호출되면서 성능 저하가 심화됨
- 이를 완화하기 위해 기본 조회 개수를 30개로 확장하여 요청 빈도 감소

**주요 변경 사항**
- 기존의 BOARD_PAGE_SIZE_PLUS_ONE = 11에서 동적으로 command.limitSize() + 1을 적용
- 프론트 기본 요청 limit을 30로 설정하여 실제 화면에 노출