### PR TITLE
[Fix] No constructor found ERROR 수정  

### DIFF
--- a/src/main/java/com/bbangle/bbangle/member/dto/MemberIdWithRoleDto.java
+++ b/src/main/java/com/bbangle/bbangle/member/dto/MemberIdWithRoleDto.java
@@ -2,12 +2,11 @@ package com.bbangle.bbangle.member.dto;
 
 import com.bbangle.bbangle.member.domain.Member;
 import com.bbangle.bbangle.member.domain.Role;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class MemberIdWithRoleDto {
 
     private Long memberId;


### PR DESCRIPTION
## 🚀 Major Changes & Explanations
- projection  DTO 클래스 생성자 접근제어자 수정 `private` => `public`

에러 로그 
```
No constructor found for class com.bbangle.bbangle.member.dto.MemberIdWithRoleDto with parameters: [class java.lang.Long, class com.bbangle.bbangle...
- url: /api/v1/oauth/login/kakao
- 위치: com.bbangle.bbangle.member.repository.MemberRepositoryImpl, findByProviderAndProviderId
- message: No constructor found for class com.bbangle.bbangle.member.dto.MemberIdWithRoleDto with parameters: [class java.lang.Long, class com.bbangle.bbangle.member.domain.Role]
```
