### PR TITLE
Review Content 컬럼 타입 수정

### DIFF
--- a/src/main/resources/flyway/V16__app.sql
+++ b/src/main/resources/flyway/V16__app.sql
@@ -1,0 +1,1 @@
+ALTER TABLE review MODIFY content TEXT;


### PR DESCRIPTION
✅ 변경 사항
- review 테이블의 content 컬럼 타입을 VARCHAR(255) → TEXT로 변경

📝 변경 배경
- 사용자 리뷰 작성 시 255자를 초과하는 내용이 저장되지 않아 오류가 발생함
(Data too long for column 'content' at row 1)
- 리뷰는 사용자의 자유로운 의견을 담는 필드로, 자유로운 길이의 입력이 필요
- 이에 따라 TEXT 타입으로 변경하여 충분한 분량의 리뷰 저장을 허용함

⚠️ 참고 사항
- 자바 엔티티 필드 타입은 기존과 동일하게 String을 유지
- 데이터 저장 로직 및 응답 구조에는 영향 없음