### PR TITLE
판매자 로그인 API 설계

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/constant/DeliveryCondition.java
+++ b/src/main/java/com/bbangle/bbangle/board/constant/DeliveryCondition.java
@@ -1,0 +1,14 @@
+package com.bbangle.bbangle.board.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DeliveryCondition {
+    PAID("유료"),
+    FREE("무료"),
+    CONDITIONAL_FREE("조건부 무료");
+
+    private final String description;
+}

--- a/src/main/java/com/bbangle/bbangle/board/controller/BoardController.java
+++ b/src/main/java/com/bbangle/bbangle/board/controller/BoardController.java
@@ -3,7 +3,7 @@ package com.bbangle.bbangle.board.controller;
 import com.bbangle.bbangle.board.constant.FolderBoardSortType;
 import com.bbangle.bbangle.board.constant.SortType;
 import com.bbangle.bbangle.board.dto.BoardResponse;
-import com.bbangle.bbangle.board.dto.BoardUploadRequest;
+import com.bbangle.bbangle.board.dto.BoardUploadRequest_v2;
 import com.bbangle.bbangle.board.dto.FilterRequest;
 import com.bbangle.bbangle.board.facade.BoardFacade;
 import com.bbangle.bbangle.board.service.BoardService;
@@ -24,7 +24,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
@@ -41,7 +47,7 @@ public class BoardController {
 
     @PostMapping("/board/{storeId}")
     public CommonResult upload(@PathVariable Long storeId,
-                               @RequestBody BoardUploadRequest request) {
+                               @RequestBody BoardUploadRequest_v2 request) {
         boardUploadService.upload(storeId, request);
         return responseService.getSuccessResult();
     }
@@ -49,44 +55,45 @@ public class BoardController {
     @Operation(summary = "게시글 전체 조회")
     @GetMapping
     public SingleResult<CursorPagination<SearchInfo.Select>> getList(
-            @ParameterObject
-            FilterRequest filterRequest,
-            @RequestParam(required = false, defaultValue = "RECOMMEND")
-            SortType sort,
-            @RequestParam(required = false)
-            Long cursorId,
-            @Parameter(
-                    description = "최대 30까지 입력 가능합니다.",
-                    schema = @Schema(defaultValue = "30", maximum = "30")
-            )
-            @RequestParam(required = false, defaultValue = "30")
-            Long limitSize,
-            @AuthenticationPrincipal
-            Long memberId
+        @ParameterObject
+        FilterRequest filterRequest,
+        @RequestParam(required = false, defaultValue = "RECOMMEND")
+        SortType sort,
+        @RequestParam(required = false)
+        Long cursorId,
+        @Parameter(
+            description = "최대 30까지 입력 가능합니다.",
+            schema = @Schema(defaultValue = "30", maximum = "30")
+        )
+        @RequestParam(required = false, defaultValue = "30")
+        Long limitSize,
+        @AuthenticationPrincipal
+        Long memberId
     ) {
-        SearchCommand.Main command = searchMapper.toSearchMain(filterRequest, sort, null, cursorId, memberId, limitSize);
+        SearchCommand.Main command = searchMapper.toSearchMain(filterRequest, sort, null, cursorId, memberId,
+            limitSize);
         CursorPagination<SearchInfo.Select> searchBoardPage = boardFacade.getBoardList(command);
         return responseService.getSingleResult(searchBoardPage);
     }
 
     @GetMapping("/folders/{folderId}")
     public SingleResult<CursorPageResponse<BoardResponse>> getPostInFolder(
-            @RequestParam(required = false, value = "sort")
-            @Schema(description = "위시리스트 상품 정렬 타입")
-            FolderBoardSortType sort,
-            @PathVariable(value = "folderId")
-            Long folderId,
-            @RequestParam(value = "cursorId", required = false)
-            @Schema(description = "커서 아이디")
-            Long cursorId,
-            @AuthenticationPrincipal
-            Long memberId
+        @RequestParam(required = false, value = "sort")
+        @Schema(description = "위시리스트 상품 정렬 타입")
+        FolderBoardSortType sort,
+        @PathVariable(value = "folderId")
+        Long folderId,
+        @RequestParam(value = "cursorId", required = false)
+        @Schema(description = "커서 아이디")
+        Long cursorId,
+        @AuthenticationPrincipal
+        Long memberId
     ) {
         if (sort == null) {
             sort = FolderBoardSortType.WISHLIST_RECENT;
         }
         CursorPageResponse<BoardResponse> boardResponseDto = boardService.getPostInFolder(
-                memberId, sort, folderId, cursorId);
+            memberId, sort, folderId, cursorId);
         return responseService.getSingleResult(boardResponseDto);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/board/domain/AvailabilityRequest.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/AvailabilityRequest.java
@@ -1,0 +1,28 @@
+package com.bbangle.bbangle.board.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "주문 가능 요일 정보")
+public record AvailabilityRequest(
+    @Schema(description = "월요일 주문 가능 여부", example = "true")
+    boolean monday,
+
+    @Schema(description = "화요일 주문 가능 여부", example = "true")
+    boolean tuesday,
+
+    @Schema(description = "수요일 주문 가능 여부", example = "true")
+    boolean wednesday,
+
+    @Schema(description = "목요일 주문 가능 여부", example = "true")
+    boolean thursday,
+
+    @Schema(description = "금요일 주문 가능 여부", example = "true")
+    boolean friday,
+
+    @Schema(description = "토요일 주문 가능 여부", example = "true")
+    boolean saturday,
+
+    @Schema(description = "일요일 주문 가능 여부", example = "true")
+    boolean sunday
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/board/domain/DietaryTagsRequest.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/DietaryTagsRequest.java
@@ -1,0 +1,22 @@
+package com.bbangle.bbangle.board.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "성분 카테고리")
+public record DietaryTagsRequest(
+    @Schema(description = "글루텐 프리 태그 여부", example = "true")
+    boolean glutenFreeTag,
+
+    @Schema(description = "고단백 태그 여부", example = "true")
+    boolean highProteinTag,
+
+    @Schema(description = "저당 태그 여부", example = "false")
+    boolean sugarFreeTag,
+
+    @Schema(description = "비건 태그 여부", example = "false")
+    boolean veganTag,
+
+    @Schema(description = "저지방 태그 여부(키토에서 변경됨)", example = "true")
+    boolean ketogenicTag
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/board/domain/NutritionInfoRequest.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/NutritionInfoRequest.java
@@ -1,0 +1,28 @@
+package com.bbangle.bbangle.board.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "영양 정보")
+public record NutritionInfoRequest(
+    @Schema(description = "총 중량 (g)", example = "250")
+    int totalWeight,
+
+    @Schema(description = "1회 제공량 (g)", example = "125")
+    int servingSize,
+
+    @Schema(description = "탄수화물 함량 (g)", example = "20")
+    int carbohydrates,
+
+    @Schema(description = "당류 함량 (g)", example = "5")
+    int sugars,
+
+    @Schema(description = "단백질 함량 (g)", example = "30")
+    int protein,
+
+    @Schema(description = "지방 함량 (g)", example = "15")
+    int fat,
+
+    @Schema(description = "칼로리 (kcal)", example = "350")
+    int calories
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/board/dto/BoardDetailRequest.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/BoardDetailRequest.java
@@ -3,21 +3,16 @@ package com.bbangle.bbangle.board.dto;
 import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.domain.BoardDetail;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@Data
 @Schema(description = "게시글 상세보기 요청 DTO")
-public class BoardDetailRequest {
-
+public record BoardDetailRequest(
     @Schema(description = "HTML 형식의 상세페이지 내용", example = "<div>...</div>")
-    private String content;
-
+    String content
+) {
     public BoardDetail toEntity(Board board) {
         return BoardDetail.builder()
-                .board(board)
-                .content(content)
-                .build();
+            .board(board)
+            .content(content)
+            .build();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/board/dto/BoardUploadRequest_v2.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/BoardUploadRequest_v2.java
@@ -1,0 +1,85 @@
+package com.bbangle.bbangle.board.dto;
+
+import com.bbangle.bbangle.board.constant.DeliveryCompany;
+import com.bbangle.bbangle.board.constant.DeliveryCondition;
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.BoardDetail;
+import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.board.domain.Store;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "게시글 업로드 요청 DTO v2")
+public record BoardUploadRequest_v2(
+    @Schema(description = "게시글 제목", example = "맛있는 다이어트 도시락")
+    String boardTitle,
+
+    @Schema(description = "상품 제작 시작 시간", example = "250800")
+    LocalDateTime productionStartDate,
+
+    @Schema(description = "기본 가격", example = "12000")
+    int price,
+
+    @Schema(description = "할인율 (%)", example = "10")
+    int discountRate,
+
+    @Schema(description = "최종 상품 금액", example = "10800")
+    int totalPrice,
+
+    @Schema(description = "배송 조건", example = "PAID")
+    DeliveryCondition deliveryCondition,
+
+    @Schema(description = "배송 회사")
+    DeliveryCompany deliveryCompany,
+
+    @Schema(description = "배송비", example = "3000")
+    int deliveryFee,
+
+    @Schema(description = "무료배송 최소 금액", example = "30000")
+    int freeShippingConditions,
+
+    @Schema(description = "대표 썸네일 이미지", example = "1")
+    Long thumbnailImgId,
+
+    @Schema(description = "등록할 추가 이미지 ID 리스트", example = "[1, 2, 3]")
+    List<Long> productImgIds,
+
+    @Schema(description = "상품 요청 목록")
+    List<ProductRequest_v2> productRequests,
+
+    @Schema(description = "게시글 상세 내용 요청")
+    BoardDetailRequest boardDetailRequest,
+
+    @Schema(description = "상품 정보 고시 요청")
+    ProductInfoNoticeRequest productInfoNoticeRequest
+) {
+    public Board toBoard(Store store) {
+        Board board = new Board(
+            store,
+            boardTitle,
+            price,
+            discountRate,
+            deliveryFee,
+            freeShippingConditions,
+            productInfoNoticeRequest.toEntity()
+        );
+        toProducts(board);
+        toBoardDetail(board);
+        return board;
+    }
+
+    private void toProducts(Board board) {
+        List<Product> products = this.productRequests
+            .stream()
+            .map(productRequest -> productRequest.toEntity(board))
+            .toList();
+
+        board.addProducts(products);
+    }
+
+    private void toBoardDetail(Board board) {
+        BoardDetail boardDetail = boardDetailRequest.toEntity(board);
+        board.addBoardDetails(boardDetail);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/board/dto/ProductInfoNoticeRequest.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/ProductInfoNoticeRequest.java
@@ -2,68 +2,63 @@ package com.bbangle.bbangle.board.dto;
 
 import com.bbangle.bbangle.board.domain.ProductInfoNotice;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@Data
 @Schema(description = "상품 정보 고시 요청 DTO")
-public class ProductInfoNoticeRequest {
-
+public record ProductInfoNoticeRequest(
     @Schema(description = "제품명", example = "비건 쿠키 3종 모음")
-    private String productName;
+    String productName,
 
     @Schema(description = "식품의 유형(기본값일 경우 게시글 상품 카테고리 자동 등록)", example = "쿠키, 빵")
-    private String foodType;
+    String foodType,
 
     @Schema(description = "제조사 또는 생산자(기본값일 경우 판매업체 자동 등록)", example = "빵그리의 오븐")
-    private String manufacturer;
+    String manufacturer,
 
     @Schema(description = "소재지(기본값일 경우 판매자 소재지 자동 등록)", example = "서울특별시 강남구 건강쿠키로 123")
-    private String originLocation;
+    String originLocation,
 
     @Schema(description = "제조일자", example = "주문 후 익일 제조 (금, 주말 주문건은 월요일 제작)")
-    private String manufactureDate;
+    String manufactureDate,
 
     @Schema(description = "소비기한 또는 품질 유지기한", example = "출고 후 바로 섭취", defaultValue = "출고 후 냉동 2주, 냉장 2일")
-    private String expirationDate;
+    String expirationDate,
 
     @Schema(description = "포장 단위 별 내용물의 용량(중량)", example = "30g", defaultValue = "상세페이지 첨부")
-    private String storageGuide;
+    String storageGuide,
 
     @Schema(description = "포장 단위 별 수량", example = "30개", defaultValue = "상세페이지 첨부")
-    private String packagingQuantityUnit;
+    String packagingQuantityUnit,
 
     @Schema(description = "원재료명", example = "통밀가루30%, 카카오10%, ...", defaultValue = "상세페이지 첨부")
-    private String rawMaterialName;
+    String rawMaterialName,
 
-    @Schema(description = "원재료명", example = "상세페이지 첨부", defaultValue = "해당사항 없음")
-    private String nutritionInfo;
+    @Schema(description = "영양성분", defaultValue = "해당사항 없음")
+    String nutritionInfo,
 
     @Schema(description = "유전자 변형 식품에 해당하는 경우의 표시", example = "해당사항 없음", defaultValue = "해당사항 없음")
-    private String transgenic;
+    String transgenic,
 
     @Schema(description = "소비자 안전을 위한 주의사항", example = "배송 즉시 냉동보관 해주세요", defaultValue = "배송 즉시 냉동보관 해주세요")
-    private String customerWaring;
+    String customerWaring,
 
     @Schema(description = "수입 식품의 경우", example = "해당사항 없음", defaultValue = "해당사항 없음")
-    private String importFood;
-
+    String importFood
+) {
     public ProductInfoNotice toEntity() {
         return new ProductInfoNotice(
-                productName,
-                foodType,
-                manufacturer,
-                originLocation,
-                manufactureDate,
-                expirationDate,
-                storageGuide,
-                packagingQuantityUnit,
-                rawMaterialName,
-                nutritionInfo,
-                transgenic,
-                customerWaring,
-                importFood
+            productName,
+            foodType,
+            manufacturer,
+            originLocation,
+            manufactureDate,
+            expirationDate,
+            storageGuide,
+            packagingQuantityUnit,
+            rawMaterialName,
+            nutritionInfo,
+            transgenic,
+            customerWaring,
+            importFood
         );
     }
 }

--- a/src/main/java/com/bbangle/bbangle/board/dto/ProductRequest_v2.java
+++ b/src/main/java/com/bbangle/bbangle/board/dto/ProductRequest_v2.java
@@ -1,0 +1,65 @@
+package com.bbangle.bbangle.board.dto;
+
+import com.bbangle.bbangle.board.domain.AvailabilityRequest;
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.Category;
+import com.bbangle.bbangle.board.domain.DietaryTagsRequest;
+import com.bbangle.bbangle.board.domain.Nutrition;
+import com.bbangle.bbangle.board.domain.NutritionInfoRequest;
+import com.bbangle.bbangle.board.domain.Product;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품 등록 요청 DTO")
+public record ProductRequest_v2(
+    @Schema(description = "상품 카테고리")
+    Category category,
+
+    @Schema(description = "상품명", example = "비건 쿠키")
+    String title,
+
+    @Schema(description = "성분 카테고리")
+    DietaryTagsRequest dietaryTags,
+
+    @Schema(description = "게시글 가격에 추가되는 금액", example = "1000")
+    int plusPriceWithBoardPrice,
+
+    @Schema(description = "재고 수량", example = "100")
+    int stock,
+
+    @Schema(description = "주문 가능 요일 정보")
+    AvailabilityRequest availability,
+
+    @Schema(description = "영양 정보")
+    NutritionInfoRequest nutritionInfo
+) {
+    public Product toEntity(Board board) {
+        return new Product(
+            board,
+            title,
+            plusPriceWithBoardPrice,
+            category,
+            stock,
+            dietaryTags.glutenFreeTag(),
+            dietaryTags.highProteinTag(),
+            dietaryTags.sugarFreeTag(),
+            dietaryTags.veganTag(),
+            dietaryTags.ketogenicTag(),
+            availability.monday(),
+            availability.tuesday(),
+            availability.wednesday(),
+            availability.thursday(),
+            availability.friday(),
+            availability.saturday(),
+            availability.sunday(),
+            new Nutrition(
+                nutritionInfo.totalWeight(),
+                nutritionInfo.servingSize(),
+                nutritionInfo.carbohydrates(),
+                nutritionInfo.sugars(),
+                nutritionInfo.protein(),
+                nutritionInfo.fat(),
+                nutritionInfo.calories()
+            )
+        );
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/board/service/BoardUploadService.java
+++ b/src/main/java/com/bbangle/bbangle/board/service/BoardUploadService.java
@@ -2,7 +2,7 @@ package com.bbangle.bbangle.board.service;
 
 import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.domain.Store;
-import com.bbangle.bbangle.board.dto.BoardUploadRequest;
+import com.bbangle.bbangle.board.dto.BoardUploadRequest_v2;
 import com.bbangle.bbangle.board.repository.BoardDetailRepository;
 import com.bbangle.bbangle.board.repository.BoardRepository;
 import com.bbangle.bbangle.board.repository.ProductInfoNoticeRepository;
@@ -27,20 +27,20 @@ public class BoardUploadService {
      * productImg - board 연결도 이 때 진행
      */
     @Transactional
-    public long upload(Long storeId, BoardUploadRequest request) {
+    public long upload(Long storeId, BoardUploadRequest_v2 request) {
         Store store = storeRepository.findById(storeId)
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.STORE_NOT_FOUND));
 
         Board board = saveBoardWithchildren(store, request);
 
         productImgService.connectImagesToBoard(
-            request.getProductImgIds(),
+            request.productImgIds(),
             board);
 
         return board.getId();
     }
 
-    private Board saveBoardWithchildren(Store store, BoardUploadRequest request) {
+    private Board saveBoardWithchildren(Store store, BoardUploadRequest_v2 request) {
         Board board = request.toBoard(store);
         return boardRepository.save(board);
     }

--- a/src/main/java/com/bbangle/bbangle/token/oauth/OauthController.java
+++ b/src/main/java/com/bbangle/bbangle/token/oauth/OauthController.java
@@ -23,12 +23,26 @@ public class OauthController {
     @GetMapping("/login/{oauthServerType}")
     @Operation(summary = "Oauth 로그인")
     CommonResult login(
-            @PathVariable("oauthServerType")
-            OauthServerType oauthServerType,
-            @RequestParam("token")
-            String token
+        @PathVariable("oauthServerType")
+        OauthServerType oauthServerType,
+        @RequestParam("token")
+        String token
     ) {
         LoginTokenResponse loginTokenResponse = oauthService.login(oauthServerType, token);
         return responseService.getSingleResult(loginTokenResponse);
     }
+
+    @GetMapping("/seller/login/{oauthServerType}")
+    @Operation(summary = "판매자 Oauth 로그인")
+    CommonResult sellerLogin(
+        @PathVariable("oauthServerType")
+        OauthServerType oauthServerType,
+        @RequestParam("token")
+        String token
+    ) {
+        // TODO: 개발 필요
+        LoginTokenResponse loginTokenResponse = oauthService.login(oauthServerType, token);
+        return responseService.getSingleResult(loginTokenResponse);
+    }
+
 }

--- a/src/main/java/com/bbangle/bbangle/token/oauth/infra/kakao/dto/LoginTokenResponse.java
+++ b/src/main/java/com/bbangle/bbangle/token/oauth/infra/kakao/dto/LoginTokenResponse.java
@@ -1,8 +1,10 @@
 package com.bbangle.bbangle.token.oauth.infra.kakao.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record LoginTokenResponse(
-    String accessToken,
-    String refreshToken
+    @Schema(description = "Access 토큰") String accessToken,
+    @Schema(description = "Refresh 토큰") String refreshToken
 ) {
 
 }


### PR DESCRIPTION

## History
연관된 이슈: #421 

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations
## 1. 판매자 로그인 api
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

<img width="401" height="285" alt="image" src="https://github.com/user-attachments/assets/41cc0a1b-5e5a-494b-a563-8b254bc4aa9a" />

- 내용 
카카오/구글 oauth 를 이용한 로그인 api이고 
기존 member 와 uri 분리해서 요청/응답 값 동일하게 설계 했습니다.

- 요청[REQUEST]  `GET /api/v1/oauth/seller/login/{oauthServerType}`
`oauthServerType` : KAKAO or GOOGLE
`token` : Bearer 토큰
- 응답[RESPONSE]
`refreshToken` : 리프레시 토큰
`accessToken` : 액세스 토큰

## 📷 Test Image
<img width="1424" height="775" alt="image" src="https://github.com/user-attachments/assets/aef9d1da-2be2-499c-85f7-7b2b62bb3df9" />

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC
기존에 사용하는 member의 oauth 로그인 url 수정할수 있으면 컨트롤러 창구 하나에서 받고 
RequestParam 으로 seller, member 구분해서 받은 후 서비스에서 분기 처리하는것도 좋을것 같습니다.
ex) /api/v1/oauth/{userRole}/login/{oauthServerType} 
<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
