### PR TITLE
[Featurea] 환경 별 application.yml 구성 및 profile 분리

### DIFF
--- a/.github/workflows/cd-pipeline-aws-deploy.yml
+++ b/.github/workflows/cd-pipeline-aws-deploy.yml
@@ -21,12 +21,6 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: application.yml 정보 넣기
-        run: |
-          mkdir -p src/main/resources
-          echo "${{ secrets.PROD_APPLICATION_YML }}" | base64 --decode > src/main/resources/application-production.yml
-          find src
-
       - name: FcmKey 정보 넣기
         run: |
           mkdir -p src/main/resources/firebase

--- a/.github/workflows/cd-pipeline-aws-deploy.yml
+++ b/.github/workflows/cd-pipeline-aws-deploy.yml
@@ -28,6 +28,10 @@ jobs:
           find src/main/resources
           cat src/main/resources/firebase/firebase_service_key.json
 
+      - name: env 파일 주입
+        run: |
+          echo "${{ secrets.PROD_ENV }}" > src/main/resources/.env
+
       - name: Gradle Caching
         uses: actions/cache@v3
         with:

--- a/.github/workflows/cd-pipeline-dev-aws.yml
+++ b/.github/workflows/cd-pipeline-dev-aws.yml
@@ -28,6 +28,10 @@ jobs:
           find src/main/resources
           cat src/main/resources/firebase/firebase_service_key.json
 
+      - name: env 파일 주입
+        run: |
+          echo "${{ secrets.DEV_ENV }}" > src/main/resources/.env
+
       - name: Gradle Caching
         uses: actions/cache@v3
         with:

--- a/.github/workflows/cd-pipeline-dev-aws.yml
+++ b/.github/workflows/cd-pipeline-dev-aws.yml
@@ -22,12 +22,6 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: application.yml 정보 넣기
-        run: |
-          mkdir -p src/main/resources
-          echo "${{ secrets.DEPLOY_APPLICATION_YML }}" | base64 --decode > src/main/resources/application-dev.yml
-          find src
-
       - name: FcmKey 정보 넣기
         run: |
           mkdir -p src/main/resources/firebase

--- a/.github/workflows/cd-pipeline-dev-aws.yml
+++ b/.github/workflows/cd-pipeline-dev-aws.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - dev
-      - swagger-login-fix
 
 jobs:
   job:

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ bin/
 !**/src/test/**/bin/
 
 ### dotenv ###
-.env
+**.env**
 
 ### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider

--- a/src/main/java/com/bbangle/bbangle/common/adaptor/slack/LocalSlackAdaptor.java
+++ b/src/main/java/com/bbangle/bbangle/common/adaptor/slack/LocalSlackAdaptor.java
@@ -1,16 +1,12 @@
 package com.bbangle.bbangle.common.adaptor.slack;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 
 @Slf4j
-@Profile({"default", "test"})
+@Profile({"test", "local"})
 @Component
 public class LocalSlackAdaptor implements SlackAdaptor {
 

--- a/src/main/java/com/bbangle/bbangle/config/CorsConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/CorsConfig.java
@@ -13,29 +13,29 @@ public class CorsConfig implements WebMvcConfigurer {
     private static final int ONE_HOUR = 60 * 60 * 1000;
 
     @Bean
-    @Profile({"dev", "default"})
+    @Profile({"dev", "local"})
     public WebMvcConfigurer devCorsConfigurer() {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(@NotNull CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOriginPatterns(
-                                "http://localhost:5000",
-                                "http://localhost:3000",
-                                "http://localhost:63342",
-                                "http://localhost:8001",
-                                "http://localhost:8000",
-                                "http://dev.bbanggree.com",
-                                "https://dev.bbanggree.com",
-                                "http://develop.bbanggree.com",
-                                "https://develop.bbanggree.com",
-                                "http://local.bbanggree.com:3000"
-                        )
-                        .allowedHeaders("*")
-                        .exposedHeaders("ACCESS_KEY", "Authorization", "RefreshToken")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")
-                        .maxAge(ONE_HOUR)
-                        .allowCredentials(true);
+                    .allowedOriginPatterns(
+                        "http://localhost:5000",
+                        "http://localhost:3000",
+                        "http://localhost:63342",
+                        "http://localhost:8001",
+                        "http://localhost:8000",
+                        "http://dev.bbanggree.com",
+                        "https://dev.bbanggree.com",
+                        "http://develop.bbanggree.com",
+                        "https://develop.bbanggree.com",
+                        "http://local.bbanggree.com:3000"
+                    )
+                    .allowedHeaders("*")
+                    .exposedHeaders("ACCESS_KEY", "Authorization", "RefreshToken")
+                    .allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")
+                    .maxAge(ONE_HOUR)
+                    .allowCredentials(true);
             }
         };
     }
@@ -47,16 +47,16 @@ public class CorsConfig implements WebMvcConfigurer {
             @Override
             public void addCorsMappings(@NotNull CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOriginPatterns(
-                                "https://www.bbanggree.com",
-                                "https://api.bbanggree.com",
-                                "https://master.d2xvuesi0d3ssg.amplifyapp.com"
-                        )
-                        .allowedHeaders("*")
-                        .exposedHeaders("ACCESS_KEY", "Authorization", "RefreshToken")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")
-                        .maxAge(ONE_HOUR)
-                        .allowCredentials(true);
+                    .allowedOriginPatterns(
+                        "https://www.bbanggree.com",
+                        "https://api.bbanggree.com",
+                        "https://master.d2xvuesi0d3ssg.amplifyapp.com"
+                    )
+                    .allowedHeaders("*")
+                    .exposedHeaders("ACCESS_KEY", "Authorization", "RefreshToken")
+                    .allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")
+                    .maxAge(ONE_HOUR)
+                    .allowCredentials(true);
             }
         };
     }

