### PR TITLE
[Fix] 테스트 소스에 Lombok annotation processor 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,8 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     compileOnly 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'


### PR DESCRIPTION
## History
- 연관된 이슈: Closes #418

## 🚀 Major Changes & Explanations
- 테스트코드에서 롬복 어노테이션을 인식하지 못하는 문제 해결
- `testCompileOnly` / `testAnnotationProcessor` 의존성 추가