### PR TITLE
판매자 로그인 API 설계

### DIFF
--- a/src/main/java/com/bbangle/bbangle/token/oauth/OauthController.java
+++ b/src/main/java/com/bbangle/bbangle/token/oauth/OauthController.java
@@ -23,12 +23,26 @@ public class OauthController {
     @GetMapping("/login/{oauthServerType}")
     @Operation(summary = "Oauth 로그인")
     CommonResult login(
-            @PathVariable("oauthServerType")
-            OauthServerType oauthServerType,
-            @RequestParam("token")
-            String token
+        @PathVariable("oauthServerType")
+        OauthServerType oauthServerType,
+        @RequestParam("token")
+        String token
     ) {
         LoginTokenResponse loginTokenResponse = oauthService.login(oauthServerType, token);
         return responseService.getSingleResult(loginTokenResponse);
     }
+
+    @GetMapping("/seller/login/{oauthServerType}")
+    @Operation(summary = "판매자 Oauth 로그인")
+    CommonResult sellerLogin(
+        @PathVariable("oauthServerType")
+        OauthServerType oauthServerType,
+        @RequestParam("token")
+        String token
+    ) {
+        // TODO: 개발 필요
+        LoginTokenResponse loginTokenResponse = oauthService.login(oauthServerType, token);
+        return responseService.getSingleResult(loginTokenResponse);
+    }
+
 }

--- a/src/main/java/com/bbangle/bbangle/token/oauth/infra/kakao/dto/LoginTokenResponse.java
+++ b/src/main/java/com/bbangle/bbangle/token/oauth/infra/kakao/dto/LoginTokenResponse.java
@@ -1,8 +1,10 @@
 package com.bbangle.bbangle.token.oauth.infra.kakao.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record LoginTokenResponse(
-    String accessToken,
-    String refreshToken
+    @Schema(description = "Access 토큰") String accessToken,
+    @Schema(description = "Refresh 토큰") String refreshToken
 ) {
 
 }


### PR DESCRIPTION
## History
연관된 이슈: #421 

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations
## 판매자 로그인 api
<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

<img width="401" height="285" alt="image" src="https://github.com/user-attachments/assets/41cc0a1b-5e5a-494b-a563-8b254bc4aa9a" />

- 내용 
카카오/구글 oauth 를 이용한 로그인 api이고 
기존 member 와 uri 분리해서 요청/응답 값 동일하게 설계 했습니다.

- 요청[REQUEST]  `GET /api/v1/oauth/seller/login/{oauthServerType}`
`oauthServerType` : KAKAO or GOOGLE
`token` : Bearer 토큰
- 응답[RESPONSE]
`refreshToken` : 리프레시 토큰
`accessToken` : 액세스 토큰

## 📷 Test Image
<img width="1424" height="775" alt="image" src="https://github.com/user-attachments/assets/aef9d1da-2be2-499c-85f7-7b2b62bb3df9" />

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC
기존에 사용하는 member의 oauth 로그인 url 수정할수 있으면 컨트롤러 창구 하나에서 받고 
RequestParam 으로 seller, member 구분해서 받은 후 서비스에서 분기 처리하는것도 좋을것 같습니다.
ex) /api/v1/oauth/{userRole}/login/{oauthServerType} 
<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