--- a/src/main/java/com/bbangle/bbangle/config/SwaggerConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/SwaggerConfig.java
@@ -21,7 +21,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
-@Profile({"dev", "default"}) // dev, local 환경에서만 Swagger 활성화
+@Profile({"dev", "local"}) // dev, local 환경에서만 Swagger 활성화
 public class SwaggerConfig {
 
     private static final String AUTHORIZATION_URL = "https://kauth.kakao.com/oauth/authorize";
@@ -30,24 +30,24 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         Info info = new Info()
-                .title("빵그리 API서버")
-                .description("본 문서는 외부에 유출하지 마세요.\n실제 서비스시에는 profile를 변경해 비활성시킵니다.")
-                .version("1.0.0");
+            .title("빵그리 API서버")
+            .description("본 문서는 외부에 유출하지 마세요.\n실제 서비스시에는 profile를 변경해 비활성시킵니다.")
+            .version("1.0.0");
 
         OAuthFlows oAuthFlows = new OAuthFlows()
-                .authorizationCode(new OAuthFlow()
-                        .authorizationUrl(AUTHORIZATION_URL)
-                        .tokenUrl(TOKEN_URL)
-                        .refreshUrl("/oauth/refresh")
-                        .scopes(new Scopes().addString("read", "읽기권한 부여")));
+            .authorizationCode(new OAuthFlow()
+                .authorizationUrl(AUTHORIZATION_URL)
+                .tokenUrl(TOKEN_URL)
+                .refreshUrl("/oauth/refresh")
+                .scopes(new Scopes().addString("read", "읽기권한 부여")));
 
         SecurityScheme jwtSchemes = new SecurityScheme()
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("Bearer")
-                .bearerFormat("JWT");
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("Bearer")
+            .bearerFormat("JWT");
         SecurityScheme oauthSchemes = new SecurityScheme()
-                .type(SecurityScheme.Type.OAUTH2)
-                .flows(oAuthFlows);
+            .type(SecurityScheme.Type.OAUTH2)
+            .flows(oAuthFlows);
         SecurityRequirement tokenLogin = new SecurityRequirement().addList("토큰 로그인");
         Server localServer = new Server();
         localServer.setDescription("local-server");
@@ -62,15 +62,15 @@ public class SwaggerConfig {
         devServerWithHttps.setUrl("https://dev.bbanggree.com");
 
         return new OpenAPI()
-                .info(info)
-                .servers(List.of(devServerWithHttps, localServer, devServerWithHttp))
-                .addSecurityItem(tokenLogin)
-                .addSecurityItem(new SecurityRequirement().addList("토큰 받아오기"))
-                .components(new Components()
-                        .addSecuritySchemes("토큰 로그인", jwtSchemes)
-                        .addSecuritySchemes("토큰 받아오기", oauthSchemes)
-                )
-                .security(Collections.singletonList(tokenLogin));
+            .info(info)
+            .servers(List.of(devServerWithHttps, localServer, devServerWithHttp))
+            .addSecurityItem(tokenLogin)
+            .addSecurityItem(new SecurityRequirement().addList("토큰 받아오기"))
+            .components(new Components()
+                .addSecuritySchemes("토큰 로그인", jwtSchemes)
+                .addSecuritySchemes("토큰 받아오기", oauthSchemes)
+            )
+            .security(Collections.singletonList(tokenLogin));
     }
 
     @Bean
@@ -84,9 +84,9 @@ public class SwaggerConfig {
             @Override
             public void addResourceHandlers(ResourceHandlerRegistry registry) {
                 registry.addResourceHandler("swagger-ui.html")
-                        .addResourceLocations("classpath:/META-INF/resources/");
+                    .addResourceLocations("classpath:/META-INF/resources/");
                 registry.addResourceHandler("/webjars/**")
-                        .addResourceLocations("classpath:/META-INF/resources/webjars/");
+                    .addResourceLocations("classpath:/META-INF/resources/webjars/");
             }
         };
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,84 @@
+### dev 설정파일
+
+server:
+  port: ${SERVER_PORT}
+  forward-headers-strategy: framework
+spring:
+  servlet:
+    multipart:
+      max-file-size: ${MAX_FILE_SIZE}
+      maxRequestSize: ${MAX_REQUEST_SIZE}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: none
+    #전송 쿼리 생성
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MariaDBDialect
+        default_batch_fetch_size: 200
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.mariadb.jdbc.Driver
+    hikari:
+      max-lifetime: 10780000
+      maximum-pool-size: 5
+      minimum-idle: 5
+  flyway:
+    locations: classpath:/flyway
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 5
+    fail-on-missing-locations: true
+
+logging:
+  level:
+    com.bbangle: DEBUG
+    com.zaxxer.hikari: DEBUG
+jwt:
+  issuer: ${JWT_ISSUER}
+  secret_key: ${JWT_SECRET}
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET}
+      end-point: ${S3_ENDPOINT}
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+      auto: false
+    stack:
+      auto: false
+    file-path:
+      recommend-board-data-file-url: ${RECOMMEND_BOARD_DATA_FILE_URL}
+      recommend-board-resource-data-url: ${RECOMMEND_BOARD_RESOURCE_DATA_URL}
+
+bucket:
+  domain: ${BUCKET_DOMAIN}
+cdn:
+  domain: ${CDN_DOMAIN}
+fcm:
+  key-path: ${FCM_KEY_PATH}
+  api-url: ${FCM_API_URL}
+  google-authentication-url: ${FCM_GOOGLE_AUTHENTICATION_URL}
+slack:
+  webhook-url: ${SLACK_WEBHOOK_URL}
+
+springdoc:
+  swagger-ui:
+    config-url: ${SWAGGER_CONFIG_URL}
+    url: ${SWAGGER_URL}
+
+app:
+  cookie:
+    domain: ${COOKIE_DOMAIN}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,8 @@ server:
   port: ${SERVER_PORT}
   forward-headers-strategy: framework
 spring:
