### PR TITLE
[Feature] (Admin) 상품 목록 페이징 조회

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/AdminBoardController.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/AdminBoardController.java
@@ -1,0 +1,38 @@
+package com.bbangle.bbangle.board.admin.controller;
+
+import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
+import com.bbangle.bbangle.board.admin.controller.swagger.AdminBoardApi;
+import com.bbangle.bbangle.board.admin.service.AdminBoardService;
+import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.common.page.BbanglePageResponse;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.AdminApiPath;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RequiredArgsConstructor
+@RequestMapping(AdminApiPath.PREFIX + "/products")
+@RestController
+public class AdminBoardController implements AdminBoardApi {
+
+    private final AdminBoardService adminBoardService;
+    private final ResponseService responseService;
+
+    @Override
+    @GetMapping
+    public SingleResult<BbanglePageResponse<AdminProductResponse>> getAdminBoards(
+        @PageableDefault(size = 20, page = 1, sort = "createdAt", direction = Sort.Direction.DESC)
+        Pageable pageable
+    ) {
+        Page<AdminProductResponse> result = adminBoardService.getAdminBoards(pageable);
+        return responseService.getSingleResult(BbanglePageResponse.of(result));
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/dto/AdminProductResponse.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/dto/AdminProductResponse.java
@@ -1,0 +1,69 @@
+package com.bbangle.bbangle.board.admin.controller.dto;
+
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.Product;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "관리자 상품 목록 조회 항목")
+public record AdminProductResponse(
+    @Schema(description = "상품 ID", example = "1001")
+    Long productId,
+
+    @Schema(description = "스토어명", example = "그린베이커리")
+    String storeName,
+
+    @Schema(description = "상품명", example = "저당 통밀 식빵")
+    String productName,
+
+    @Schema(description = "상품 기본가", example = "6800")
+    Integer productPrice,
+
+    @Schema(description = "상품 옵션 목록")
+    List<AdminProductOptionResponse> productOptions
+) {
+
+    @Schema(description = "관리자 상품 옵션 정보")
+    public record AdminProductOptionResponse(
+        @Schema(description = "옵션 ID", example = "2001")
+        Long optionId,
+
+        @Schema(description = "옵션명", example = "기본")
+        String optionName,
+
+        @Schema(description = "옵션 추가 가격", example = "0")
+        Integer price,
+
+        @Schema(description = "재고 수량", example = "120")
+        Integer stock,
+
+        @Schema(description = "상품 태그 목록", example = "[\"비건\", \"저지방\"]")
+        List<String> tags
+    ) {
+
+        public static AdminProductOptionResponse fromEntity(Product product) {
+            return new AdminProductOptionResponse(
+                product.getId(),
+                product.getTitle(),
+                product.getPrice(),
+                product.getStock(),
+                product.getTags()
+            );
+        }
+    }
+
+    public static AdminProductResponse fromEntity(Board board) {
+        List<AdminProductOptionResponse> productOptions = board.getProducts().stream()
+            .map(AdminProductOptionResponse::fromEntity)
+            .toList();
+
+        return new AdminProductResponse(
+            board.getId(),
+            board.getStore().getName(),
+            board.getTitle(),
+            board.getPrice(),
+            productOptions
+        );
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/swagger/AdminBoardApi.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/swagger/AdminBoardApi.java
@@ -1,0 +1,22 @@
+package com.bbangle.bbangle.board.admin.controller.swagger;
+
+import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
+import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.common.page.BbanglePageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+
+@Tag(name = "AdminProduct", description = "(관리자) 상품 게시글 관련 API")
+public interface AdminBoardApi {
+
+    @Operation(
+        summary = "관리자 상품 목록 조회",
+        description = "관리자 페이지에서 상품 목록을 페이징 형태로 조회합니다."
+    )
+    SingleResult<BbanglePageResponse<AdminProductResponse>> getAdminBoards(
+        @ParameterObject Pageable pageable
+    );
+
+}

--- a/src/main/java/com/bbangle/bbangle/board/admin/service/AdminBoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/service/AdminBoardService.java
@@ -1,0 +1,24 @@
+package com.bbangle.bbangle.board.admin.service;
+
+import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class AdminBoardService {
+
+    private final BoardRepository boardRepository;
+
+    public Page<AdminProductResponse> getAdminBoards(Pageable pageable) {
+        Page<Board> boards = boardRepository.findAll(pageable);
+        return boards.map(AdminProductResponse::fromEntity);
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/board/admin/service/AdminBoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/service/AdminBoardService.java
@@ -17,7 +17,7 @@ public class AdminBoardService {
     private final BoardRepository boardRepository;
 
     public Page<AdminProductResponse> getAdminBoards(Pageable pageable) {
-        Page<Board> boards = boardRepository.findAll(pageable);
+        Page<Board> boards = boardRepository.findByIsCrawlingTrueAndIsDeletedFalse(pageable);
         return boards.map(AdminProductResponse::fromEntity);
     }
 

--- a/src/main/java/com/bbangle/bbangle/board/domain/Board.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Board.java
@@ -82,6 +82,9 @@ public class Board extends SoftDeleteBaseEntity {
     @Column(name = "courier")
     private String courier;
 
+    @Column(name = "is_crawling", columnDefinition = "tinyint")
+    private boolean isCrawling;
+
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
     private List<Product> products = new ArrayList<>();
 

--- a/src/main/java/com/bbangle/bbangle/board/domain/Product.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Product.java
@@ -56,7 +56,7 @@ public class Product {
     @Column(name = "price")
     private int price;
 
-    @Column(name = "category", columnDefinition = "varchar")
+    @Column(name = "category")
     @Enumerated(EnumType.STRING)
     private Category category;
 

--- a/src/main/java/com/bbangle/bbangle/board/repository/BoardRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/BoardRepository.java
@@ -13,6 +13,6 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardQueryD
     Optional<Board> findById(Long boardId);
 
     @EntityGraph(attributePaths = {"boardStatistic"})
-    Page<Board> findAll(Pageable pageable);
+    Page<Board> findByIsCrawlingTrueAndIsDeletedFalse(Pageable pageable);
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/BoardRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/BoardRepository.java
@@ -1,14 +1,18 @@
 package com.bbangle.bbangle.board.repository;
 
 import com.bbangle.bbangle.board.domain.Board;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long>, BoardQueryDSLRepository {
 
     @EntityGraph(attributePaths = {"store", "boardDetail", "boardStatistic"})
     Optional<Board> findById(Long boardId);
+
+    @EntityGraph(attributePaths = {"boardStatistic"})
+    Page<Board> findAll(Pageable pageable);
 
 }

--- a/src/main/resources/flyway/V26__app.sql
+++ b/src/main/resources/flyway/V26__app.sql
@@ -1,0 +1,6 @@
+ALTER TABLE product_board
+    ADD COLUMN is_crawling TINYINT(1) NOT NULL DEFAULT 0
+    COMMENT '크롤링 여부';
+
+UPDATE product_board
+SET is_crawling = 1;

--- a/src/test/java/com/bbangle/bbangle/board/admin/controller/AdminBoardControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/admin/controller/AdminBoardControllerTest.java
@@ -1,0 +1,140 @@
+package com.bbangle.bbangle.board.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
+import com.bbangle.bbangle.board.admin.service.AdminBoardService;
+import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
+import com.bbangle.bbangle.common.page.BbanglePageResponse;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.JsonDataEncoder;
+import com.bbangle.bbangle.config.security.AdminApiPath;
+import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.fixture.AdminProductResponseFixture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("[컨트롤러 테스트] AdminBoardController")
+@Import({
+    TestSlackAdaptorConfig.class,
+    JsonDataEncoder.class,
+    TokenProvider.class,
+    TestJwtPropertiesConfig.class,
+    ResponseService.class
+})
+@WebMvcTest(AdminBoardController.class)
+class AdminBoardControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private AdminBoardService adminBoardService;
+
+    @SpyBean
+    private ResponseService responseService;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("[상품 페이징 조회] 관리자는 상품 목록을 페이징 형태로 조회할 수 있다")
+    void getAdminBoards_success() throws Exception {
+        // given
+        int page = 0;
+        int size = 20;
+
+        AdminProductResponse response = AdminProductResponseFixture.defaultResponse();
+        Page<AdminProductResponse> pageResult = new PageImpl<>(List.of(response), PageRequest.of(page, size), 1);
+        BbanglePageResponse<AdminProductResponse> bbanglePageResponse = BbanglePageResponse.of(pageResult);
+
+        given(adminBoardService.getAdminBoards(any(Pageable.class))).willReturn(pageResult);
+
+        // when & then
+        mvc.perform(get(AdminApiPath.PREFIX + "/products")
+                .param("page", String.valueOf(page))
+                .param("size", String.valueOf(size))
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(0))
+            .andExpect(jsonPath("$.result.content.length()").value(1))
+            .andExpect(jsonPath("$.result.page").value(page))
+            .andExpect(jsonPath("$.result.size").value(size))
+            .andExpect(jsonPath("$.result.totalPages").value(1))
+            .andExpect(jsonPath("$.result.totalElements").value(1));
+        then(adminBoardService).should().getAdminBoards(any(Pageable.class));
+        then(responseService).should().getSingleResult(eq(bbanglePageResponse));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("[상품 페이징 조회] page가 범위를 초과하면 빈 목록을 반환한다")
+    void getAdminBoards_emptyResult_whenPageOutOfRange() throws Exception {
+        // given
+        int page = 5;
+        int size = 20;
+
+        Page<AdminProductResponse> emptyPage =
+            new PageImpl<>(
+                List.of(),
+                PageRequest.of(page, size),
+                10 // 실제 데이터는 존재
+            );
+
+        BbanglePageResponse<AdminProductResponse> bbanglePageResponse =
+            BbanglePageResponse.of(emptyPage);
+
+        given(adminBoardService.getAdminBoards(any(Pageable.class)))
+            .willReturn(emptyPage);
+
+        // when & then
+        mvc.perform(get(AdminApiPath.PREFIX + "/products")
+                .param("page", String.valueOf(page))
+                .param("size", String.valueOf(size))
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(0))
+            .andExpect(jsonPath("$.result.content.length()").value(0))
+            .andExpect(jsonPath("$.result.page").value(page))
+            .andExpect(jsonPath("$.result.size").value(size))
+            .andExpect(jsonPath("$.result.totalPages").value(1))
+            .andExpect(jsonPath("$.result.totalElements").value(10));
+
+        then(adminBoardService).should().getAdminBoards(any(Pageable.class));
+        then(responseService).should().getSingleResult(eq(bbanglePageResponse));
+    }
+
+    @Test
+    @DisplayName("[상품 페이징 조회] ADMIN 권한이 없으면 접근에 실패한다")
+    void getAdminBoards_fail_whenNoAdminRole() throws Exception {
+        // when & then
+        mvc.perform(get(AdminApiPath.PREFIX + "/products")
+                .param("page", "0")
+                .param("size", "20")
+            )
+            .andExpect(status().isUnauthorized());
+
+        then(adminBoardService).shouldHaveNoInteractions();
+        then(responseService).shouldHaveNoInteractions();
+    }
+
+}

--- a/src/test/java/com/bbangle/bbangle/board/admin/service/AdminBoardServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/admin/service/AdminBoardServiceIntegrationTest.java
@@ -1,0 +1,101 @@
+package com.bbangle.bbangle.board.admin.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.repository.BoardRepository;
+import com.bbangle.bbangle.fixture.BoardFixture;
+import com.bbangle.bbangle.fixture.StoreFixture;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.repository.StoreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[통합테스트] AdminBoardService")
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class AdminBoardServiceIntegrationTest {
+
+    @Autowired
+    private AdminBoardService adminBoardService;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Test
+    @DisplayName("상품이 존재하면 관리자 상품 목록을 페이징 형태로 조회한다")
+    void getAdminBoards_success() {
+        // given
+        Store store = storeRepository.save(StoreFixture.defaultStore());
+        Board board1 = BoardFixture.defaultBoard(store, "상품1");
+        Board board2 = BoardFixture.defaultBoard(store, "상품2");
+
+        boardRepository.saveAndFlush(board1);
+        boardRepository.saveAndFlush(board2);
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<AdminProductResponse> result =
+            adminBoardService.getAdminBoards(pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+
+        AdminProductResponse response = result.getContent().get(0);
+        assertThat(response.productId()).isNotNull();
+        assertThat(response.productName()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("page가 범위를 초과하면 빈 목록을 반환한다")
+    void getAdminBoards_outOfRangePage_returnsEmpty() {
+        // given
+        Store store = storeRepository.save(StoreFixture.defaultStore());
+        Board board = BoardFixture.defaultBoard(store, "상품1");
+        boardRepository.saveAndFlush(board);
+
+        Pageable pageable = PageRequest.of(10, 10); // 범위 초과
+
+        // when
+        Page<AdminProductResponse> result =
+            adminBoardService.getAdminBoards(pageable);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("상품이 하나도 없으면 빈 페이지를 반환한다")
+    void getAdminBoards_emptyDatabase() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<AdminProductResponse> result = adminBoardService.getAdminBoards(pageable);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        assertThat(result.getTotalPages()).isZero();
+    }
+
+
+}

--- a/src/test/java/com/bbangle/bbangle/board/admin/service/AdminBoardServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/admin/service/AdminBoardServiceIntegrationTest.java
@@ -9,6 +9,7 @@ import com.bbangle.bbangle.fixture.BoardFixture;
 import com.bbangle.bbangle.fixture.StoreFixture;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.repository.StoreRepository;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,15 +36,17 @@ class AdminBoardServiceIntegrationTest {
     private StoreRepository storeRepository;
 
     @Test
-    @DisplayName("상품이 존재하면 관리자 상품 목록을 페이징 형태로 조회한다")
-    void getAdminBoards_success() {
+    @DisplayName("관리자 상품 목록은 크롤링되고 삭제되지 않은 상품만 조회된다")
+    void getAdminBoards_filtersByCrawlingAndDeleted() {
         // given
         Store store = storeRepository.save(StoreFixture.defaultStore());
-        Board board1 = BoardFixture.defaultBoard(store, "상품1");
-        Board board2 = BoardFixture.defaultBoard(store, "상품2");
 
-        boardRepository.saveAndFlush(board1);
-        boardRepository.saveAndFlush(board2);
+        Board valid1 = BoardFixture.crawlingActiveBoard(store, "정상상품1");
+        Board valid2 = BoardFixture.crawlingActiveBoard(store, "정상상품2");
+        Board deleted = BoardFixture.crawlingDeletedBoard(store, "삭제상품");
+        Board nonCrawling = BoardFixture.nonCrawlingActiveBoard(store, "비크롤링상품");
+
+        boardRepository.saveAll(List.of(valid1, valid2, deleted, nonCrawling));
 
         Pageable pageable = PageRequest.of(0, 10);
 
@@ -52,23 +55,24 @@ class AdminBoardServiceIntegrationTest {
             adminBoardService.getAdminBoards(pageable);
 
         // then
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent())
+            .hasSize(2)
+            .extracting(AdminProductResponse::productName)
+            .containsExactlyInAnyOrder("정상상품1", "정상상품2");
+
         assertThat(result.getTotalElements()).isEqualTo(2);
         assertThat(result.getTotalPages()).isEqualTo(1);
-
-        AdminProductResponse response = result.getContent().get(0);
-        assertThat(response.productId()).isNotNull();
-        assertThat(response.productName()).isNotBlank();
     }
 
     @Test
-    @DisplayName("page가 범위를 초과하면 빈 목록을 반환한다")
-    void getAdminBoards_outOfRangePage_returnsEmpty() {
+    @DisplayName("페이지 범위를 초과하면 content는 비어 있고 total 정보는 유지된다")
+    void getAdminBoards_outOfRangePage_returnsEmptyContent() {
         // given
         Store store = storeRepository.save(StoreFixture.defaultStore());
-        Board board = BoardFixture.defaultBoard(store, "상품1");
-        boardRepository.saveAndFlush(board);
+
+        boardRepository.save(
+            BoardFixture.crawlingActiveBoard(store, "정상상품")
+        );
 
         Pageable pageable = PageRequest.of(10, 10); // 범위 초과
 
@@ -83,19 +87,29 @@ class AdminBoardServiceIntegrationTest {
     }
 
     @Test
-    @DisplayName("상품이 하나도 없으면 빈 페이지를 반환한다")
-    void getAdminBoards_emptyDatabase() {
+    @DisplayName("조회 대상이 되는 상품이 하나도 없으면 빈 페이지를 반환한다")
+    void getAdminBoards_noValidBoards_returnsEmptyPage() {
         // given
+        Store store = storeRepository.save(StoreFixture.defaultStore());
+
+        boardRepository.saveAll(
+            List.of(
+                BoardFixture.crawlingDeletedBoard(store, "삭제상품"),
+                BoardFixture.nonCrawlingActiveBoard(store, "비크롤링상품"),
+                BoardFixture.nonCrawlingDeletedBoard(store, "완전제외상품")
+            )
+        );
+
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        Page<AdminProductResponse> result = adminBoardService.getAdminBoards(pageable);
+        Page<AdminProductResponse> result =
+            adminBoardService.getAdminBoards(pageable);
 
         // then
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
         assertThat(result.getTotalPages()).isZero();
     }
-
 
 }

--- a/src/test/java/com/bbangle/bbangle/board/admin/service/AdminBoardServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/admin/service/AdminBoardServiceUnitTest.java
@@ -40,7 +40,7 @@ class AdminBoardServiceUnitTest {
         Board board = BoardFixture.defaultBoard();
         Page<Board> boardPage = new PageImpl<>(List.of(board), pageable, 1);
 
-        given(boardRepository.findAll(pageable)).willReturn(boardPage);
+        given(boardRepository.findByIsCrawlingTrueAndIsDeletedFalse(pageable)).willReturn(boardPage);
 
         // when
         Page<AdminProductResponse> result = sut.getAdminBoards(pageable);
@@ -57,7 +57,7 @@ class AdminBoardServiceUnitTest {
         assertThat(result.getNumber()).isEqualTo(page);
         assertThat(result.getSize()).isEqualTo(size);
         assertThat(result.getTotalElements()).isEqualTo(1);
-        then(boardRepository).should().findAll(pageable);
+        then(boardRepository).should().findByIsCrawlingTrueAndIsDeletedFalse(pageable);
     }
 
     @Test
@@ -67,7 +67,7 @@ class AdminBoardServiceUnitTest {
         Pageable pageable = PageRequest.of(0, 20);
         Page<Board> emptyPage = new PageImpl<>(List.of(), pageable, 0);
 
-        given(boardRepository.findAll(pageable)).willReturn(emptyPage);
+        given(boardRepository.findByIsCrawlingTrueAndIsDeletedFalse(pageable)).willReturn(emptyPage);
 
         // when
         Page<AdminProductResponse> result = sut.getAdminBoards(pageable);
@@ -75,7 +75,7 @@ class AdminBoardServiceUnitTest {
         // then
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
-        then(boardRepository).should().findAll(pageable);
+        then(boardRepository).should().findByIsCrawlingTrueAndIsDeletedFalse(pageable);
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/board/admin/service/AdminBoardServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/admin/service/AdminBoardServiceUnitTest.java
@@ -1,0 +1,81 @@
+package com.bbangle.bbangle.board.admin.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.repository.BoardRepository;
+import com.bbangle.bbangle.fixture.BoardFixture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DisplayName("[단위 테스트] AdminBoardService")
+@ExtendWith(MockitoExtension.class)
+class AdminBoardServiceUnitTest {
+
+    @InjectMocks
+    private AdminBoardService sut;
+
+    @Mock
+    private BoardRepository boardRepository;
+
+    @Test
+    @DisplayName("관리자 상품 목록을 페이징 형태로 조회한다")
+    void getAdminBoards_success() {
+        // given
+        int page = 0;
+        int size = 20;
+        Pageable pageable = PageRequest.of(page, size);
+        Board board = BoardFixture.defaultBoard();
+        Page<Board> boardPage = new PageImpl<>(List.of(board), pageable, 1);
+
+        given(boardRepository.findAll(pageable)).willReturn(boardPage);
+
+        // when
+        Page<AdminProductResponse> result = sut.getAdminBoards(pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+
+        AdminProductResponse response = result.getContent().get(0);
+        assertThat(response.productId()).isEqualTo(board.getId());
+        assertThat(response.productName()).isEqualTo(board.getTitle());
+        assertThat(response.productPrice()).isEqualTo(board.getPrice());
+
+        assertThat(result.getNumber()).isEqualTo(page);
+        assertThat(result.getSize()).isEqualTo(size);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        then(boardRepository).should().findAll(pageable);
+    }
+
+    @Test
+    @DisplayName("조회 결과가 없으면 빈 Page를 반환한다")
+    void getAdminBoards_emptyResult() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Board> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+        given(boardRepository.findAll(pageable)).willReturn(emptyPage);
+
+        // when
+        Page<AdminProductResponse> result = sut.getAdminBoards(pageable);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        then(boardRepository).should().findAll(pageable);
+    }
+
+}

--- a/src/test/java/com/bbangle/bbangle/fixture/AdminProductResponseFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/AdminProductResponseFixture.java
@@ -1,0 +1,21 @@
+package com.bbangle.bbangle.fixture;
+
+import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
+import java.util.List;
+
+public final class AdminProductResponseFixture {
+
+    private AdminProductResponseFixture() {
+    }
+
+    public static AdminProductResponse defaultResponse() {
+        return new AdminProductResponse(
+            1L,
+            "스토어명",
+            "상품명",
+            10000,
+            List.of()
+        );
+    }
+
+}

--- a/src/test/java/com/bbangle/bbangle/fixture/BoardFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/BoardFixture.java
@@ -1,0 +1,21 @@
+package com.bbangle.bbangle.fixture;
+
+import com.bbangle.bbangle.board.domain.Board;
+import java.util.ArrayList;
+
+public final class BoardFixture {
+
+    private BoardFixture() {
+    }
+
+    public static Board defaultBoard() {
+        return Board.builder()
+            .id(1L)
+            .title("상품명")
+            .price(10_000)
+            .products(new ArrayList<>())
+            .productImgs(new ArrayList<>())
+            .store(StoreFixture.defaultStore())
+            .build();
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/fixture/BoardFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/BoardFixture.java
@@ -9,30 +9,10 @@ public final class BoardFixture {
     private BoardFixture() {
     }
 
-    public static Board defaultBoard() {
-        return Board.builder()
-            .id(1L)
-            .title("상품명")
-            .price(10_000)
-            .products(new ArrayList<>())
-            .productImgs(new ArrayList<>())
-            .store(StoreFixture.defaultStore())
-            .build();
-    }
-
-    public static Board defaultBoard(String title) {
-        return Board.builder()
-            .title(title)
-            .price(10_000)
-            .discountRate(0)
-            .deliveryFee(0)
-            .store(StoreFixture.defaultStore())
-            .products(new ArrayList<>())
-            .productImgs(new ArrayList<>())
-            .build();
-    }
-
-    public static Board defaultBoard(Store store, String title) {
+    /* =====================
+       기본 공통 Builder
+     ===================== */
+    private static Board.BoardBuilder baseBuilder(Store store, String title) {
         return Board.builder()
             .title(title)
             .price(10_000)
@@ -40,8 +20,64 @@ public final class BoardFixture {
             .deliveryFee(0)
             .store(store)
             .products(new ArrayList<>())
-            .productImgs(new ArrayList<>())
+            .productImgs(new ArrayList<>());
+    }
+
+    /* =====================
+       기존 default 계열
+     ===================== */
+    public static Board defaultBoard() {
+        return baseBuilder(StoreFixture.defaultStore(), "상품명")
             .build();
     }
 
+    public static Board defaultBoard(String title) {
+        return baseBuilder(StoreFixture.defaultStore(), title)
+            .build();
+    }
+
+    public static Board defaultBoard(Store store, String title) {
+        return baseBuilder(store, title)
+            .build();
+    }
+
+    /**
+     * 관리자 조회 대상 isCrawling = true isDeleted  = false
+     */
+    public static Board crawlingActiveBoard(Store store, String title) {
+        return baseBuilder(store, title)
+            .isCrawling(true)
+            .isDeleted(false)
+            .build();
+    }
+
+    /**
+     * 크롤링 데이터이지만 삭제됨
+     */
+    public static Board crawlingDeletedBoard(Store store, String title) {
+        return baseBuilder(store, title)
+            .isCrawling(true)
+            .isDeleted(true)
+            .build();
+    }
+
+    /**
+     * 수동 등록 상품 (관리자 조회 제외)
+     */
+    public static Board nonCrawlingActiveBoard(Store store, String title) {
+        return baseBuilder(store, title)
+            .isCrawling(false)
+            .isDeleted(false)
+            .build();
+    }
+
+    /**
+     * 완전 제외 대상
+     */
+    public static Board nonCrawlingDeletedBoard(Store store, String title) {
+        return baseBuilder(store, title)
+            .isCrawling(false)
+            .isDeleted(true)
+            .build();
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/fixture/BoardFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/BoardFixture.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.fixture;
 
 import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.store.domain.Store;
 import java.util.ArrayList;
 
 public final class BoardFixture {
@@ -18,4 +19,29 @@ public final class BoardFixture {
             .store(StoreFixture.defaultStore())
             .build();
     }
+
+    public static Board defaultBoard(String title) {
+        return Board.builder()
+            .title(title)
+            .price(10_000)
+            .discountRate(0)
+            .deliveryFee(0)
+            .store(StoreFixture.defaultStore())
+            .products(new ArrayList<>())
+            .productImgs(new ArrayList<>())
+            .build();
+    }
+
+    public static Board defaultBoard(Store store, String title) {
+        return Board.builder()
+            .title(title)
+            .price(10_000)
+            .discountRate(0)
+            .deliveryFee(0)
+            .store(store)
+            .products(new ArrayList<>())
+            .productImgs(new ArrayList<>())
+            .build();
+    }
+
 }

--- a/src/test/java/com/bbangle/bbangle/fixture/BoardFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/BoardFixture.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.fixture;
 import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.store.domain.Store;
 import java.util.ArrayList;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public final class BoardFixture {
 
@@ -45,39 +46,39 @@ public final class BoardFixture {
      * 관리자 조회 대상 isCrawling = true isDeleted  = false
      */
     public static Board crawlingActiveBoard(Store store, String title) {
-        return baseBuilder(store, title)
-            .isCrawling(true)
-            .isDeleted(false)
-            .build();
+        Board board = baseBuilder(store, title).build();
+        ReflectionTestUtils.setField(board, "isCrawling", true);
+        ReflectionTestUtils.setField(board, "isDeleted", false);
+        return board;
     }
 
     /**
      * 크롤링 데이터이지만 삭제됨
      */
     public static Board crawlingDeletedBoard(Store store, String title) {
-        return baseBuilder(store, title)
-            .isCrawling(true)
-            .isDeleted(true)
-            .build();
+        Board board = baseBuilder(store, title).build();
+        ReflectionTestUtils.setField(board, "isCrawling", true);
+        ReflectionTestUtils.setField(board, "isDeleted", true);
+        return board;
     }
 
     /**
      * 수동 등록 상품 (관리자 조회 제외)
      */
     public static Board nonCrawlingActiveBoard(Store store, String title) {
-        return baseBuilder(store, title)
-            .isCrawling(false)
-            .isDeleted(false)
-            .build();
+        Board board = baseBuilder(store, title).build();
+        ReflectionTestUtils.setField(board, "isCrawling", false);
+        ReflectionTestUtils.setField(board, "isDeleted", false);
+        return board;
     }
 
     /**
      * 완전 제외 대상
      */
     public static Board nonCrawlingDeletedBoard(Store store, String title) {
-        return baseBuilder(store, title)
-            .isCrawling(false)
-            .isDeleted(true)
-            .build();
+        Board board = baseBuilder(store, title).build();
+        ReflectionTestUtils.setField(board, "isCrawling", false);
+        ReflectionTestUtils.setField(board, "isDeleted", true);
+        return board;
     }
 }

--- a/src/test/java/com/bbangle/bbangle/fixture/StoreFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/StoreFixture.java
@@ -1,0 +1,16 @@
+package com.bbangle.bbangle.fixture;
+
+import com.bbangle.bbangle.store.domain.Store;
+
+public final class StoreFixture {
+
+    private StoreFixture() {
+    }
+
+    public static Store defaultStore() {
+        return Store.builder()
+            .name("가게명")
+            .build();
+    }
+
+}


### PR DESCRIPTION
## History
- [Admin 상품 목록 조회 API](https://www.notion.so/sideproject-unione/2d6622e86d3d804f9683e606c548c885?source=copy_link) 

## 🚀 Major Changes & Explanations
- 어드민 상품 목록 페이징 조회 기능 구현 및 단위/통합 테스트 작성
- 별다른 이슈 상황은 없었으나, `board`와 `boardStatistic`(주인) 1:1 관계에서 board(주인이 아닌쪽)에서 조회를 하면 LAZY 옵션 상관없이 `boardStatistic` 접근이 없음에도 N 번만큼 `boardStatistic` 조회쿼리가 발생하는 문제가 있었습니다. `@EntityGraph`를 통해 조인을 활용하여 boardStatistic를 즉시 로딩하도록 구현하여 문제를 해결했습니다.
- 크롤링 데이터인지 판단을 위해 `product_board` 테이블에  `is_crawling` 컬럼 추가 (erd 클라우드 업데이트 완료)