### PR TITLE
판매자 등록 API 설계 및 문서화

### DIFF
--- a/src/main/java/com/bbangle/bbangle/seller/controller/SellerController.java
+++ b/src/main/java/com/bbangle/bbangle/seller/controller/SellerController.java
@@ -1,0 +1,25 @@
+package com.bbangle.bbangle.seller.controller;
+
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.seller.controller.swagger.SellerApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SellerController implements SellerApi {
+
+    private final ResponseService responseService;
+
+    @Override
+    public CommonResult createSeller(@RequestBody SellerRequest.sellerCreateRequest request) {
+
+        // TODO : 비즈니스 로직 수행했다는 가정
+
+        return responseService.getSuccessResult();
+    }
+
+
+}

--- a/src/main/java/com/bbangle/bbangle/seller/controller/SellerController.java
+++ b/src/main/java/com/bbangle/bbangle/seller/controller/SellerController.java
@@ -2,9 +2,9 @@ package com.bbangle.bbangle.seller.controller;
 
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.seller.controller.SellerRequest.SellerCreateRequest;
 import com.bbangle.bbangle.seller.controller.swagger.SellerApi;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -14,12 +14,8 @@ public class SellerController implements SellerApi {
     private final ResponseService responseService;
 
     @Override
-    public CommonResult createSeller(@RequestBody SellerRequest.sellerCreateRequest request) {
-
-        // TODO : 비즈니스 로직 수행했다는 가정
-
+    public CommonResult createSeller(SellerCreateRequest request) {
         return responseService.getSuccessResult();
     }
-
 
 }

--- a/src/main/java/com/bbangle/bbangle/seller/controller/SellerRequest.java
+++ b/src/main/java/com/bbangle/bbangle/seller/controller/SellerRequest.java
@@ -1,23 +1,42 @@
 package com.bbangle.bbangle.seller.controller;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
 public class SellerRequest {
 
-    public record sellerCreateRequest(
+    public record SellerCreateRequest(
+        @NotBlank
         String storeName,
-        String phoneNumber,
-        String subPhoneNumber,
-        String email,
-        Long verificationNumber,
-        String originAddress,
-        String originAddressDetail) {
 
+        @NotBlank
+        String phoneNumber,
+
+        @NotBlank
+        String subPhoneNumber,
+
+        @Email
+        String email,
+
+        @NotNull
+        Long verificationNumber,
+
+        @NotBlank
+        String originAddress,
+
+        @NotBlank
+        String originAddressDetail,
+
+        MultipartFile profileImage
+
+    ) {
         /*
          * TODO:
          *  1.유효성 검증 로직 추가
          *  2. 서비스 레이어로 값을 전달할 command 객체 생성 로직 필요
-         *
          */
-
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/seller/controller/SellerRequest.java
+++ b/src/main/java/com/bbangle/bbangle/seller/controller/SellerRequest.java
@@ -1,0 +1,23 @@
+package com.bbangle.bbangle.seller.controller;
+
+public class SellerRequest {
+
+    public record sellerCreateRequest(
+        String storeName,
+        String phoneNumber,
+        String subPhoneNumber,
+        String email,
+        Long verificationNumber,
+        String originAddress,
+        String originAddressDetail) {
+
+        /*
+         * TODO:
+         *  1.유효성 검증 로직 추가
+         *  2. 서비스 레이어로 값을 전달할 command 객체 생성 로직 필요
+         *
+         */
+
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/seller/controller/swagger/SellerApi.java
+++ b/src/main/java/com/bbangle/bbangle/seller/controller/swagger/SellerApi.java
@@ -1,0 +1,48 @@
+package com.bbangle.bbangle.seller.controller.swagger;
+
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.exception.ErrorResponse;
+import com.bbangle.bbangle.seller.controller.SellerRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Sellers", description = "판매자 관련 API")
+@RequestMapping("/api/v1/sellers")
+public interface SellerApi {
+
+    // TODO : 우선적으로 성공응답만 명시적으로 지정
+    @Operation(summary = "신규 판매자 생성", description = "새로운 판매자 정보를 시스템에 등록합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200",
+            description = "판매자 생성 성공",
+            content = @Content(
+                schema = @Schema(implementation = CommonResult.class),
+                examples = @ExampleObject(
+                    name = "successResponse",
+                    summary = "성공응답 예시",
+                    value = """
+                        {
+                            "success" : true,
+                            "code" : 0,
+                            "message" : "SUCCESS"
+                        } 
+                        """
+                ))),
+        @ApiResponse(responseCode = "400",
+            description = "잘못된 요청 데이터",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class)
+            ))
+    })
+    @PostMapping
+    CommonResult createSeller(@RequestBody SellerRequest.sellerCreateRequest request);
+
+}

--- a/src/main/java/com/bbangle/bbangle/seller/controller/swagger/SellerApi.java
+++ b/src/main/java/com/bbangle/bbangle/seller/controller/swagger/SellerApi.java
@@ -4,24 +4,32 @@ import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.exception.ErrorResponse;
 import com.bbangle.bbangle.seller.controller.SellerRequest;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name = "Sellers", description = "판매자 관련 API")
 @RequestMapping("/api/v1/sellers")
 public interface SellerApi {
 
-    // TODO : 우선적으로 성공응답만 명시적으로 지정
-    @Operation(summary = "신규 판매자 생성", description = "새로운 판매자 정보를 시스템에 등록합니다.")
+
+    @Operation(
+        summary = "신규 판매자 생성",
+        description = "판매자 정보(JSON)와 프로필 이미지 파일을 업로드합니다."
+    )
+
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200",
+        @ApiResponse(
+            responseCode = "200",
             description = "판매자 생성 성공",
             content = @Content(
                 schema = @Schema(implementation = CommonResult.class),
@@ -35,14 +43,26 @@ public interface SellerApi {
                             "message" : "SUCCESS"
                         } 
                         """
-                ))),
-        @ApiResponse(responseCode = "400",
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
             description = "잘못된 요청 데이터",
             content = @Content(
                 schema = @Schema(implementation = ErrorResponse.class)
-            ))
+            )
+        )
     })
-    @PostMapping
-    CommonResult createSeller(@RequestBody SellerRequest.sellerCreateRequest request);
+    @PostMapping(
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    CommonResult createSeller(
+        @Parameter(
+            description = "판매자 생성 요청",
+            schema = @Schema(implementation = SellerCreateMultipartDoc.class) // <-- Swagger 문서에는 이걸 노출
+        )
+        @Valid @ModelAttribute SellerRequest.SellerCreateRequest request);
 
 }

--- a/src/main/java/com/bbangle/bbangle/seller/controller/swagger/SellerCreateMultipartDoc.java
+++ b/src/main/java/com/bbangle/bbangle/seller/controller/swagger/SellerCreateMultipartDoc.java
@@ -1,0 +1,33 @@
+package com.bbangle.bbangle.seller.controller.swagger;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.web.multipart.MultipartFile;
+
+public record SellerCreateMultipartDoc(
+    @Schema(description = "스토어명", example = "빵그리의 오븐 1호점")
+    String storeName,
+
+    @Schema(description = "연락처", example = "01012345678")
+    String phoneNumber,
+
+    @Schema(description = "서브 연락처", example = "01012345678")
+    String subPhoneNumber,
+
+    @Schema(description = "이메일", example = "user@example.com", format = "email")
+    String email,
+
+    @Schema(description = "인증번호(6자리)", example = "123456")
+    Long verificationNumber,
+
+    @Schema(description = "판매자 주소", example = "(우편번호) 성남시 금광동 222-31")
+    String originAddress,
+
+    @Schema(description = "판매자 상세 주소", example = "나동 202호")
+    String originAddressDetail,
+    
+    @Schema(description = "프로필 이미지 파일", type = "string", format = "binary")
+    MultipartFile profileImage
+) {
+
+
+}


### PR DESCRIPTION
## History

연관된 이슈 : #421 

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

판매자 정보 등록 API
<img width="1438" height="568" alt="image" src="https://github.com/user-attachments/assets/ca556354-0215-4484-bb22-12f21efb7c2a" />


- 내용
   -  판매자 등록 API를 설계하였습니다.

- 요청(Request)
   -  `POST /api/v1/sellers`
   -  파일도 같이 넘겨줘야 하기에  `@ModelAttribute` 사용
   -  사용 객체 :  `SellerCreateRequest`
        -  `storeName `: 스토어명
        -  `phoneNumber` :  연락처
        -  `subPhonNumber` : 서브 연락처
        -  `email` : 이메일
        -  `verificationNumber` : 인증 번호
        -  `originAddress` :  판매자 주소
        -  `originAddressDetail` : 판매자 상세주소
        -  `profileImage` : 프로필 이미지 파일 (`file`)

- 응답(Response)

  ```  java

   {
        "success" : true,
         "code" : 0,
         "message" : "SUCCESS"
    } 
 

<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

<img width="1247" height="1728" alt="image" src="https://github.com/user-attachments/assets/ba62dfd1-89f0-422c-8012-c434edc11700" />

<img width="1891" height="496" alt="image" src="https://github.com/user-attachments/assets/f5d161ba-2b99-4a0f-ba4a-8da003dc7175" />

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->

- Swagger 코드를 별도의 인터페이스로 추출해서 사용하는 방식을 채택
- 이유 : Swagger 코드가 controller에 들어오면 코드의 양이 불필요하게 많아지고, 순수하게 controller 로직만 볼 수있어 효과적이라고 생각하여 진행함
