### PR TITLE
[Fix] PreferenceType.NONE 추가로  프론트 요청 대응

### DIFF
--- a/src/main/java/com/bbangle/bbangle/preference/domain/PreferenceType.java
+++ b/src/main/java/com/bbangle/bbangle/preference/domain/PreferenceType.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum PreferenceType {
+    NONE("선택안함", PreferenceType::calculateNoneScore),
     DIET("다이어트", PreferenceType::calculateDietOrMuscleGrowScore),
     MUSCLE_GROW("근육 증가", PreferenceType::calculateDietOrMuscleGrowScore),
     CONSTITUTION("체질 개선", PreferenceType::calculateAllergyScore),
@@ -25,6 +26,10 @@ public enum PreferenceType {
 
     public int getCalculatedScore(TagsDao tags){
         return function.apply(tags);
+    }
+
+    private static int calculateNoneScore(TagsDao tags) {
+        return 0;
     }
 
     private static int calculateDietOrMuscleGrowScore(TagsDao tags){


### PR DESCRIPTION
## 🗒️History
프론트에서 선호도 수정 요청 시 `해당없음`에 대한 항목이 필요해서 해당 요청에 대해 대응하기 위해 `Preference Type`에 `NONE` 항목을 추가함. 

## 💡 ETC 
@yunyechan9893 
`board_preferece_staticis` 생성하는 로직에서 NONE 인 경우 선호도 스코어를 0으로 처리하면 될까요?