### PR TITLE
[Fix] 위시리스트 조회 이미지와 left join으로 수정

### DIFF
--- a/src/main/java/com/bbangle/bbangle/wishlist/repository/WishListFolderRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/repository/WishListFolderRepositoryImpl.java
@@ -43,7 +43,7 @@ public class WishListFolderRepositoryImpl implements WishListFolderQueryDSLRepos
                 .on(wishedBoard.wishlistFolderId.eq(wishListFolder.id))
                 .leftJoin(board)
                 .on(wishedBoard.boardId.eq(board.id))
-                .innerJoin(productImg)
+                .leftJoin(productImg)
                 .on(board.id.eq(productImg.board.id).and(productImg.imgOrder.eq(0)))
                 .where(wishListFolder.member.eq(member)
                         .and(wishListFolder.isDeleted.eq(false)))


### PR DESCRIPTION

- inner join으로서 상품이미지가 없으면 조회가 안됐습니다.
- left join으로 오류 수정