### PR TITLE
[Feat] 판매자 서류 등록 API 설계 및 문서화

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/controller/StoreController.java
+++ b/src/main/java/com/bbangle/bbangle/board/controller/StoreController.java
@@ -1,6 +1,8 @@
 package com.bbangle.bbangle.board.controller;
 
-import com.bbangle.bbangle.board.controller.dto.StoreResponse;
+import static com.bbangle.bbangle.board.controller.dto.StoreResponse.StoreDetail;
+
+import com.bbangle.bbangle.board.controller.dto.StoreResponse.SearchResponse;
 import com.bbangle.bbangle.board.controller.mapper.StoreMapper;
 import com.bbangle.bbangle.board.facade.StoreFacade;
 import com.bbangle.bbangle.board.service.dto.StoreInfo;
@@ -9,6 +11,10 @@ import com.bbangle.bbangle.common.dto.ListResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.page.CursorPageResponse;
 import com.bbangle.bbangle.common.service.ResponseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Store", description = "스토어 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/stores")
@@ -28,41 +35,55 @@ public class StoreController {
     private final ResponseService responseService;
 
     @GetMapping("/{storeId}")
-    public SingleResult<StoreResponse.StoreDetail> getPopularBoardResponse(
-            @PathVariable("storeId")
-            Long storeId,
-            @AuthenticationPrincipal
-            Long memberId
+    public SingleResult<StoreDetail> getPopularBoardResponse(
+        @PathVariable("storeId")
+        Long storeId,
+        @AuthenticationPrincipal
+        Long memberId
     ) {
         StoreInfo.StoreDetail storeDetail = storeFacade.getStoreDetail(memberId, storeId);
-        StoreResponse.StoreDetail storeDetailResponse = storeMapper.toStoreDetailResponse(
-                storeDetail);
+        StoreDetail storeDetailResponse = storeMapper.toStoreDetailResponse(
+            storeDetail);
         return responseService.getSingleResult(storeDetailResponse);
     }
 
     @GetMapping("/{storeId}/boards/best")
     public ListResult<StoreInfo.BestBoard> getPopularBoardResponses(
-            @PathVariable("storeId")
-            Long storeId,
-            @AuthenticationPrincipal
-            Long memberId
+        @PathVariable("storeId")
+        Long storeId,
+        @AuthenticationPrincipal
+        Long memberId
     ) {
         List<StoreInfo.BestBoard> popularBoardResponses = storeFacade.getBestBoards(
-                memberId, storeId);
+            memberId, storeId);
         return responseService.getListResult(popularBoardResponses);
     }
 
     @GetMapping("/{storeId}/boards")
     public SingleResult<CursorPageResponse<AllBoard>> getStoreAllBoard(
-            @PathVariable("storeId")
-            Long storeId,
-            @RequestParam(value = "cursorId", required = false)
-            Long boardIdAsCursorId,
-            @AuthenticationPrincipal
-            Long memberId
+        @PathVariable("storeId")
+        Long storeId,
+        @RequestParam(value = "cursorId", required = false)
+        Long boardIdAsCursorId,
+        @AuthenticationPrincipal
+        Long memberId
     ) {
         CursorPageResponse<AllBoard> response = storeFacade.getAllBoard(memberId, storeId, boardIdAsCursorId);
         return responseService.getSingleResult(response);
-
     }
+
+    @Operation(summary = "스토어 검색")
+    @GetMapping("/search")
+    public ListResult<SearchResponse> search(
+        @RequestParam
+        @Parameter(description = "검색어", example = "빵그리의 오븐")
+        String searchValue
+    ) {
+        // TODO: 구현 필요
+        List<SearchResponse> response = new ArrayList<>();
+        response.add(new SearchResponse(1L, "빵그리의 오븐 즉석빵 상점"));
+        response.add(new SearchResponse(2L, "빵그리의 오븐 공장빵 상점"));
+        return responseService.getListResult(response);
+    }
+
 }

