### PR TITLE
[Refactor] Soft Delete 엔티티 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/domain/Board.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Board.java
@@ -1,7 +1,7 @@
 package com.bbangle.bbangle.board.domain;
 
 import com.bbangle.bbangle.boardstatistic.domain.BoardStatistic;
-import com.bbangle.bbangle.common.domain.BaseEntity;
+import com.bbangle.bbangle.common.domain.SoftDeleteBaseEntity;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.store.domain.Store;
@@ -34,7 +34,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
-public class Board extends BaseEntity {
+public class Board extends SoftDeleteBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -72,9 +72,6 @@ public class Board extends BaseEntity {
 
     @Column(name = "free_shipping_conditions")
     private Integer freeShippingConditions;
-
-    @Column(name = "is_deleted", columnDefinition = "tinyint")
-    private boolean isDeleted;
 
     @Column(name = "view")
     private int view;
@@ -115,7 +112,6 @@ public class Board extends BaseEntity {
         this.discountRate = discountRate;
         this.deliveryFee = deliveryFee;
         this.freeShippingConditions = freeShippingConditions;
-        this.isDeleted = false;
         this.productInfoNotice = productInfoNotice;
     }
 

--- a/src/main/java/com/bbangle/bbangle/common/domain/BaseEntity.java
+++ b/src/main/java/com/bbangle/bbangle/common/domain/BaseEntity.java
@@ -7,7 +7,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 @Getter
 @MappedSuperclass
-public class BaseEntity extends CreatedAtBaseEntity {
+public abstract class BaseEntity extends CreatedAtBaseEntity {
 
     @UpdateTimestamp
     private LocalDateTime modifiedAt;

--- a/src/main/java/com/bbangle/bbangle/common/domain/CreatedAtBaseEntity.java
+++ b/src/main/java/com/bbangle/bbangle/common/domain/CreatedAtBaseEntity.java
@@ -4,9 +4,10 @@ import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import org.hibernate.annotations.CreationTimestamp;
+
 @Getter
 @MappedSuperclass
-public class CreatedAtBaseEntity {
+public abstract class CreatedAtBaseEntity {
 
     @CreationTimestamp
     private LocalDateTime createdAt;

--- a/src/main/java/com/bbangle/bbangle/common/domain/SoftDeleteBaseEntity.java
+++ b/src/main/java/com/bbangle/bbangle/common/domain/SoftDeleteBaseEntity.java
@@ -1,0 +1,22 @@
+package com.bbangle.bbangle.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class SoftDeleteBaseEntity extends BaseEntity {
+
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "tinyint")
+    private boolean isDeleted = false;
+
+    public void restore() {
+        this.isDeleted = false;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/common/domain/SoftDeleteCreatedAtBaseEntity.java
+++ b/src/main/java/com/bbangle/bbangle/common/domain/SoftDeleteCreatedAtBaseEntity.java
@@ -1,0 +1,22 @@
+package com.bbangle.bbangle.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class SoftDeleteCreatedAtBaseEntity extends CreatedAtBaseEntity {
+
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "tinyint")
+    private boolean isDeleted = false;
+
+    public void restore() {
+        this.isDeleted = false;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/member/domain/Member.java
+++ b/src/main/java/com/bbangle/bbangle/member/domain/Member.java
@@ -1,7 +1,7 @@
 package com.bbangle.bbangle.member.domain;
 
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
-import com.bbangle.bbangle.common.domain.BaseEntity;
+import com.bbangle.bbangle.common.domain.SoftDeleteBaseEntity;
 import com.bbangle.bbangle.config.CdnConfig;
 import com.bbangle.bbangle.member.customer.dto.InfoUpdateRequest;
 import com.bbangle.bbangle.member.customer.dto.MemberInfoRequest;
@@ -30,7 +30,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Member extends BaseEntity {
+public class Member extends SoftDeleteBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -65,9 +65,6 @@ public class Member extends BaseEntity {
     @Column(name = "provider_id")
     private String providerId;
 
-    @Column(name = "is_deleted", columnDefinition = "tinyint")
-    private boolean isDeleted;
-
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     List<Withdrawal> withdrawals = new ArrayList<>();
 
@@ -79,8 +76,8 @@ public class Member extends BaseEntity {
 
     @Builder
     public Member(
-            Long id, String email, String phone, String name, String nickname,
-            String birth, boolean isDeleted, String profile, OauthServerType provider, String providerId
+        Long id, String email, String phone, String name, String nickname,
+        String birth, String profile, OauthServerType provider, String providerId
     ) {
         this.id = id;
         this.email = email;
@@ -88,7 +85,6 @@ public class Member extends BaseEntity {
         this.name = name;
         this.nickname = nickname;
         this.birth = birth;
-        this.isDeleted = isDeleted;
         this.profile = profile;
         this.providerId = providerId;
         this.provider = provider;
@@ -128,8 +124,9 @@ public class Member extends BaseEntity {
         }
     }
 
+    @Override
     public void delete() {
-        this.isDeleted = true;
+        super.delete();
         this.email = "-";
         this.phone = "-";
         this.name = "-";

--- a/src/main/java/com/bbangle/bbangle/review/domain/Review.java
+++ b/src/main/java/com/bbangle/bbangle/review/domain/Review.java
@@ -1,7 +1,7 @@
 package com.bbangle.bbangle.review.domain;
 
 
-import com.bbangle.bbangle.common.domain.BaseEntity;
+import com.bbangle.bbangle.common.domain.SoftDeleteBaseEntity;
 import com.bbangle.bbangle.review.customer.dto.ReviewRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -27,7 +27,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Review extends BaseEntity {
+public class Review extends SoftDeleteBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -63,9 +63,6 @@ public class Review extends BaseEntity {
     @Column(name = "content")
     private String content;
 
-    @Column(name = "is_deleted", columnDefinition = "tinyint")
-    private boolean isDeleted;
-
     public void insertBadge(Badge badge) {
         switch (badge) {
             case GOOD, BAD -> this.badgeTaste = badge;
@@ -86,10 +83,6 @@ public class Review extends BaseEntity {
         }
         this.rate = reviewRequest.rate();
         this.content = reviewRequest.content();
-    }
-
-    public void delete() {
-        this.isDeleted = true;
     }
 
     public static Review of(ReviewRequest reviewRequest, Long memberId) {

--- a/src/main/java/com/bbangle/bbangle/search/domain/Search.java
+++ b/src/main/java/com/bbangle/bbangle/search/domain/Search.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.search.domain;
 
+import com.bbangle.bbangle.common.domain.SoftDeleteCreatedAtBaseEntity;
 import com.bbangle.bbangle.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
@@ -12,18 +13,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
 
 @Table(name = "search")
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Search {
+public class Search extends SoftDeleteCreatedAtBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,12 +35,6 @@ public class Search {
     @Column(name = "keyword")
     private String keyword;
 
-    @Column(name = "is_deleted", columnDefinition = "tinyint")
-    private boolean isDeleted = false;
-
-    @CreationTimestamp
-    private LocalDateTime createdAt;
-
     @Builder
     public Search(Long memberId, String keyword) {
         this.member = Member.builder()
@@ -49,4 +42,5 @@ public class Search {
             .build();
         this.keyword = keyword;
     }
+    
 }

--- a/src/main/java/com/bbangle/bbangle/seller/domain/Seller.java
+++ b/src/main/java/com/bbangle/bbangle/seller/domain/Seller.java
@@ -9,8 +9,6 @@ import com.bbangle.bbangle.seller.domain.model.EmailVO;
 import com.bbangle.bbangle.seller.domain.model.PhoneNumberVO;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.domain.StoreStatus;
-import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -98,12 +96,14 @@ public class Seller extends BaseEntity {
         CertificationStatus certificationStatus,
         Store store
     ) {
-        if(store == null)  throw new BbangleException(BbangleErrorCode.INVALID_STORE);
+        if (store == null) {
+            throw new BbangleException(BbangleErrorCode.INVALID_STORE);
+        }
 
         store.changeStatus(StoreStatus.RESERVED);
 
         return Seller.builder()
-            .phoneNumberVO(PhoneNumberVO.of(phone,subPhone))
+            .phoneNumberVO(PhoneNumberVO.of(phone, subPhone))
             .emailVO(EmailVO.of(email))
             .originAddressLine(originAddressLine)
             .originAddressDetail(originAddressDetail)
@@ -121,16 +121,15 @@ public class Seller extends BaseEntity {
         Store store
     ) {
 
-
         if (originAddressLine == null || originAddressLine.isEmpty()) {
             throw new BbangleException(BbangleErrorCode.INVALID_ADDRESS);
         }
 
-        if(originAddressDetail == null || originAddressDetail.isEmpty()) {
+        if (originAddressDetail == null || originAddressDetail.isEmpty()) {
             throw new BbangleException(BbangleErrorCode.INVALID_DETAIL_ADDRESS);
         }
 
-        if(profile == null || profile.isEmpty()) {
+        if (profile == null || profile.isEmpty()) {
             throw new BbangleException(BbangleErrorCode.INVALID_PROFILE);
         }
 

--- a/src/main/java/com/bbangle/bbangle/store/domain/Store.java
+++ b/src/main/java/com/bbangle/bbangle/store/domain/Store.java
@@ -1,7 +1,7 @@
 package com.bbangle.bbangle.store.domain;
 
 import com.bbangle.bbangle.board.domain.Board;
-import com.bbangle.bbangle.common.domain.BaseEntity;
+import com.bbangle.bbangle.common.domain.SoftDeleteBaseEntity;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import jakarta.persistence.Column;
@@ -29,7 +29,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Store extends BaseEntity {
+public class Store extends SoftDeleteBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,9 +47,6 @@ public class Store extends BaseEntity {
     @Column(name = "profile")
     private String profile;
 
-    @Column(name = "is_deleted", columnDefinition = "tinyint")
-    private boolean isDeleted;
-
     @Column(name = "status")
     @Enumerated(EnumType.STRING)
     private StoreStatus status;
@@ -61,14 +58,13 @@ public class Store extends BaseEntity {
         String.valueOf((Math.abs(UUID.randomUUID().getLeastSignificantBits()) % 90000) + 10000);
 
     public static Store createForSeller(String name) {
-        return new Store(name, DEFAULT_IDENTIFIER, false, StoreStatus.NONE);
+        return new Store(name, DEFAULT_IDENTIFIER, StoreStatus.NONE);
     }
 
-    private Store(String name, String identifier, boolean isDeleted, StoreStatus status) {
+    private Store(String name, String identifier, StoreStatus status) {
         validateField(name);
         this.name = name;
         this.identifier = identifier;
-        this.isDeleted = isDeleted;
         this.status = status;
     }
 

--- a/src/main/java/com/bbangle/bbangle/wishlist/customer/service/WishListFolderService.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/customer/service/WishListFolderService.java
@@ -33,7 +33,6 @@ public class WishListFolderService {
         WishListFolder folder = WishListFolder.builder()
             .member(member)
             .folderName(requestDto.title())
-            .isDeleted(false)
             .build();
 
         return wishListFolderRepository.save(folder)

--- a/src/main/java/com/bbangle/bbangle/wishlist/customer/service/WishListStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/customer/service/WishListStoreService.java
@@ -50,7 +50,7 @@ public class WishListStoreService {
             .orElseThrow(() -> new BbangleException(STORE_NOT_FOUND));
         Member member = memberRepository.findMemberById(memberId);
         wishListStoreRepository.findWishListStore(memberId, storeId)
-            .ifPresentOrElse(WishListStore::changeDeletedFalse,
+            .ifPresentOrElse(WishListStore::restore,
                 () -> wishListStoreRepository.save(WishListStore.builder()
                     .member(member)
                     .store(store)

--- a/src/main/java/com/bbangle/bbangle/wishlist/domain/WishListFolder.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/domain/WishListFolder.java
@@ -1,6 +1,6 @@
 package com.bbangle.bbangle.wishlist.domain;
 
-import com.bbangle.bbangle.common.domain.BaseEntity;
+import com.bbangle.bbangle.common.domain.SoftDeleteBaseEntity;
 import com.bbangle.bbangle.member.domain.Member;
 import com.bbangle.bbangle.wishlist.customer.validator.WishListFolderValidator;
 import jakarta.persistence.Column;
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class WishListFolder extends BaseEntity {
+public class WishListFolder extends SoftDeleteBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,15 +36,11 @@ public class WishListFolder extends BaseEntity {
     @Column(name = "folder_name")
     private String folderName;
 
-    @Column(name = "is_deleted", columnDefinition = "tinyint")
-    private boolean isDeleted;
-
     @Builder
     private WishListFolder(
         Long id,
         Member member,
-        String folderName,
-        boolean isDeleted
+        String folderName
     ) {
         WishListFolderValidator.validateMember(member);
         WishListFolderValidator.validateTitle(folderName);
@@ -52,16 +48,11 @@ public class WishListFolder extends BaseEntity {
         this.id = id;
         this.member = member;
         this.folderName = folderName;
-        this.isDeleted = isDeleted;
     }
 
     public void updateTitle(String title) {
         WishListFolderValidator.validateTitle(folderName);
         this.folderName = title;
-    }
-
-    public void delete() {
-        this.isDeleted = true;
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/wishlist/domain/WishListStore.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/domain/WishListStore.java
@@ -1,9 +1,8 @@
 package com.bbangle.bbangle.wishlist.domain;
 
-import com.bbangle.bbangle.common.domain.BaseEntity;
+import com.bbangle.bbangle.common.domain.SoftDeleteBaseEntity;
 import com.bbangle.bbangle.member.domain.Member;
 import com.bbangle.bbangle.store.domain.Store;
-import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -26,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class WishListStore extends BaseEntity {
+public class WishListStore extends SoftDeleteBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,17 +38,6 @@ public class WishListStore extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Store store;
-
-    @Column(name = "is_deleted", columnDefinition = "tinyint")
-    private boolean isDeleted;
-
-    public void delete() {
-        this.isDeleted = true;
-    }
-
-    public void changeDeletedFalse() {
-        this.isDeleted = false;
-    }
 
     public static WishListStore createEmptyWishList() {
         return new WishListStore();

--- a/src/test/java/com/bbangle/bbangle/store/repository/StoreRepositoryPagingTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/repository/StoreRepositoryPagingTest.java
@@ -75,10 +75,9 @@ public class StoreRepositoryPagingTest {
         // 데이터 생성
         IntStream.rangeClosed(1, TOTAL_STORES).forEach(i -> {
             mockTime = mockTime.plusSeconds(1);
-            
+
             storeRepository.save(Store.builder()
                 .name("Store " + i)
-                .isDeleted(false)
                 .status(StoreStatus.NONE)
                 .build());
 

--- a/src/test/java/com/bbangle/bbangle/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/repository/StoreRepositoryTest.java
@@ -1,6 +1,9 @@
 package com.bbangle.bbangle.store.repository;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.bbangle.bbangle.TestContainersConfig;
 import com.bbangle.bbangle.config.QueryDslConfig;
 import com.bbangle.bbangle.search.repository.component.SearchFilter;
@@ -16,8 +19,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-
-import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("[슬라이스 테스트] StoreRepository")
 @ActiveProfiles("test")
@@ -45,7 +46,6 @@ public class StoreRepositoryTest {
             .name("testStore")
             .introduce("This is a test store.")
             .profile("profile.png")
-            .isDeleted(false)
             .build();
         storeRepository.save(store);
         // act
@@ -66,7 +66,6 @@ public class StoreRepositoryTest {
             .name("testStore")
             .introduce("This is a test store.")
             .profile("profile.png")
-            .isDeleted(false)
             .build();
         storeRepository.save(store);
         // act
@@ -85,7 +84,6 @@ public class StoreRepositoryTest {
             .name("Bbanggle")
             .introduce("This is a test store.")
             .profile("profile.png")
-            .isDeleted(false)
             .build();
         storeRepository.save(store1);
 
@@ -94,7 +92,6 @@ public class StoreRepositoryTest {
             .name("Bbanggle")
             .introduce("This is a test store.")
             .profile("profile.png")
-            .isDeleted(false)
             .build();
         storeRepository.save(store2);
 
@@ -104,7 +101,6 @@ public class StoreRepositoryTest {
         assertThatThrownBy(() -> storeRepository.findByStoreName(searchKeyword))
             .isInstanceOf(NonUniqueResultException.class);
     }
-
 
 
 }

--- a/src/test/java/com/bbangle/bbangle/store/seller/service/SellerStoreServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/seller/service/SellerStoreServiceIntegrationTest.java
@@ -75,7 +75,6 @@ public class SellerStoreServiceIntegrationTest {
             .forEach(name -> {
                 storeRepository.save(Store.builder()
                     .name(name)
-                    .isDeleted(false)
                     .status(StoreStatus.NONE)
                     .build());
 


### PR DESCRIPTION
## History
- Soft Delete 정책을 사용하는 엔티티마다 `is_deleted` 필드를 개별적으로 선언하면서 필드 정의와 삭제 로직이 중복되는 문제가 있었습니다.
- Soft Delete 정책을 일관되게 관리하기 어려운 상태였습니다.

## 🚀 Major Changes & Explanations
### 1. Soft Delete 전용 추상 엔티티 도입
- `is_deleted` 필드와 Soft Delete 관련 공통 로직(`delete()`, `restore()`)을 포함하는 추상 엔티티 클래스를 추가하였습니다.
- Soft Delete 정책을 사용하는 엔티티는 해당 클래스를 상속하도록 구조를 개선하였습니다.

### 2. 더티 체킹 기반 Soft Delete 방식 채택
- `@SoftDelete`, `@SQLDelete`, `@SQLRestriction` 등의 Hibernate 기능 사용하여 **조회 시 자동 필터링**과 **삭제 시 자동 soft delete 삭제**를 검토하였으나, 해당 애너테이션은 **삭제 처리를 유연하게 가져갈 수 없고, 삭제된 데이터를 조회하는데 어려움**이 있었습니다.
  - 저희 프로젝트 특성상 관리자/백오피스 기능이 많으므로 **유연한 조회가 가능해야 한다는 점을 고려**하였습니다.
- **삭제 시** 엔티티 **상태 변경 + 더티 체킹을 통한 Update 방식으로 Soft Delete를 처리**하도록 설계하였습니다.
- **삭제되지 않은 데이터 조회가 필요**할 때 **`is_deleted` 필터링이 필요**합니다.

- 조회 예시
```java
queryFactory.selectFrom(review)
    .where(review.isDeleted.isFalse())
    .fetch();
```

- 삭제/복구 예시
```java
review.delete(); // isDeleted = true
review.restore(); //  isDeleted = false
```
