### PR TITLE
[Feat] 새로운 아키텍쳐 EC2에 맞게 production ci/cd 재구성

### DIFF
--- a/.github/workflows/cd-pipeline-aws-deploy.yml
+++ b/.github/workflows/cd-pipeline-aws-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: application.yml 정보 넣기
         run: |
           mkdir -p src/main/resources
-          echo "${{ secrets.APPLICATION_YML_AWS }}" | base64 --decode > src/main/resources/application-production.yml
+          echo "${{ secrets.PROD_APPLICATION_YML }}" | base64 --decode > src/main/resources/application-production.yml
           find src
 
       - name: FcmKey 정보 넣기
@@ -57,30 +57,30 @@ jobs:
       - name: 기존 서버 내 jar 파일 삭제
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.DEPLOY_AWS_SSH_HOST }}
-          username: ${{ secrets.DEPLOY_AWS_SSH_USERNAME }}
-          key: ${{ secrets.DEPLOY_AWS_SSH_KEY }}
-          port: ${{ secrets.DEPLOY_AWS_SSH_PORT }}
+          host: ${{ secrets.PROD_AWS_SSH_HOST }}
+          username: ${{ secrets.PROD_AWS_SSH_USERNAME }}
+          key: ${{ secrets.PROD_AWS_SSH_KEY }}
+          port: ${{ secrets.PROD_AWS_SSH_PORT }}
           script: |
             rm -f ~/docker/server/Bbangle-0.0.1-SNAPSHOT.jar
 
       - name: jar 파일 운영 서버 전송
         uses: appleboy/scp-action@master
         with:
-          host: ${{ secrets.DEPLOY_AWS_SSH_HOST }}
-          username: ${{ secrets.DEPLOY_AWS_SSH_USERNAME }}
-          key: ${{ secrets.DEPLOY_AWS_SSH_KEY }}
-          port: ${{ secrets.DEPLOY_AWS_SSH_PORT }}
+          host: ${{ secrets.PROD_AWS_SSH_HOST }}
+          username: ${{ secrets.PROD_AWS_SSH_USERNAME }}
+          key: ${{ secrets.PROD_AWS_SSH_KEY }}
+          port: ${{ secrets.PROD_AWS_SSH_PORT }}
           source: "Bbangle-0.0.1-SNAPSHOT.jar"
           target: "~/docker/server"
 
       - name: 이미지 새로 build 및 docker 서버 재실행
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.DEPLOY_AWS_SSH_HOST }}
-          username: ${{ secrets.DEPLOY_AWS_SSH_USERNAME }}
-          key: ${{ secrets.DEPLOY_AWS_SSH_KEY }}
-          port: ${{ secrets.DEPLOY_AWS_SSH_PORT }}
+          host: ${{ secrets.PROD_AWS_SSH_HOST }}
+          username: ${{ secrets.PROD_AWS_SSH_USERNAME }}
+          key: ${{ secrets.PROD_AWS_SSH_KEY }}
+          port: ${{ secrets.PROD_AWS_SSH_PORT }}
           script: |
             chmod +x main-docker.sh
             ./main-docker.sh


### PR DESCRIPTION
이슈 : https://github.com/eco-dessert-platform/backend/issues/451

변경 사유

아키텍쳐 변경에 따라 각 서버가 독립적인 EC2를 갖고, DEV와 PROD 접두사로 파일을 나눌 필요가 사라짐
동일한 파일명을 사용함으로써 혼선 방지