### PR TITLE
[Feature] 관리자 공지사항 등록 기능

### DIFF
--- a/src/main/java/com/bbangle/bbangle/config/security/WebOAuthSecurityConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/WebOAuthSecurityConfig.java
@@ -63,12 +63,14 @@ public class WebOAuthSecurityConfig implements WebMvcConfigurer {
                 .addFilterBefore(tokenAuthenticationFilter(),
                         UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/.well-known/**").permitAll() // Chrome DevTools 및 well-known URI
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll() // Swagger
                         .requestMatchers(PublicApiPath.ANY_METHOD).permitAll() // Public (모든 HTTP 메서드)
                         .requestMatchers(GET, PublicApiPath.GET_ONLY).permitAll() //Public (GET 전용)
                         .requestMatchers(PATCH, PublicApiPath.PATCH_OLLY).permitAll() // Public (PATCH 전용)
                         .requestMatchers(CustomerApiPath.ANY_METHOD)
                         .hasAuthority(ROLE_CUSTOMER.getRole()) // Customer API
-                        .requestMatchers(SellerApiPath.ANY_METHOD).hasAuthority(ROLE_SELLER.getRole())  // Seller API
+                        .requestMatchers(SellerApiPath.ANY_METHOD).permitAll()  // Seller API
                         .requestMatchers(AdminApiPath.ANY_METHOD).hasAuthority(ROLE_ADMIN.getRole()) // Admin API
                         .requestMatchers("/api/**").authenticated() // 나머지 /api 하위는 인증 필요
                         .anyRequest().permitAll())

--- a/src/main/java/com/bbangle/bbangle/config/security/WebOAuthSecurityConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/WebOAuthSecurityConfig.java
@@ -70,7 +70,7 @@ public class WebOAuthSecurityConfig implements WebMvcConfigurer {
                         .requestMatchers(PATCH, PublicApiPath.PATCH_OLLY).permitAll() // Public (PATCH 전용)
                         .requestMatchers(CustomerApiPath.ANY_METHOD)
                         .hasAuthority(ROLE_CUSTOMER.getRole()) // Customer API
-                        .requestMatchers(SellerApiPath.ANY_METHOD).permitAll()  // Seller API
+                        .requestMatchers(SellerApiPath.ANY_METHOD).hasAuthority(ROLE_SELLER.getRole()) // Seller API
                         .requestMatchers(AdminApiPath.ANY_METHOD).hasAuthority(ROLE_ADMIN.getRole()) // Admin API
                         .requestMatchers("/api/**").authenticated() // 나머지 /api 하위는 인증 필요
                         .anyRequest().permitAll())

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -108,7 +108,12 @@ public enum BbangleErrorCode {
     ADMIN_NOT_FOUND(-741, "존재하지 않는 관리자입니다.", NOT_FOUND),
     INVALID_ADMIN_ID(-740, "유효하지 않은 관리자 아이디 입니다.", BAD_REQUEST),
     ADMIN_INVALID_PASSWORD(-742, "비밀번호가 일치하지 않습니다.", BAD_REQUEST),
-    INVALID_REFRESH_TOKEN(-743, "유효하지 않은 리프레시 토큰입니다.", BAD_REQUEST);
+    INVALID_REFRESH_TOKEN(-743, "유효하지 않은 리프레시 토큰입니다.", BAD_REQUEST),
+
+    // NOTICE Error(761~770)
+    TITLE_IS_EMPTY(-761, "제목이 존재하지 않습니다.",BAD_REQUEST),
+    CONTENT_IS_EMPTY(-762, "본문이 존재하지 않습니다.",BAD_REQUEST),
+    ADMIN_NOTICE_CREATION_FAILED(-763, "본문이 존재하지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final int code;
     private final String message;

--- a/src/main/java/com/bbangle/bbangle/image/customer/service/S3Service.java
+++ b/src/main/java/com/bbangle/bbangle/image/customer/service/S3Service.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -41,7 +40,6 @@ public class S3Service {
     @Value("${cdn.domain}")
     private String cdnDomain;
 
-    @Transactional
     public String saveImage(MultipartFile request) {
         validateImage(request);
 
@@ -51,7 +49,6 @@ public class S3Service {
         return uploadImage(request, ext, changedImageName);
     }
 
-    @Transactional
     public String saveAndReturnWithCdn(String folderName, MultipartFile image) {
         String imagePath = saveImage(image, folderName);
         log.debug("Show image path: {}", imagePath);
@@ -59,7 +56,12 @@ public class S3Service {
         return addCdnDomain(imagePath);
     }
 
-    @Transactional
+    public List<String> saveMultipleAndReturnWithCdn(String folderName, List<MultipartFile> images) {
+        return images.stream()
+            .map(image -> saveAndReturnWithCdn(folderName, image))
+            .toList();
+    }
+
     public String saveImage(MultipartFile request, String folder) {
         validateImage(request);
 
@@ -83,6 +85,10 @@ public class S3Service {
 
     public void deleteImages(List<String> urls) {
         urls.forEach(url -> amazonS3.deleteObject(bucket, url));
+    }
+
+    public void deleteImagesCdn(List<String> urls) {
+       urls.forEach(this::deleteImage);
     }
 
     public void deleteImage(String url) {

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationApi.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationApi.java
@@ -1,0 +1,21 @@
+package com.bbangle.bbangle.notification.admin.controller;
+
+import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationCreateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Notification", description = "(관리자) 공지사항 API")
+public interface AdminNotificationApi {
+
+    @Operation(summary = "(관리자) 공지사항 등록")
+    SingleResult<AdminNotificationCreateResponse> registerNotification(
+        Long adminId,
+        AdminNotificationCreateRequest request,
+        List<MultipartFile> profileImage
+    );
+
+}

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
@@ -1,0 +1,41 @@
+package com.bbangle.bbangle.notification.admin.controller;
+
+import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.AdminApiPath;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationCreateResponse;
+import com.bbangle.bbangle.notification.admin.facade.AdminNotificationFacade;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(AdminApiPath.PREFIX + "/notifications")
+public class AdminNotificationController implements AdminNotificationApi {
+
+    private final ResponseService responseService;
+    private final AdminNotificationFacade adminNotificationFacade;
+
+    @PostMapping(value= "/{adminId}/register", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @Override
+    public SingleResult<AdminNotificationCreateResponse> registerNotification(@PathVariable Long adminId,
+                                                                              @RequestPart @Valid AdminNotificationCreateRequest request,
+                                                                              @RequestPart List<MultipartFile> profileImage) {
+
+        NoticeInfo noticeInfo = adminNotificationFacade.createNotice(adminId, request, profileImage);
+        AdminNotificationCreateResponse response = AdminNotificationCreateResponse.from(noticeInfo);
+
+        return responseService.getSingleResult(response);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/dto/AdminNotificationRequest.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/dto/AdminNotificationRequest.java
@@ -1,0 +1,38 @@
+package com.bbangle.bbangle.notification.admin.controller.dto;
+
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeCreateCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+
+public class AdminNotificationRequest {
+
+    @Schema(description = "관리자 공지사항 생성 DTO")
+    public record AdminNotificationCreateRequest(
+        @Schema(description = "공지사항 제목")
+        @NotBlank(message = "공지사항 제목은 필수입니다.")
+        String title,
+        @Schema(description = "공지사항 본문")
+        @NotBlank(message = "공지사항 본문은 필수입니다.")
+        String content,
+        @Schema(description = "링크 목록")
+        List<LinkDto> links
+    ) {
+
+        public AdminNoticeCreateCommand toCreateCommand(Long adminId, List<String> imageLinks) {
+            return AdminNoticeCreateCommand.builder()
+                .adminId(adminId)
+                .title(title)
+                .content(content)
+                .links(links)
+                .imageLinks(imageLinks)
+                .build();
+        }
+    }
+
+
+
+}
+
+

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/dto/AdminNotificationResponse.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/dto/AdminNotificationResponse.java
@@ -1,0 +1,44 @@
+package com.bbangle.bbangle.notification.admin.controller.dto;
+
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+public class AdminNotificationResponse {
+
+    @Schema(description = "관리자 공지사항 응답 DTO")
+    @Builder
+    public record AdminNotificationCreateResponse(
+        @Schema(description = "공지사항 ID")
+        Long id,
+        @Schema(description = "제목")
+        String title,
+        @Schema(description = "내용")
+        String content,
+        @Schema(description = "링크 목록")
+        List<LinkDto> links,
+        @Schema(description = "이미지 링크 목록")
+        List<String> imageLinks,
+        @Schema(description = "생성 일시")
+        LocalDateTime createAt,
+        @Schema(description = "수정 일시")
+        LocalDateTime modifiedAt
+    ){
+
+        public static AdminNotificationCreateResponse from(NoticeInfo noticeInfo) {
+            return AdminNotificationCreateResponse.builder()
+                .id(noticeInfo.id())
+                .title(noticeInfo.title())
+                .content(noticeInfo.content())
+                .links(noticeInfo.links())
+                .imageLinks(noticeInfo.imageLinks())
+                .createAt(noticeInfo.createAt())
+                .modifiedAt(noticeInfo.modifiedAt())
+                .build();
+        }
+    }
+
+
+}

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/dto/LinkDto.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/dto/LinkDto.java
@@ -1,0 +1,9 @@
+package com.bbangle.bbangle.notification.admin.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LinkDto(@Schema(description = "링크 URL", example = "https://example.com")
+                      String url,
+                      @Schema(description = "링크 표시 텍스트", example = "더보기")
+                      String linkText) {
+}

--- a/src/main/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacade.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacade.java
@@ -1,0 +1,39 @@
+package com.bbangle.bbangle.notification.admin.facade;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.image.customer.service.S3Service;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.service.AdminNotificationService;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class AdminNotificationFacade {
+
+     private final S3Service s3Service;
+     private final AdminNotificationService adminNotificationService;
+
+    private static final String ADMIN_NOTICE_FOLDER = "admin-notice-images";
+
+    public NoticeInfo createNotice(Long adminId, AdminNotificationCreateRequest request, List<MultipartFile> profileImage) {
+        // 이미지 저장
+        List<String> imageLinks = s3Service.saveMultipleAndReturnWithCdn(ADMIN_NOTICE_FOLDER, profileImage);
+        try {
+            // 공지사항 생성
+            return adminNotificationService.createAdminNotification(request.toCreateCommand(adminId, imageLinks));
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            log.debug("이미지 업로드 되어진 이미지 삭제 진행");
+            s3Service.deleteImagesCdn(imageLinks);
+            throw new BbangleException(BbangleErrorCode.ADMIN_NOTICE_CREATION_FAILED);
+        }
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationService.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationService.java
@@ -1,0 +1,47 @@
+package com.bbangle.bbangle.notification.admin.service;
+
+
+import com.bbangle.bbangle.admin.domain.Admin;
+import com.bbangle.bbangle.admin.repository.AdminRepository;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeCreateCommand;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
+import com.bbangle.bbangle.notification.domain.Notice;
+import com.bbangle.bbangle.notification.repository.NotificationRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminNotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final AdminRepository adminRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public NoticeInfo createAdminNotification(AdminNoticeCreateCommand command) {
+        Admin admin = adminRepository.findById(command.adminId())
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.ADMIN_NOT_FOUND));
+
+        try {
+            String linksJson = objectMapper.writeValueAsString(command.links());
+            String imageLinksJson = objectMapper.writeValueAsString(command.imageLinks());
+
+            Notice notice = Notice.createNoticeForAdmin(command.title(), command.content(), linksJson, imageLinksJson, admin);
+            Notice savedNotice = notificationRepository.save(notice);
+
+            return NoticeInfo.from(savedNotice, objectMapper);
+        } catch (JsonProcessingException e) {
+            throw new BbangleException(BbangleErrorCode.JSON_SERIALIZATION_ERROR);
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+
+}

--- a/src/main/java/com/bbangle/bbangle/notification/admin/service/model/AdminNoticeCommand.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/service/model/AdminNoticeCommand.java
@@ -1,0 +1,19 @@
+package com.bbangle.bbangle.notification.admin.service.model;
+
+import com.bbangle.bbangle.notification.admin.controller.dto.LinkDto;
+import java.util.List;
+import lombok.Builder;
+
+public class AdminNoticeCommand {
+
+    @Builder
+    public record AdminNoticeCreateCommand(Long adminId,
+                                           String title,
+                                           String content,
+                                           List<LinkDto> links,
+                                           List<String> imageLinks) {
+    }
+
+
+
+}

--- a/src/main/java/com/bbangle/bbangle/notification/admin/service/model/AdminNoticeInfo.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/service/model/AdminNoticeInfo.java
@@ -1,0 +1,54 @@
+package com.bbangle.bbangle.notification.admin.service.model;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.notification.admin.controller.dto.LinkDto;
+import com.bbangle.bbangle.notification.domain.Notice;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+public class AdminNoticeInfo {
+
+    @Builder
+    public record NoticeInfo(Long id,
+                             String title,
+                             String content,
+                             List<LinkDto> links,
+                             List<String> imageLinks,
+                             LocalDateTime createAt,
+                             LocalDateTime modifiedAt) {
+
+
+        public static NoticeInfo from(Notice notice, ObjectMapper objectMapper) {
+            try {
+                List<LinkDto> linksList = notice.getLinks() != null
+                    ? objectMapper.readValue(notice.getLinks(), new TypeReference<List<LinkDto>>() {})
+                    : List.of();
+
+                List<String> imageLinksList = notice.getImageLinks() != null
+                    ? objectMapper.readValue(notice.getImageLinks(), new TypeReference<List<String>>() {})
+                    : List.of();
+
+                return NoticeInfo.builder()
+                    .id(notice.getId())
+                    .title(notice.getTitle())
+                    .content(notice.getContent())
+                    .links(linksList)
+                    .imageLinks(imageLinksList)
+                    .createAt(notice.getCreatedAt())
+                    .modifiedAt(notice.getModifiedAt())
+                    .build();
+            } catch (JsonProcessingException e) {
+                throw new BbangleException(BbangleErrorCode.JSON_SERIALIZATION_ERROR);
+            }
+        }
+
+    }
+
+
+
+}

--- a/src/main/java/com/bbangle/bbangle/notification/domain/Notice.java
+++ b/src/main/java/com/bbangle/bbangle/notification/domain/Notice.java
@@ -1,10 +1,20 @@
 package com.bbangle.bbangle.notification.domain;
 
+import com.bbangle.bbangle.admin.domain.Admin;
+import com.bbangle.bbangle.common.domain.BaseEntity;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.notification.customer.dto.NotificationResponse;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -13,7 +23,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
 
 @Table(name = "notice")
 @Entity
@@ -21,15 +30,21 @@ import org.hibernate.annotations.CreationTimestamp;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Notice {
+public class Notice extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String title;
     private String content;
-    @CreationTimestamp
-    private LocalDateTime createdAt;
+    @Column(columnDefinition = "JSON")
+    private String links;
+    @Column(columnDefinition = "JSON")
+    private String imageLinks;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Admin admin;
 
     public static NotificationResponse makeNotificationResponse(Notice notice) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
@@ -41,4 +56,30 @@ public class Notice {
             formattedDateTime
         );
     }
+
+    public static Notice createNoticeForAdmin(String title, String content, String links , String imageLinks, Admin admin) {
+        return new Notice(title, content, links, imageLinks, admin);
+    }
+
+    public Notice(String title, String content, String links , String imageLinks, Admin admin) {
+        validateField(title, content, admin);
+        this.title = title;
+        this.content = content;
+        this.links = links;
+        this.imageLinks = imageLinks;
+        this.admin = admin;
+    }
+
+    private void validateField(String title, String content, Admin admin) {
+        if (title == null || title.isEmpty()) {
+            throw new BbangleException(BbangleErrorCode.TITLE_IS_EMPTY);
+        }
+        if (content == null || content.isEmpty()) {
+            throw new BbangleException(BbangleErrorCode.CONTENT_IS_EMPTY);
+        }
+        if (admin == null) {
+            throw new BbangleException(BbangleErrorCode.ADMIN_NOT_FOUND);
+        }
+    }
+
 }

--- a/src/main/resources/flyway/V25__app.sql
+++ b/src/main/resources/flyway/V25__app.sql
@@ -1,0 +1,6 @@
+ALTER TABLE notice
+ADD COLUMN links JSON NULL,
+ADD COLUMN image_links JSON NULL,
+ADD COLUMN modified_at datetime(6) NULL,
+ADD COLUMN admin_id INT NULL;
+

--- a/src/test/java/com/bbangle/bbangle/auth/admin/service/AdminAuthServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/admin/service/AdminAuthServiceUnitTest.java
@@ -121,4 +121,12 @@ class AdminAuthServiceUnitTest {
         // then
         verify(refreshTokenRepository, times(1)).deleteByUserIdAndUserRole(adminId, Role.ROLE_ADMIN);
     }
+
+    @Test
+    @DisplayName("관리자 비밀번호 생성 테스트")
+    void getEncodedPassword() {
+        String rawPassword = "your_password"; // 사용하고 싶은 실제 비밀번호
+        String encodedPassword = passwordEncoder.encode(rawPassword);
+        System.out.println("Encoded Password: " + encodedPassword);
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/fixture/NoticeFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/NoticeFixture.java
@@ -10,24 +10,26 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NoticeFixture {
 
-    private static final Admin TEST_ADMIN = Admin.builder()
-        .accountId("test-admin")
-        .password("test-password")
-        .name("테스트 관리자")
-        .build();
-
-    public static Notice notice(String title, String content) {
-        return new Notice(title, content, null, null, TEST_ADMIN);
+    public static Admin createTestAdmin() {
+        return Admin.builder()
+            .accountId("test-admin")
+            .password("test-password")
+            .name("테스트 관리자")
+            .build();
     }
 
-    public static Notice notice(String title, String content, LocalDateTime createdAt) {
-        Notice notice = new Notice(title, content, null, null, TEST_ADMIN);
+    public static Notice notice(String title, String content, Admin admin) {
+        return new Notice(title, content, null, null, admin);
+    }
+
+    public static Notice notice(String title, String content, LocalDateTime createdAt, Admin admin) {
+        Notice notice = new Notice(title, content, null, null, admin);
         setCreatedAt(notice, createdAt);
         return notice;
     }
 
-    public static Notice noticeWithIdAndCreatedAt(Long id, String title, String content, LocalDateTime createdAt) {
-        Notice notice = new Notice(title, content, null, null, TEST_ADMIN);
+    public static Notice noticeWithIdAndCreatedAt(Long id, String title, String content, LocalDateTime createdAt, Admin admin) {
+        Notice notice = new Notice(title, content, null, null, admin);
         setId(notice, id);
         setCreatedAt(notice, createdAt);
         return notice;

--- a/src/test/java/com/bbangle/bbangle/fixture/NoticeFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/NoticeFixture.java
@@ -1,6 +1,8 @@
 package com.bbangle.bbangle.fixture;
 
+import com.bbangle.bbangle.admin.domain.Admin;
 import com.bbangle.bbangle.notification.domain.Notice;
+import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -8,12 +10,47 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NoticeFixture {
 
+    private static final Admin TEST_ADMIN = Admin.builder()
+        .accountId("test-admin")
+        .password("test-password")
+        .name("테스트 관리자")
+        .build();
+
+    public static Notice notice(String title, String content) {
+        return new Notice(title, content, null, null, TEST_ADMIN);
+    }
+
     public static Notice notice(String title, String content, LocalDateTime createdAt) {
-        return Notice.builder()
-                .title(title)
-                .content(content)
-                .createdAt(createdAt)
-                .build();
+        Notice notice = new Notice(title, content, null, null, TEST_ADMIN);
+        setCreatedAt(notice, createdAt);
+        return notice;
+    }
+
+    public static Notice noticeWithIdAndCreatedAt(Long id, String title, String content, LocalDateTime createdAt) {
+        Notice notice = new Notice(title, content, null, null, TEST_ADMIN);
+        setId(notice, id);
+        setCreatedAt(notice, createdAt);
+        return notice;
+    }
+
+    private static void setId(Notice notice, Long id) {
+        try {
+            Field field = notice.getClass().getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(notice, id);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Failed to set id field", e);
+        }
+    }
+
+    private static void setCreatedAt(Notice notice, LocalDateTime createdAt) {
+        try {
+            Field field = notice.getClass().getSuperclass().getSuperclass().getDeclaredField("createdAt");
+            field.setAccessible(true);
+            field.set(notice, createdAt);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Failed to set createdAt field", e);
+        }
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/notification/admin/NoticeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/admin/NoticeUnitTest.java
@@ -1,0 +1,158 @@
+package com.bbangle.bbangle.notification.admin;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bbangle.bbangle.admin.domain.Admin;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.notification.domain.Notice;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[단위 테스트] Notice")
+public class NoticeUnitTest {
+
+    private static final Admin TEST_ADMIN = Admin.builder()
+        .accountId("test-admin")
+        .password("test-password")
+        .name("테스트 관리자")
+        .build();
+
+    @Test
+    @DisplayName("관리자용 공지사항 생성에 성공한다.")
+    void success_create_notice_for_admin() {
+        // arrange
+        String title = "공지사항 제목";
+        String content = "공지사항 내용";
+        String links = "[\"https://example.com\"]";
+        String imageLinks = "[\"https://example.com\"]";
+
+        // act
+        Notice notice = Notice.createNoticeForAdmin(title, content, links, imageLinks, TEST_ADMIN);
+
+        // assert
+        assertThat(notice).isNotNull();
+        assertThat(notice.getTitle()).isEqualTo(title);
+        assertThat(notice.getContent()).isEqualTo(content);
+        assertThat(notice.getLinks()).isEqualTo(links);
+        assertThat(notice.getImageLinks()).isEqualTo(imageLinks);
+    }
+
+    @Test
+    @DisplayName("title이 null이면 공지사항 생성에 실패한다.")
+    void fail_create_notice_when_title_is_null() {
+        // arrange
+        String title = null;
+        String content = "공지사항 내용";
+        String links = "[\"https://example.com\"]";
+        String imageLinks = "[\"https://example.com\"]";
+
+        // act & assert
+        assertThatThrownBy(() -> Notice.createNoticeForAdmin(title, content, links, imageLinks, TEST_ADMIN))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.TITLE_IS_EMPTY.getMessage());
+    }
+
+    @Test
+    @DisplayName("title이 empty이면 공지사항 생성에 실패한다.")
+    void fail_create_notice_when_title_is_empty() {
+        // arrange
+        String title = "";
+        String content = "공지사항 내용";
+        String links = "[\"https://example.com\"]";
+        String imageLinks = "[\"https://image.example.com\"]";
+
+        // act & assert
+        assertThatThrownBy(() -> Notice.createNoticeForAdmin(title, content, links, imageLinks, TEST_ADMIN))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.TITLE_IS_EMPTY.getMessage());
+    }
+
+    @Test
+    @DisplayName("content가 null이면 공지사항 생성에 실패한다.")
+    void fail_create_notice_when_content_is_null() {
+        // arrange
+        String title = "공지사항 제목";
+        String content = null;
+        String links = "[\"https://example.com\"]";
+        String imageLinks = "[\"https://image.example.com\"]";
+
+        // act & assert
+        assertThatThrownBy(() -> Notice.createNoticeForAdmin(title, content, links, imageLinks, TEST_ADMIN))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.CONTENT_IS_EMPTY.getMessage());
+    }
+
+    @Test
+    @DisplayName("content가 empty이면 공지사항 생성에 실패한다.")
+    void fail_create_notice_when_content_is_empty() {
+        // arrange
+        String title = "공지사항 제목";
+        String content = "";
+        String links = "[\"https://example.com\"]";
+        String imageLinks = "[\"https://image.example.com\"]";
+
+        // act & assert
+        assertThatThrownBy(() -> Notice.createNoticeForAdmin(title, content, links, imageLinks, TEST_ADMIN))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.CONTENT_IS_EMPTY.getMessage());
+    }
+
+    @Test
+    @DisplayName("links가 null이어도 공지사항 생성에 성공한다.")
+    void success_create_notice_when_links_is_null() {
+        // arrange
+        String title = "공지사항 제목";
+        String content = "공지사항 내용";
+        String links = null;
+        String imageLinks = "[\"https://image.example.com\"]";
+
+        // act
+        Notice notice = Notice.createNoticeForAdmin(title, content, links, imageLinks, TEST_ADMIN);
+
+        // assert
+        assertThat(notice).isNotNull();
+        assertThat(notice.getTitle()).isEqualTo(title);
+        assertThat(notice.getContent()).isEqualTo(content);
+        assertThat(notice.getLinks()).isNull();
+        assertThat(notice.getImageLinks()).isEqualTo(imageLinks);
+    }
+
+    @Test
+    @DisplayName("imageLinks가 null이어도 공지사항 생성에 성공한다.")
+    void success_create_notice_when_imageLinks_is_null() {
+        // arrange
+        String title = "공지사항 제목";
+        String content = "공지사항 내용";
+        String links = "[\"https://example.com\"]";
+        String imageLinks = null;
+
+        // act
+        Notice notice = Notice.createNoticeForAdmin(title, content, links, imageLinks, TEST_ADMIN);
+
+        // assert
+        assertThat(notice).isNotNull();
+        assertThat(notice.getTitle()).isEqualTo(title);
+        assertThat(notice.getContent()).isEqualTo(content);
+        assertThat(notice.getLinks()).isEqualTo(links);
+        assertThat(notice.getImageLinks()).isNull();
+    }
+
+    @Test
+    @DisplayName("admin이 null이면 공지사항 생성에 실패한다.")
+    void fail_create_notice_when_admin_is_null() {
+        // arrange
+        String title = "공지사항 제목";
+        String content = "공지사항 내용";
+        String links = "[\"https://example.com\"]";
+        String imageLinks = "[\"https://image.example.com\"]";
+        Admin admin = null;
+
+        // act & assert
+        assertThatThrownBy(() -> Notice.createNoticeForAdmin(title, content, links, imageLinks, admin))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.ADMIN_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationControllerTest.java
@@ -1,0 +1,217 @@
+package com.bbangle.bbangle.notification.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.JsonDataEncoder;
+import com.bbangle.bbangle.config.security.AdminApiPath;
+import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.controller.dto.LinkDto;
+import com.bbangle.bbangle.notification.admin.facade.AdminNotificationFacade;
+import com.bbangle.bbangle.notification.admin.service.AdminNotificationService;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@DisplayName("[컨트롤러 테스트] AdminNotificationController")
+@WebMvcTest(controllers = AdminNotificationController.class)
+@Import({
+    TestSlackAdaptorConfig.class,
+    JsonDataEncoder.class,
+    TokenProvider.class,
+    TestJwtPropertiesConfig.class,
+    ResponseService.class
+})
+@ActiveProfiles("test")
+public class AdminNotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AdminNotificationFacade adminNotificationFacade;
+
+    @MockBean
+    private AdminNotificationService adminNotificationService;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("관리자 공지사항을 정상적으로 생성한다")
+    void registerNotification_Succeeds_WithValidInput() throws Exception {
+        // given
+        Long adminId = 1L;
+
+        // 1. 요청 DTO 생성
+        List<LinkDto> links = List.of(
+            new LinkDto("https://example.com", "더보기")
+        );
+
+        AdminNotificationCreateRequest createRequest = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "<div>공지사항 본문 HTML</div>",
+            links
+        );
+
+        // 2. 업로드할 가짜 이미지 파일들 생성
+        MockMultipartFile image1 = new MockMultipartFile(
+            "profileImage",
+            "image1.jpg",
+            MediaType.IMAGE_JPEG_VALUE,
+            "image1 content".getBytes()
+        );
+
+        MockMultipartFile image2 = new MockMultipartFile(
+            "profileImage",
+            "image2.jpg",
+            MediaType.IMAGE_JPEG_VALUE,
+            "image2 content".getBytes()
+        );
+
+        // 3. DTO를 JSON으로 변환
+        String requestJson = objectMapper.writeValueAsString(createRequest);
+
+        // 4. JSON 데이터를 MockMultipartFile로 감싸기
+        MockMultipartFile requestPart = new MockMultipartFile(
+            "request",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            requestJson.getBytes(StandardCharsets.UTF_8)
+        );
+
+        // 5. Mock 응답 데이터 생성
+        NoticeInfo mockNoticeInfo = NoticeInfo.builder()
+            .id(1L)
+            .title("공지사항 제목")
+            .content("<div>공지사항 본문 HTML</div>")
+            .links(links)
+            .imageLinks(List.of(
+                "https://cdn.example.com/image1.jpg",
+                "https://cdn.example.com/image2.jpg"
+            ))
+            .createAt(LocalDateTime.now())
+            .modifiedAt(LocalDateTime.now())
+            .build();
+
+        // 6. Facade Mock 동작 정의
+        when(adminNotificationFacade.createNotice(any(Long.class), any(), any()))
+            .thenReturn(mockNoticeInfo);
+
+        // when & then
+        mockMvc.perform(
+                MockMvcRequestBuilders.multipart(AdminApiPath.PREFIX + "/notifications/" + adminId + "/register")
+                    .file(image1)
+                    .file(image2)
+                    .file(requestPart)
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.result.id").value(1L))
+            .andExpect(jsonPath("$.result.title").value("공지사항 제목"))
+            .andExpect(jsonPath("$.result.content").value("<div>공지사항 본문 HTML</div>"))
+            .andExpect(jsonPath("$.result.links[0].url").value("https://example.com"))
+            .andExpect(jsonPath("$.result.links[0].linkText").value("더보기"))
+            .andExpect(jsonPath("$.result.imageLinks[0]").value("https://cdn.example.com/image1.jpg"))
+            .andExpect(jsonPath("$.result.imageLinks[1]").value("https://cdn.example.com/image2.jpg"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("제목이 비어있으면 공지사항 생성에 실패한다")
+    void registerNotification_Fails_WithBlankTitle() throws Exception {
+        // given
+        Long adminId = 1L;
+
+        AdminNotificationCreateRequest createRequest = new AdminNotificationCreateRequest(
+            "", // 빈 제목
+            "<div>공지사항 본문 HTML</div>",
+            List.of()
+        );
+
+        MockMultipartFile image = new MockMultipartFile(
+            "profileImage",
+            "image.jpg",
+            MediaType.IMAGE_JPEG_VALUE,
+            "image content".getBytes()
+        );
+
+        String requestJson = objectMapper.writeValueAsString(createRequest);
+        MockMultipartFile requestPart = new MockMultipartFile(
+            "request",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            requestJson.getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when & then
+        mockMvc.perform(
+                MockMvcRequestBuilders.multipart(AdminApiPath.PREFIX + "/notifications/" + adminId + "/register")
+                    .file(image)
+                    .file(requestPart)
+            )
+            .andDo(print())
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("본문이 비어있으면 공지사항 생성에 실패한다")
+    void registerNotification_Fails_WithBlankContent() throws Exception {
+        // given
+        Long adminId = 1L;
+
+        AdminNotificationCreateRequest createRequest = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "", // 빈 본문
+            List.of()
+        );
+
+        MockMultipartFile image = new MockMultipartFile(
+            "profileImage",
+            "image.jpg",
+            MediaType.IMAGE_JPEG_VALUE,
+            "image content".getBytes()
+        );
+
+        String requestJson = objectMapper.writeValueAsString(createRequest);
+        MockMultipartFile requestPart = new MockMultipartFile(
+            "request",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            requestJson.getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when & then
+        mockMvc.perform(
+                MockMvcRequestBuilders.multipart(AdminApiPath.PREFIX + "/notifications/" + adminId + "/register")
+                    .file(image)
+                    .file(requestPart)
+            )
+            .andDo(print())
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacadeIntegrationTest.java
@@ -1,0 +1,189 @@
+package com.bbangle.bbangle.notification.admin.facade;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bbangle.bbangle.admin.domain.Admin;
+import com.bbangle.bbangle.admin.repository.AdminRepository;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.image.customer.service.S3Service;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.controller.dto.LinkDto;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
+import com.bbangle.bbangle.notification.repository.NotificationRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@DisplayName("[통합 테스트] AdminNotificationFacade")
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class AdminNotificationFacadeIntegrationTest {
+
+    @Autowired
+    private AdminNotificationFacade adminNotificationFacade;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private S3Service s3Service;
+
+    private Long testAdminId;
+
+    @BeforeEach
+    void resetTable() {
+        em.flush();
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+        em.createNativeQuery("TRUNCATE TABLE notice").executeUpdate();
+        em.createNativeQuery("TRUNCATE TABLE admin").executeUpdate();
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+
+        // 테스트용 Admin 생성
+        Admin testAdmin = Admin.builder()
+            .accountId("test-admin")
+            .password("test-password")
+            .name("테스트 관리자")
+            .build();
+        testAdminId = adminRepository.save(testAdmin).getId();
+        em.flush();
+        em.clear();
+    }
+
+
+    @Test
+    @DisplayName("관리자 공지사항 생성에 성공한다")
+    void success_create_notification_with_images() {
+        // given
+        List<LinkDto> links = List.of(
+            new LinkDto("https://example.com", "더보기"),
+            new LinkDto("https://example2.com", "상세보기")
+        );
+
+        // MockMultipartFile을 사용하여 이미지 파일 생성
+        MockMultipartFile image1 = new MockMultipartFile(
+            "images",                       // 파라미터 이름
+            "image1.jpg",                   // 원본 파일명
+            MediaType.IMAGE_JPEG_VALUE,     // 컨텐츠 타입
+            "image1 content".getBytes()     // 파일 내용
+        );
+
+        MockMultipartFile image2 = new MockMultipartFile(
+            "images",
+            "image2.jpg",
+            MediaType.IMAGE_JPEG_VALUE,
+            "image2 content".getBytes()
+        );
+
+        List<MultipartFile> images = List.of(image1, image2);
+
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "공지사항 내용",
+            links
+        );
+
+        // S3Service Mock 설정: 이미지 업로드 성공
+        List<String> mockImageUrls = List.of(
+            "https://cdn.example.com/image1.jpg",
+            "https://cdn.example.com/image2.jpg"
+        );
+        when(s3Service.saveMultipleAndReturnWithCdn(anyString(), anyList()))
+            .thenReturn(mockImageUrls);
+
+        // when
+        NoticeInfo noticeInfo = adminNotificationFacade.createNotice(testAdminId, request, images);
+
+        // then
+        assertThat(noticeInfo).isNotNull();
+        assertThat(noticeInfo.id()).isNotNull();
+        assertThat(noticeInfo.title()).isEqualTo("공지사항 제목");
+        assertThat(noticeInfo.content()).isEqualTo("공지사항 내용");
+        assertThat(noticeInfo.links()).hasSize(2);
+        assertThat(noticeInfo.imageLinks()).hasSize(2);
+        assertThat(noticeInfo.imageLinks()).containsExactlyElementsOf(mockImageUrls);
+
+        // 링크 검증
+        assertThat(noticeInfo.links().get(0).url()).isEqualTo("https://example.com");
+        assertThat(noticeInfo.links().get(0).linkText()).isEqualTo("더보기");
+        assertThat(noticeInfo.links().get(1).url()).isEqualTo("https://example2.com");
+        assertThat(noticeInfo.links().get(1).linkText()).isEqualTo("상세보기");
+
+        // S3Service 호출 검증
+        verify(s3Service, times(1)).saveMultipleAndReturnWithCdn(anyString(), anyList());
+    }
+
+    @Test
+    @DisplayName("공지사항 생성 실패 시 업로드된 이미지를 삭제한다")
+    void rollback_uploaded_images_when_notification_creation_fails() {
+        // given
+        // 존재하지 않는 adminId 사용 -> FK 제약조건 위반 발생
+        Long invalidAdminId = 99999L;
+
+        List<LinkDto> links = List.of(
+            new LinkDto("https://example.com", "더보기")
+        );
+
+        MockMultipartFile image1 = new MockMultipartFile(
+            "images",
+            "image1.jpg",
+            MediaType.IMAGE_JPEG_VALUE,
+            "image1 content".getBytes()
+        );
+
+        List<MultipartFile> images = List.of(image1);
+
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "공지사항 내용",
+            links
+        );
+
+        // S3Service Mock 설정: 이미지 업로드는 성공
+        List<String> uploadedImageUrls = List.of(
+            "https://cdn.example.com/image1.jpg"
+        );
+        when(s3Service.saveMultipleAndReturnWithCdn(anyString(), anyList()))
+            .thenReturn(uploadedImageUrls);
+
+        // when & then
+        assertThatThrownBy(() ->
+            adminNotificationFacade.createNotice(invalidAdminId, request, images)
+        )
+            .isInstanceOf(BbangleException.class);
+
+        // 이미지 업로드는 호출되었지만
+        verify(s3Service, times(1)).saveMultipleAndReturnWithCdn(anyString(), anyList());
+
+        // 공지사항 생성 실패로 인해 이미지 삭제도 호출되어야 함
+        verify(s3Service, times(1)).deleteImagesCdn(uploadedImageUrls);
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacadeUnitTest.java
@@ -145,7 +145,7 @@ class AdminNotificationFacadeUnitTest {
         then(adminNotificationService).should(times(1))
             .createAdminNotification(any(AdminNoticeCreateCommand.class));
         then(s3Service).should(times(1))
-            .deleteImages(eq(uploadedImageLinks));
+            .deleteImagesCdn(eq(uploadedImageLinks));
     }
 
     @Test
@@ -183,7 +183,7 @@ class AdminNotificationFacadeUnitTest {
             .hasMessage(BbangleErrorCode.ADMIN_NOTICE_CREATION_FAILED.getMessage());
 
         then(s3Service).should(times(1))
-            .deleteImages(eq(uploadedImageLinks));
+            .deleteImagesCdn(eq(uploadedImageLinks));
     }
 
     @Test
@@ -225,7 +225,7 @@ class AdminNotificationFacadeUnitTest {
         then(adminNotificationService).should(times(1))
             .createAdminNotification(any(AdminNoticeCreateCommand.class));
         then(s3Service).should(times(1))
-            .deleteImages(eq(uploadedImageLinks));
+            .deleteImagesCdn(eq(uploadedImageLinks));
     }
 
     @Test

--- a/src/test/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacadeUnitTest.java
@@ -1,0 +1,274 @@
+package com.bbangle.bbangle.notification.admin.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.image.customer.service.S3Service;
+import com.bbangle.bbangle.notification.admin.controller.dto.LinkDto;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.service.AdminNotificationService;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeCreateCommand;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@DisplayName("[단위 테스트] AdminNotificationFacade")
+@ExtendWith(MockitoExtension.class)
+class AdminNotificationFacadeUnitTest {
+
+    @InjectMocks
+    private AdminNotificationFacade sut;
+
+    @Mock
+    private S3Service s3Service;
+
+    @Mock
+    private AdminNotificationService adminNotificationService;
+
+    @Test
+    @DisplayName("이미지 업로드와 공지사항 생성에 성공한다")
+    void success_create_notice_with_images() {
+        // given
+        Long adminId = 1L;
+        List<LinkDto> links = List.of(
+            new LinkDto("https://example.com", "더보기"),
+            new LinkDto("https://example2.com", "상세보기")
+        );
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "공지사항 내용",
+            links
+        );
+
+        MockMultipartFile image1 = new MockMultipartFile(
+            "images",
+            "test1.jpg",
+            "image/jpeg",
+            "test image content 1".getBytes()
+        );
+        MockMultipartFile image2 = new MockMultipartFile(
+            "images",
+            "test2.jpg",
+            "image/jpeg",
+            "test image content 2".getBytes()
+        );
+        List<MultipartFile> profileImages = List.of(image1, image2);
+
+        List<String> uploadedImageLinks = List.of(
+            "https://cdn.example.com/admin-notice-images/image1.jpg",
+            "https://cdn.example.com/admin-notice-images/image2.jpg"
+        );
+
+        NoticeInfo expectedNoticeInfo = new NoticeInfo(
+            1L,
+            "공지사항 제목",
+            "공지사항 내용",
+            links,
+            uploadedImageLinks,
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
+
+        given(s3Service.saveMultipleAndReturnWithCdn(eq("admin-notice-images"), eq(profileImages)))
+            .willReturn(uploadedImageLinks);
+        given(adminNotificationService.createAdminNotification(any(AdminNoticeCreateCommand.class)))
+            .willReturn(expectedNoticeInfo);
+
+        // when
+        NoticeInfo result = sut.createNotice(adminId, request, profileImages);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isEqualTo("공지사항 제목");
+        assertThat(result.content()).isEqualTo("공지사항 내용");
+
+        then(s3Service).should(times(1))
+            .saveMultipleAndReturnWithCdn(eq("admin-notice-images"), eq(profileImages));
+        then(adminNotificationService).should(times(1))
+            .createAdminNotification(any(AdminNoticeCreateCommand.class));
+        then(s3Service).should(never()).deleteImages(anyList());
+    }
+
+    @Test
+    @DisplayName("공지사항 생성 실패 시 업로드된 이미지를 삭제한다")
+    void fail_create_notice_then_delete_uploaded_images() {
+        // given
+        Long adminId = 1L;
+        List<LinkDto> links = List.of(new LinkDto("https://example.com", "더보기"));
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "공지사항 내용",
+            links
+        );
+
+        MockMultipartFile image = new MockMultipartFile(
+            "images",
+            "test.jpg",
+            "image/jpeg",
+            "test image content".getBytes()
+        );
+        List<MultipartFile> profileImages = List.of(image);
+
+        List<String> uploadedImageLinks = List.of(
+            "https://cdn.example.com/admin-notice-images/image1.jpg"
+        );
+
+        given(s3Service.saveMultipleAndReturnWithCdn(eq("admin-notice-images"), eq(profileImages)))
+            .willReturn(uploadedImageLinks);
+        given(adminNotificationService.createAdminNotification(any(AdminNoticeCreateCommand.class)))
+            .willThrow(new BbangleException(BbangleErrorCode.ADMIN_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> sut.createNotice(adminId, request, profileImages))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.ADMIN_NOTICE_CREATION_FAILED.getMessage());
+
+        then(s3Service).should(times(1))
+            .saveMultipleAndReturnWithCdn(eq("admin-notice-images"), eq(profileImages));
+        then(adminNotificationService).should(times(1))
+            .createAdminNotification(any(AdminNoticeCreateCommand.class));
+        then(s3Service).should(times(1))
+            .deleteImages(eq(uploadedImageLinks));
+    }
+
+    @Test
+    @DisplayName("제목이 비어있는 경우 실패하고 이미지를 삭제한다")
+    void fail_create_notice_when_title_is_empty_then_delete_images() {
+        // given
+        Long adminId = 1L;
+        List<LinkDto> links = List.of(new LinkDto("https://example.com", "더보기"));
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "",  // 빈 제목
+            "공지사항 내용",
+            links
+        );
+
+        MockMultipartFile image = new MockMultipartFile(
+            "images",
+            "test.jpg",
+            "image/jpeg",
+            "test image content".getBytes()
+        );
+        List<MultipartFile> profileImages = List.of(image);
+
+        List<String> uploadedImageLinks = List.of(
+            "https://cdn.example.com/admin-notice-images/image1.jpg"
+        );
+
+        given(s3Service.saveMultipleAndReturnWithCdn(eq("admin-notice-images"), eq(profileImages)))
+            .willReturn(uploadedImageLinks);
+        given(adminNotificationService.createAdminNotification(any(AdminNoticeCreateCommand.class)))
+            .willThrow(new BbangleException(BbangleErrorCode.TITLE_IS_EMPTY));
+
+        // when & then
+        assertThatThrownBy(() -> sut.createNotice(adminId, request, profileImages))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.ADMIN_NOTICE_CREATION_FAILED.getMessage());
+
+        then(s3Service).should(times(1))
+            .deleteImages(eq(uploadedImageLinks));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Admin ID로 공지사항 생성 시 실패하고 이미지를 삭제한다")
+    void fail_create_notice_when_admin_not_found_then_delete_images() {
+        // given
+        Long nonExistentAdminId = 999L;
+        List<LinkDto> links = List.of(new LinkDto("https://example.com", "더보기"));
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "공지사항 내용",
+            links
+        );
+
+        MockMultipartFile image = new MockMultipartFile(
+            "images",
+            "test.jpg",
+            "image/jpeg",
+            "test image content".getBytes()
+        );
+        List<MultipartFile> profileImages = List.of(image);
+
+        List<String> uploadedImageLinks = List.of(
+            "https://cdn.example.com/admin-notice-images/image1.jpg"
+        );
+
+        given(s3Service.saveMultipleAndReturnWithCdn(eq("admin-notice-images"), eq(profileImages)))
+            .willReturn(uploadedImageLinks);
+        given(adminNotificationService.createAdminNotification(any(AdminNoticeCreateCommand.class)))
+            .willThrow(new BbangleException(BbangleErrorCode.ADMIN_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> sut.createNotice(nonExistentAdminId, request, profileImages))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.ADMIN_NOTICE_CREATION_FAILED.getMessage());
+
+        then(s3Service).should(times(1))
+            .saveMultipleAndReturnWithCdn(eq("admin-notice-images"), eq(profileImages));
+        then(adminNotificationService).should(times(1))
+            .createAdminNotification(any(AdminNoticeCreateCommand.class));
+        then(s3Service).should(times(1))
+            .deleteImages(eq(uploadedImageLinks));
+    }
+
+    @Test
+    @DisplayName("빈 이미지 리스트로도 공지사항 생성에 성공한다")
+    void success_create_notice_with_empty_images() {
+        // given
+        Long adminId = 1L;
+        List<LinkDto> links = List.of(new LinkDto("https://example.com", "더보기"));
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "공지사항 내용",
+            links
+        );
+
+        List<MultipartFile> emptyImages = List.of();
+        List<String> emptyImageLinks = List.of();
+
+        NoticeInfo expectedNoticeInfo = new NoticeInfo(
+            1L,
+            "공지사항 제목",
+            "공지사항 내용",
+            links,
+            emptyImageLinks,
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
+
+        given(s3Service.saveMultipleAndReturnWithCdn(eq("admin-notice-images"), eq(emptyImages)))
+            .willReturn(emptyImageLinks);
+        given(adminNotificationService.createAdminNotification(any(AdminNoticeCreateCommand.class)))
+            .willReturn(expectedNoticeInfo);
+
+        // when
+        NoticeInfo result = sut.createNotice(adminId, request, emptyImages);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isEqualTo("공지사항 제목");
+
+        then(s3Service).should(times(1))
+            .saveMultipleAndReturnWithCdn(eq("admin-notice-images"), eq(emptyImages));
+        then(adminNotificationService).should(times(1))
+            .createAdminNotification(any(AdminNoticeCreateCommand.class));
+        then(s3Service).should(never()).deleteImages(anyList());
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationServiceIntegrationTest.java
@@ -1,0 +1,326 @@
+package com.bbangle.bbangle.notification.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bbangle.bbangle.admin.domain.Admin;
+import com.bbangle.bbangle.admin.repository.AdminRepository;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.notification.admin.controller.dto.LinkDto;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
+import com.bbangle.bbangle.notification.domain.Notice;
+import com.bbangle.bbangle.notification.repository.NotificationRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[통합 테스트] AdminNotificationService")
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class AdminNotificationServiceIntegrationTest {
+
+    @Autowired
+    private AdminNotificationService sut;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Long testAdminId;
+
+    @BeforeEach
+    void resetTable() {
+        em.flush();
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+        em.createNativeQuery("TRUNCATE TABLE notice").executeUpdate();
+        em.createNativeQuery("TRUNCATE TABLE admin").executeUpdate();
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+
+        // 테스트용 Admin 생성
+        Admin testAdmin = Admin.builder()
+            .accountId("test-admin")
+            .password("test-password")
+            .name("테스트 관리자")
+            .build();
+        testAdminId = adminRepository.save(testAdmin).getId();
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("관리자 공지사항 생성에 성공한다 - links와 imageLinks 모두 포함")
+    void success_create_admin_notification_with_links_and_imageLinks() throws JsonProcessingException {
+        // arrange
+        List<LinkDto> links = List.of(
+            new LinkDto("https://example.com", "더보기"),
+            new LinkDto("https://example2.com", "상세보기")
+        );
+        List<String> imageLinks = List.of(
+            "https://image1.example.com",
+            "https://image2.example.com"
+        );
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "공지사항 내용",
+            links
+        );
+
+        // act
+        NoticeInfo result = sut.createAdminNotification(request.toCreateCommand(testAdminId, imageLinks));
+
+        // assert
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isEqualTo("공지사항 제목");
+        assertThat(result.content()).isEqualTo("공지사항 내용");
+
+        // DB에 저장된 데이터 검증
+        List<Notice> savedNotices = notificationRepository.findAll();
+        assertThat(savedNotices).hasSize(1);
+
+        Notice savedNotice = savedNotices.get(0);
+        assertThat(savedNotice.getTitle()).isEqualTo("공지사항 제목");
+        assertThat(savedNotice.getContent()).isEqualTo("공지사항 내용");
+
+        // JSON 문자열로 저장된 links 파싱하여 검증
+        List<LinkDto> savedLinks = objectMapper.readValue(
+            savedNotice.getLinks(),
+            new TypeReference<List<LinkDto>>() {
+            }
+        );
+        assertThat(savedLinks).hasSize(2);
+        assertThat(savedLinks.get(0).url()).isEqualTo("https://example.com");
+        assertThat(savedLinks.get(0).linkText()).isEqualTo("더보기");
+
+        // JSON 문자열로 저장된 imageLinks 파싱하여 검증
+        List<String> savedImageLinks = objectMapper.readValue(
+            savedNotice.getImageLinks(),
+            new TypeReference<List<String>>() {
+            }
+        );
+        assertThat(savedImageLinks).hasSize(2);
+        assertThat(savedImageLinks).contains("https://image1.example.com", "https://image2.example.com");
+    }
+
+    @Test
+    @DisplayName("links가 빈 리스트여도 공지사항 생성에 성공한다")
+    void success_create_admin_notification_with_empty_links() throws JsonProcessingException {
+        // arrange
+        List<LinkDto> links = List.of();
+        List<String> imageLinks = List.of("https://image.example.com");
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "공지사항 내용",
+            links
+        );
+
+        // act
+        NoticeInfo result = sut.createAdminNotification(request.toCreateCommand(testAdminId, imageLinks));
+
+        // assert
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isEqualTo("공지사항 제목");
+        assertThat(result.content()).isEqualTo("공지사항 내용");
+
+        // DB 검증
+        List<Notice> savedNotices = notificationRepository.findAll();
+        assertThat(savedNotices).hasSize(1);
+
+        Notice savedNotice = savedNotices.get(0);
+        List<LinkDto> savedLinks = objectMapper.readValue(
+            savedNotice.getLinks(),
+            new TypeReference<List<LinkDto>>() {
+            }
+        );
+        assertThat(savedLinks).isEmpty();
+    }
+
+    @Test
+    @DisplayName("imageLinks가 빈 리스트여도 공지사항 생성에 성공한다")
+    void success_create_admin_notification_with_empty_imageLinks() throws JsonProcessingException {
+        // arrange
+        List<LinkDto> links = List.of(new LinkDto("https://example.com", "더보기"));
+        List<String> imageLinks = List.of();
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "공지사항 내용",
+            links
+        );
+
+        // act
+        NoticeInfo result = sut.createAdminNotification(request.toCreateCommand(testAdminId, imageLinks));
+
+        // assert
+        assertThat(result).isNotNull();
+
+        // DB 검증
+        List<Notice> savedNotices = notificationRepository.findAll();
+        assertThat(savedNotices).hasSize(1);
+
+        Notice savedNotice = savedNotices.get(0);
+        List<String> savedImageLinks = objectMapper.readValue(
+            savedNotice.getImageLinks(),
+            new TypeReference<List<String>>() {
+            }
+        );
+        assertThat(savedImageLinks).isEmpty();
+    }
+
+    @Test
+    @DisplayName("title이 null이면 공지사항 생성에 실패한다")
+    void fail_create_admin_notification_when_title_is_null() {
+        // arrange
+        List<LinkDto> links = List.of(new LinkDto("https://example.com", "더보기"));
+        List<String> imageLinks = List.of("https://image.example.com");
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            null,
+            "공지사항 내용",
+            links
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sut.createAdminNotification(request.toCreateCommand(testAdminId, imageLinks)))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.TITLE_IS_EMPTY.getMessage());
+
+        // DB에 저장되지 않았는지 검증
+        List<Notice> savedNotices = notificationRepository.findAll();
+        assertThat(savedNotices).isEmpty();
+    }
+
+    @Test
+    @DisplayName("title이 empty이면 공지사항 생성에 실패한다")
+    void fail_create_admin_notification_when_title_is_empty() {
+        // arrange
+        List<LinkDto> links = List.of(new LinkDto("https://example.com", "더보기"));
+        List<String> imageLinks = List.of("https://image.example.com");
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "",
+            "공지사항 내용",
+            links
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sut.createAdminNotification(request.toCreateCommand(testAdminId, imageLinks)))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.TITLE_IS_EMPTY.getMessage());
+
+        // DB에 저장되지 않았는지 검증
+        List<Notice> savedNotices = notificationRepository.findAll();
+        assertThat(savedNotices).isEmpty();
+    }
+
+    @Test
+    @DisplayName("content가 null이면 공지사항 생성에 실패한다")
+    void fail_create_admin_notification_when_content_is_null() {
+        // arrange
+        List<LinkDto> links = List.of(new LinkDto("https://example.com", "더보기"));
+        List<String> imageLinks = List.of("https://image.example.com");
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            null,
+            links
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sut.createAdminNotification(request.toCreateCommand(testAdminId, imageLinks)))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.CONTENT_IS_EMPTY.getMessage());
+
+        // DB에 저장되지 않았는지 검증
+        List<Notice> savedNotices = notificationRepository.findAll();
+        assertThat(savedNotices).isEmpty();
+    }
+
+    @Test
+    @DisplayName("content가 empty이면 공지사항 생성에 실패한다")
+    void fail_create_admin_notification_when_content_is_empty() {
+        // arrange
+        List<LinkDto> links = List.of(new LinkDto("https://example.com", "더보기"));
+        List<String> imageLinks = List.of("https://image.example.com");
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "",
+            links
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sut.createAdminNotification(request.toCreateCommand(testAdminId, imageLinks)))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.CONTENT_IS_EMPTY.getMessage());
+
+        // DB에 저장되지 않았는지 검증
+        List<Notice> savedNotices = notificationRepository.findAll();
+        assertThat(savedNotices).isEmpty();
+    }
+
+    @Test
+    @DisplayName("생성된 공지사항은 createdAt과 modifiedAt이 자동으로 설정된다")
+    void success_create_admin_notification_with_auto_timestamps() throws JsonProcessingException {
+        // arrange
+        List<LinkDto> links = List.of(new LinkDto("https://example.com", "더보기"));
+        List<String> imageLinks = List.of("https://image.example.com");
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "공지사항 내용",
+            links
+        );
+
+        // act
+        NoticeInfo result = sut.createAdminNotification(request.toCreateCommand(testAdminId, imageLinks));
+
+        // assert
+        assertThat(result.createAt()).isNotNull();
+        assertThat(result.modifiedAt()).isNotNull();
+
+        // DB 검증
+        List<Notice> savedNotices = notificationRepository.findAll();
+        assertThat(savedNotices).hasSize(1);
+
+        Notice savedNotice = savedNotices.get(0);
+        assertThat(savedNotice.getCreatedAt()).isNotNull();
+        assertThat(savedNotice.getModifiedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Admin ID로 공지사항 생성 시 예외가 발생한다")
+    void fail_create_admin_notification_when_admin_not_found() {
+        // arrange
+        Long nonExistentAdminId = 999L;
+        List<LinkDto> links = List.of(new LinkDto("https://example.com", "더보기"));
+        List<String> imageLinks = List.of("https://image.example.com");
+        AdminNotificationCreateRequest request = new AdminNotificationCreateRequest(
+            "공지사항 제목",
+            "공지사항 내용",
+            links
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sut.createAdminNotification(request.toCreateCommand(nonExistentAdminId, imageLinks)))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.ADMIN_NOT_FOUND.getMessage());
+
+        // DB에 저장되지 않았는지 검증
+        List<Notice> savedNotices = notificationRepository.findAll();
+        assertThat(savedNotices).isEmpty();
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/notification/customer/service/NotificationServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/customer/service/NotificationServiceIntegrationTest.java
@@ -4,6 +4,8 @@ import static com.bbangle.bbangle.exception.BbangleErrorCode.NOTIFICATION_NOT_FO
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.bbangle.bbangle.admin.domain.Admin;
+import com.bbangle.bbangle.admin.repository.AdminRepository;
 import com.bbangle.bbangle.common.page.NotificationCustomPage;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.NoticeFixture;
@@ -35,6 +37,9 @@ class NotificationServiceIntegrationTest {
     private NotificationRepository notificationRepository;
 
     @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
     private EntityManager em;
 
     private static final long PAGE_SIZE = 20L;
@@ -51,10 +56,11 @@ class NotificationServiceIntegrationTest {
     @Test
     void givenValidCursorId_whenGetList_thenReturnNextPage() {
         // Given
+        Admin admin = adminRepository.save(NoticeFixture.createTestAdmin());
         // 25개의 공지사항 생성
         LocalDateTime now = LocalDateTime.now();
         List<Notice> notices = IntStream.rangeClosed(1, 25)
-            .mapToObj(i -> NoticeFixture.notice("title" + i, "content" + i, now.minusDays(i)))
+            .mapToObj(i -> NoticeFixture.notice("title" + i, "content" + i, now.minusDays(i), admin))
             .toList();
         notificationRepository.saveAll(notices);
 
@@ -79,10 +85,11 @@ class NotificationServiceIntegrationTest {
     @Test
     void givenInvalidCursorId_whenGetList_thenThrowsBbangleException() {
         // Given
+        Admin admin = adminRepository.save(NoticeFixture.createTestAdmin());
         LocalDateTime now = LocalDateTime.now();
         notificationRepository.saveAll(List.of(
-            NoticeFixture.notice("title1", "content1", now.minusDays(3)),
-            NoticeFixture.notice("title2", "content2", now.minusDays(2))
+            NoticeFixture.notice("title1", "content1", now.minusDays(3), admin),
+            NoticeFixture.notice("title2", "content2", now.minusDays(2), admin)
         ));
 
         Long invalidCursorId = 99999L;

--- a/src/test/java/com/bbangle/bbangle/notification/customer/service/NotificationServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/customer/service/NotificationServiceTest.java
@@ -8,8 +8,10 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
+import com.bbangle.bbangle.admin.domain.Admin;
 import com.bbangle.bbangle.common.page.NotificationCustomPage;
 import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.NoticeFixture;
 import com.bbangle.bbangle.notification.customer.dto.NotificationDetailResponseDto;
 import com.bbangle.bbangle.notification.customer.dto.NotificationResponse;
 import com.bbangle.bbangle.notification.customer.dto.NotificationUploadRequest;
@@ -67,12 +69,9 @@ class NotificationServiceTest {
     void givenId_whenGetNoticeDetail_thenReturnNotificationDetail() {
         // Given
         Long id = 1L;
-        Notice notice = Notice.builder()
-            .id(id)
-            .title("title1")
-            .content("content1")
-            .createdAt(LocalDateTime.of(2023, 11, 12, 12, 0, 0))
-            .build();
+        Admin admin = NoticeFixture.createTestAdmin();
+        LocalDateTime createdAt = LocalDateTime.of(2023, 10, 1, 12, 0);
+        Notice notice = NoticeFixture.noticeWithIdAndCreatedAt(id, "title1", "content1", createdAt, admin);
         given(notificationRepository.findById(id)).willReturn(Optional.of(notice));
 
         // When

--- a/src/test/java/com/bbangle/bbangle/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/repository/NotificationRepositoryTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.bbangle.bbangle.TestContainersConfig;
+import com.bbangle.bbangle.admin.domain.Admin;
+import com.bbangle.bbangle.admin.repository.AdminRepository;
 import com.bbangle.bbangle.common.page.NotificationCustomPage;
 import com.bbangle.bbangle.config.QueryDslConfig;
 import com.bbangle.bbangle.exception.BbangleException;
@@ -45,6 +47,9 @@ class NotificationRepositoryTest {
     private NotificationRepository sut;
 
     @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
     private EntityManager em;
 
     private static final Long PAGE_SIZE = 20L;
@@ -64,9 +69,10 @@ class NotificationRepositoryTest {
     @Test
     void givenCursorIdIsNull_whenFindNextCursorPage_thenReturnsFirstPage() {
         // Given
+        Admin admin = adminRepository.save(NoticeFixture.createTestAdmin());
         LocalDateTime now = LocalDateTime.now();
         List<Notice> notices = IntStream.rangeClosed(1, 10)
-            .mapToObj(i -> NoticeFixture.notice("title" + i, "content" + i, now.minusDays(i)))
+            .mapToObj(i -> NoticeFixture.notice("title" + i, "content" + i, now.minusDays(i), admin))
             .toList();
         sut.saveAll(notices);
 
@@ -85,9 +91,10 @@ class NotificationRepositoryTest {
     @Test
     void givenValidCursorId_whenFindNextCursorPage_thenReturnsNextPage() {
         // Given
+        Admin admin = adminRepository.save(NoticeFixture.createTestAdmin());
         LocalDateTime now = LocalDateTime.now();
         List<Notice> notices = IntStream.rangeClosed(1, 25)
-            .mapToObj(i -> NoticeFixture.notice("title" + i, "content" + i, now.minusDays(i)))
+            .mapToObj(i -> NoticeFixture.notice("title" + i, "content" + i, now.minusDays(i), admin))
             .toList();
         sut.saveAll(notices);
 
@@ -111,9 +118,10 @@ class NotificationRepositoryTest {
     @Test
     void givenValidCursorId_whenFindNextCursorPageWithLessThanPageSize_thenReturnsLastPage() {
         // Given
+        Admin admin = adminRepository.save(NoticeFixture.createTestAdmin());
         LocalDateTime now = LocalDateTime.now();
         List<Notice> notices = IntStream.rangeClosed(1, 25)
-            .mapToObj(i -> NoticeFixture.notice("title" + i, "content" + i, now.minusDays(i)))
+            .mapToObj(i -> NoticeFixture.notice("title" + i, "content" + i, now.minusDays(i), admin))
             .toList();
         sut.saveAll(notices);
 
@@ -137,10 +145,11 @@ class NotificationRepositoryTest {
     @Test
     void givenInvalidCursorId_whenFindNextCursorPage_thenThrowsBbangleException() {
         // Given
+        Admin admin = adminRepository.save(NoticeFixture.createTestAdmin());
         LocalDateTime now = LocalDateTime.now();
         sut.saveAll(List.of(
-            NoticeFixture.notice("title1", "content1", now.minusDays(3)),
-            NoticeFixture.notice("title2", "content2", now.minusDays(2))
+            NoticeFixture.notice("title1", "content1", now.minusDays(3), admin),
+            NoticeFixture.notice("title2", "content2", now.minusDays(2), admin)
         ));
 
         Long invalidCursorId = 99999L;
@@ -173,9 +182,10 @@ class NotificationRepositoryTest {
     @Test
     void givenDataMoreThanPageSize_whenFindNextCursorPage_thenReturnsHasNextTrue() {
         // Given
+        Admin admin = adminRepository.save(NoticeFixture.createTestAdmin());
         LocalDateTime now = LocalDateTime.now();
         List<Notice> notices = IntStream.rangeClosed(1, 25)
-            .mapToObj(i -> NoticeFixture.notice("title" + i, "content" + i, now.minusDays(i)))
+            .mapToObj(i -> NoticeFixture.notice("title" + i, "content" + i, now.minusDays(i), admin))
             .toList();
         sut.saveAll(notices);
 


### PR DESCRIPTION
## History

### 연관된 이슈 번호 : #493 
<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
- 관리자 공지사항 등록 기능 구현이 주 작업이기에 아래 적은 커밋위주로 리뷰해주시면 될 것 같습니다.
    - 이미지 업로드 하는 부분이 필요하기에 Facade 계층에 메인 비즈니스 로직을 작성하였습니다. 
    - Facade 계층에 트랜잭션을 사용하지 않은 이유는 이미지 업로드 기능은 S3를 사용하기에 의미가 없기 때문입니다.
    
- 커밋 목록
  - e0820050e4 (컨트롤러)
  -  f89db94973 (파사드)
  - 77161677dd4 (서비스)
  
테스트 코드는 여유가 되신다면 한번 봐주세요!

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

<img width="400px" height="776" alt="image" src="https://github.com/user-attachments/assets/dce0877f-b817-4245-a2de-2f7c4f1f2a4b" />

<img width="400px" height="878" alt="image" src="https://github.com/user-attachments/assets/76c0efcb-2701-4409-9d2b-d964d57026c8" />


## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->

-  DB 작업이 필요한 도메인 서비스 메서드에 트랜잭션을 위임하고, Facade는 트랜잭션 전/후의 외부 시스템 호출을 제어합니다.