+  config:
+    import: optional:classpath:.env[.properties]
   servlet:
     multipart:
       max-file-size: ${MAX_FILE_SIZE}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -76,3 +76,7 @@ fcm:
   google-authentication-url: ${FCM_GOOGLE_AUTHENTICATION_URL}
 slack:
   webhook-url: ${SLACK_WEBHOOK_URL}
+
+app:
+  cookie:
+    domain: ${COOKIE_DOMAIN}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,3 +1,5 @@
+### local 설정 파일
+
 server:
   port: ${SERVER_PORT}
 spring:
@@ -28,7 +30,6 @@ spring:
       max-lifetime: 10780000
       maximum-pool-size: 5
       minimum-idle: 5
-
   devtools:
     livereload:
       enabled: false
@@ -75,7 +76,3 @@ fcm:
   google-authentication-url: ${FCM_GOOGLE_AUTHENTICATION_URL}
 slack:
   webhook-url: ${SLACK_WEBHOOK_URL}
-
-app:
-  cookie:
-    domain: localhost

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,6 +3,8 @@
 server:
   port: ${SERVER_PORT}
 spring:
+  config:
+    import: optional:classpath:.env[.properties]
   servlet:
     multipart:
       max-file-size: ${MAX_FILE_SIZE}

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -4,6 +4,8 @@ server:
   port: ${SERVER_PORT}
   forward-headers-strategy: framework
 spring:
