### PR TITLE
[Fix] wishCnt 필드 제거로 Null 매핑 예외 해결

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/domain/Board.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Board.java
@@ -79,9 +79,6 @@ public class Board extends BaseEntity {
     @Column(name = "view")
     private int view;
 
-    @Column(name = "wish_cnt")
-    private int wishCnt;
-
     @Column(name = "discount_price")
     private int discountPrice;
 


### PR DESCRIPTION
## History
- #471 에서 발생된 에러
- DB에서 `wish_cnt` 컬럼 값이 NULL인 데이터가 존재함.
- 엔티티의 `wishCnt` 필드가 int(primitive type)로 선언되어 있어 JPA 매핑 시 null → int 변환 과정에서 예외 발생

에러 로그
```
Null value was assigned to a property [class com.bbangle.bbangle.board.domain.Board.wishCnt] 
of primitive type: 'com.bbangle.bbangle.board.domain.Board.wishCnt' (setter)
```

## 🚀 Major Changes & Explanations
- Board 엔티티의 `wishCnt` 필드 제거
  - Integer 로 변경해서 문제를 해결할 수 있지만, 우선 wishCnt 필드를 사용하는 쪽이 없어서 필드를 제거하는 편을 선택함.


## 💡 ETC
