### PR TITLE
프로필 삭제 에러 수정

### DIFF
--- a/src/main/java/com/bbangle/bbangle/member/domain/Member.java
+++ b/src/main/java/com/bbangle/bbangle/member/domain/Member.java
@@ -146,6 +146,10 @@ public class Member extends BaseEntity implements UserDetails {
         this.nickname = request.nickname();
     }
 
+    public void clearProfile() {
+        updateProfile(null);
+    }
+
     public void updateProfile(String imgUrl) {
         this.profile = imgUrl;
     }

--- a/src/main/java/com/bbangle/bbangle/member/service/ProfileServiceImpl.java
+++ b/src/main/java/com/bbangle/bbangle/member/service/ProfileServiceImpl.java
@@ -42,10 +42,14 @@ public class ProfileServiceImpl implements ProfileService {
     ) {
         Member member = profileRepository.findById(memberId)
             .orElseThrow(() -> new BbangleException(NOTFOUND_MEMBER));
+
         if (profileImg != null && !profileImg.isEmpty()) {
             String imgUrl = imageService.save(MEMBER_PROFILE, profileImg, memberId);
             member.updateProfile(imgUrl);
+        } else {
+            member.clearProfile();
         }
+
         member.update(request);
     }
 


### PR DESCRIPTION
## History
- 프로필 삭제 후 수정 시 프로필 삭제가 안되고 있음
- else문 추가로 이미지에 대한 내용이 없을 경우 null 처리