+  config:
+    import: optional:classpath:.env[.properties]
   servlet:
     multipart:
       max-file-size: ${MAX_FILE_SIZE}

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -1,0 +1,86 @@
+### dev 설정파일
+
+server:
+  port: ${SERVER_PORT}
+  forward-headers-strategy: framework
+spring:
+  servlet:
+    multipart:
+      max-file-size: ${MAX_FILE_SIZE}
+      maxRequestSize: ${MAX_REQUEST_SIZE}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: none
+    #전송 쿼리 생성
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MariaDBDialect
+        default_batch_fetch_size: 500
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.mariadb.jdbc.Driver
+    hikari:
+      max-lifetime: 10780000
+      maximum-pool-size: 5
+      minimum-idle: 5
+  flyway:
+    locations: classpath:/flyway
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 5
+    fail-on-missing-locations: true
+
+logging:
+  level:
+    root: info
+    com.zaxxer.hikari.HikariConfig: DEBUG
+    com.zaxxer.hikari: TRACE
+jwt:
+  issuer: ${JWT_ISSUER}
+  secret_key: ${JWT_SECRET}
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET}
+      end-point: ${S3_ENDPOINT}
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+      auto: false
+    stack:
+      auto: false
+    file-path:
+      recommend-board-data-file-url: ${RECOMMEND_BOARD_DATA_FILE_URL}
+      recommend-board-resource-data-url: ${RECOMMEND_BOARD_RESOURCE_DATA_URL}
+
+bucket:
+  domain: ${BUCKET_DOMAIN}
+cdn:
+  domain: ${CDN_DOMAIN}
+fcm:
+  key-path: ${FCM_KEY_PATH}
+  api-url: ${FCM_API_URL}
+  google-authentication-url: ${FCM_GOOGLE_AUTHENTICATION_URL}
+slack:
+  webhook-url: ${SLACK_WEBHOOK_URL}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      probes:
+        enabled: true

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -1,4 +1,4 @@
-### dev 설정파일
+### production 설정파일
 
 server:
   port: ${SERVER_PORT}


### PR DESCRIPTION
## 🚀 Major Changes & Explanations

### 1. application.yml 관리 방식 개선 및 Profile 분리
- 기존에는 dev / production 환경의 application.yml을 수동으로 관리하고, 배포 파이프라인에서 파일을 주입하는 방식으로 운영하고 있었습니다.
- 이로 인해 설정 파일을 수동으로 관리해야 했고, 변경 이력 추적이 어렵다는 문제가 있었습니다.

이를 개선하기 위해 환경별 application.yml 파일을 해당 레포지토리에서 직접 관리하도록 결정했습니다.
다만 환경별 설정 분리가 필요하여, application.yml을 Spring Profile 기반으로 분리하고
각 환경(dev, production)에 맞게 관리하도록 구성했습니다.

또한 기존에는 로컬 실행 시 default profile을 사용하고 있었으나,
환경별 역할을 명확히 구분하기 위해 default 대신 local profile을 사용하도록 변경했습니다.

### 2. CI / CD 파이프라인 수정

- 위와 같은 구조로 변경함에 따라, GitHub Actions 워크플로우에서 수행하던 application.yml 생성 및 주입 job을 제거했습니다.
  - 이제 application.yml 설정 파일은 CI/CD 단계에서 주입되지 않으며, Profile과 환경 변수 기반으로 런타임에서 결정됩니다.
- env 파일을 주입해주는 jop이 추가 되었습니다.

## 팀원 모두가 확인이 필요한 부분
- 로컬에서 실행 시 jvm 옵션에 `-Dspring.profiles.active=local` 추가해줘야 합니다. 
- .env 파일 수정되었으므로 확인 부탁드립니다.
- 자세한 내용은 백엔드 자료실의 애플리케이션 실행 가이드를 참고해 주세요.

## TODO
- [x] application.yml 환경별 구성 및 profile 설정
- [x] ci/cd 파이프라인 수정(application.yml 주입 jop 삭제, env 파일 주입 jop 추가)
- [x] applicatiom.yml 관련 Github secret 제거 및 env secret 추가
- [x] 백엔드 자료실 업데이트