--- a/src/main/java/com/bbangle/bbangle/board/controller/dto/StoreResponse.java
+++ b/src/main/java/com/bbangle/bbangle/board/controller/dto/StoreResponse.java
@@ -1,14 +1,24 @@
 package com.bbangle.bbangle.board.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public class StoreResponse {
 
-        public record StoreDetail(
-            Long storeId,
-            String profile,
-            String storeName,
-            String introduce,
-            Boolean isWished
-        ) {
-        }
+    @Schema(description = "스토어 상세 응답 DTO")
+    public record StoreDetail(
+        @Schema(description = "스토어 ID", example = "1") Long storeId,
+        @Schema(description = "스토어 프로필 이미지 URL", example = "https://d37g3q9mfan3cw.cloudfront.net/store/000000/logo.png") String profile,
+        @Schema(description = "스토어명", example = "빵그리의 오븐 즉석빵 상점") String storeName,
+        @Schema(description = "스토어 소개", example = "건강한 디저트를 만드는 베이커리") String introduce,
+        @Schema(description = "현재 로그인한 사용자가 위시리스트에 추가했는지 여부", example = "true") Boolean isWished
+    ) {
+    }
+
+    @Schema(description = "스토어 검색 응답 DTO")
+    public record SearchResponse(
+        @Schema(description = "스토어 ID", example = "1") Long storeId,
+        @Schema(description = "스토어명", example = "빵그리의 오븐 즉석빵 상점") String storeName
+    ) {
+    }
 
 }

--- a/src/main/java/com/bbangle/bbangle/seller/controller/SellerController.java
+++ b/src/main/java/com/bbangle/bbangle/seller/controller/SellerController.java
@@ -1,0 +1,34 @@
+package com.bbangle.bbangle.seller.controller;
+
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.seller.controller.dto.SellerRequest.SellerDocumentsRegisterRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Seller", description = "판매자 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/sellers")
+public class SellerController {
+
+    private final ResponseService responseService;
+
+    @Operation(summary = "판매자 서류 등록")
+    @PostMapping(value = "/documents", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public CommonResult registerDocuments(
+        @ModelAttribute SellerDocumentsRegisterRequest request,
+        @AuthenticationPrincipal Long memberId
+    ) {
+        // TODO: 구현 필요
+        return responseService.getSuccessResult();
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/seller/controller/dto/SellerRequest.java
+++ b/src/main/java/com/bbangle/bbangle/seller/controller/dto/SellerRequest.java
@@ -1,0 +1,25 @@
+package com.bbangle.bbangle.seller.controller.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.web.multipart.MultipartFile;
+
+public class SellerRequest {
+
+    public record SellerDocumentsRegisterRequest(
+        @Schema(description = "사업자 등록증", requiredMode = REQUIRED, type = "string", format = "binary")
+        MultipartFile businessLicense,
+
+        @Schema(description = "통신판매업 신고증", requiredMode = REQUIRED, type = "string", format = "binary")
+        MultipartFile mailOrderLicense,
+
+        @Schema(description = "개인명의 통장 사본", requiredMode = REQUIRED, type = "string", format = "binary")
+        MultipartFile bankbookCopy,
+
+        @Schema(description = "즉석식품제조가공업 & 식품제조업", requiredMode = REQUIRED, type = "string", format = "binary")
+        MultipartFile foodManufactureLicense
+    ) {
+    }
+
+}


### PR DESCRIPTION
## History
연관된 이슈: #421 

## 🚀 Major Changes & Explanations

### 1. 판매자 서류 등록 API 설계
<img width="751" height="506" alt="image" src="https://github.com/user-attachments/assets/346cba05-8181-4510-890d-c4d5c5b7e208" />

요청: `POST /api/v1/sellers/documents`
- `Content-Type: multipart/form-data`
- Request
  - `businessLicense`: 사업자 등록증 (`File`) 
  - `mailOrderLicense`: 통신판매업 신고증 (`File`)
  - `bankbookCopy`: 개인명의통장사본 (`File`)
  - `foodManufactureLicense`: 즉석식품가공업&식품제조업 (`File`)
- 판매자 ID를 요청 파라미터로 받을 지 고민이 되는 상황임 => 자세한 내용은 ETC 참고부탁드립니다.

응답
```json
{
  "success": true,
  "code": 0,
  "message": "SUCCESS"
}
```

Swagger 이미지
<img width="1276" height="587" alt="image" src="https://github.com/user-attachments/assets/ca65d4db-6af4-4264-853f-ff92d142e835" />

## 💡ETC
판매자 ID 전달 방식에 대한 결정

고민한 점
- 서류 등록 시 판매자 ID가 필요한 상황
  - 옵션 1: `sellerId`를 요청 파라미터로 직접 받는다. 
  - 옵션 2: 인증된 사용자(`@AuthenticationPrincipal`) 기준으로 판매자 정보를 조회 및 매핑한다.

선택한 방향
- 판매자 ID를 요청 파라미터로 받지 않고, 인증된 사용자 기준으로 판매자 엔티티를 매핑하도록 설계
- 이유: 외부에서 임의로 판매자 ID를 조작할 수 없게 하고, 클라이언트는 별도 파라미터를 전달하지 않도록 단순화 할 수 있다고 판단.
