### PR TITLE
상품 게시글 삭제 API 설계

### DIFF
--- a/src/main/java/com/bbangle/bbangle/seller/store/controller/ProductBoardController_v3.java
+++ b/src/main/java/com/bbangle/bbangle/seller/store/controller/ProductBoardController_v3.java
@@ -2,7 +2,7 @@ package com.bbangle.bbangle.seller.store.controller;
 
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.service.ResponseService;
-import com.bbangle.bbangle.seller.store.controller.swagger.ProductBoardApi;
+import com.bbangle.bbangle.seller.store.controller.swagger.ProductBoardApi_v3;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("api/v1/seller/store")
 @Slf4j
-public class ProductBoardController implements ProductBoardApi {
+public class ProductBoardController_v3 implements ProductBoardApi_v3 {
 
     private final ResponseService responseService;
 

--- a/src/main/java/com/bbangle/bbangle/seller/store/controller/swagger/ProductBoardApi_v3.java
+++ b/src/main/java/com/bbangle/bbangle/seller/store/controller/swagger/ProductBoardApi_v3.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
 @Tag(name = "ProductBoards", description = "상품 게시글 관련 API")
-public interface ProductBoardApi {
+public interface ProductBoardApi_v3 {
 
     @Operation(
         summary = "상품 게시글 삭제",


### PR DESCRIPTION

## History

연관된 이슈 : #421

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

<img width="1323" height="942" alt="image" src="https://github.com/user-attachments/assets/4bdb9a4b-4c4c-4a59-afcc-217296636ec3" />


- 내용
   - 상품 게시글 삭제 API 개발
 
- 요청(Request) 
  - POST/api/v1/seller/store/{storeId}/boards
  - 사용 객체 : 
     - storeId : 스토어 ID
     - boardIds : 게시글 ID 리스트

- 응답(Response)

``` 
{
    "success": true,
    "code": 0,
    "message": "SUCCESS",
}

```

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->
<img width="985" height="574" alt="image" src="https://github.com/user-attachments/assets/51408c37-f2cb-4996-97e2-cda5d3e02e46" />
<img width="1022" height="348" alt="image" src="https://github.com/user-attachments/assets/88b1e0bf-0af5-4bef-92e1-b0d4935ee803" />



## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
- 삭제는 기본적으로 Delete 메서드 사용을 고려했으나 한 페이지에서 수십개의 게시글을 삭제할 수있을 가능성이 존재
    - URL 길이 문제 (@RequestParam, @PathVariable 활용 시) 발생 위험 
   -  fetch API, 일부 API Gateway, OpenAPI/Swagger 툴에서 DELETE body를 잘 지원하지 않음
