### PR TITLE
[!HotFix] 프로필 Null 일 시, 조회 안되는 에러 해결

### DIFF
--- a/src/main/java/com/bbangle/bbangle/member/domain/Member.java
+++ b/src/main/java/com/bbangle/bbangle/member/domain/Member.java
@@ -8,19 +8,7 @@ import com.bbangle.bbangle.member.customer.exception.UserValidator;
 import com.bbangle.bbangle.token.oauth.domain.OauthServerType;
 import com.bbangle.bbangle.wishlist.domain.WishListFolder;
 import com.bbangle.bbangle.wishlist.domain.WishListStore;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,6 +16,11 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 
 @Table(name = "member")
 @Entity
@@ -182,7 +175,15 @@ public class Member extends BaseEntity implements UserDetails {
     }
 
     public String getProfile() {
-        return profile.contains("http") ? profile : String.format("%s/%s", CdnConfig.getCloudFrontUrl(), profile);
+        if (Objects.isNull(profile)) {
+            return "";
+        }
+
+        if (profile.contains("http")) {
+            return profile;
+        }
+
+        return String.format("%s/%s", CdnConfig.getCloudFrontUrl(), profile);
     }
 
 }


### PR DESCRIPTION
### 에러
```
Cannot invoke "String.contains(java.lang.CharSequence)" because "this.profile" is null
- url: /api/v1/profile
- 위치: com.bbangle.bbangle.member.domain.Member, getProfile
- message: Cannot invoke "String.contains(java.lang.CharSequence)" because "this.profile" is null****
```

### 문제
- 프로필이 널 일 시, contain 메서드 에서 에러 발생.  

### 해결
- null일 때, "" 빈 값 반환 하도록 변경