### PR TITLE
[Feat] (관리자) 공지사항 수정 기능 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/common/service/HtmlContentProcessor.java
+++ b/src/main/java/com/bbangle/bbangle/common/service/HtmlContentProcessor.java
@@ -1,6 +1,5 @@
 package com.bbangle.bbangle.common.service;
 
-import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.image.customer.service.S3Service;
 import java.util.List;
@@ -22,15 +21,12 @@ public class HtmlContentProcessor {
 
     /**
      * HTML content 내의 img 태그를 파싱하고 원본 src를 CDN URL로 교체합니다.
-     * HTML의 img 개수가 originalSrcs 개수와 정확히 일치해야 합니다.
      *
      * @param content HTML 문자열
      * @param cdnUrlMap CDN URL 맵
      * @return 처리된 HTML 문자열
-     * @throws BbangleException HTML img 개수가 originalSrcs 개수와 일치하지 않을 경우
-     * @throws BbangleException 매칭되지 않은 img 태그가 있을 경우
      */
-    public String changeToCdn(String content, Map<String,String> cdnUrlMap) {
+    public String changeToCdn(String content, Map<String, String> cdnUrlMap) {
         // Jsoup을 사용하여 HTML 안전하게 파싱
         Document doc = Jsoup.parse(content);
         doc.outputSettings().prettyPrint(false);
@@ -40,8 +36,17 @@ public class HtmlContentProcessor {
         for (Element img : imgTags) {
             String uuid = img.attr("data-id");
             img.attr("src",cdnUrlMap.get(uuid));
+            // 2. data-id 속성 삭제
+            img.removeAttr("data-id"); // 공지사항 수정 시 수정된 이미지를 구분하기 위함
         }
         return doc.body().html();
     }
 
+    public List<String> extractImageSrc(String content) {
+        Document doc = Jsoup.parse(content);
+        Elements imgTags = doc.select("img");
+        return imgTags.stream()
+            .map(img -> img.attr("src"))
+            .toList();
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -113,10 +113,13 @@ public enum BbangleErrorCode {
     // NOTICE Error(761~770)
     TITLE_IS_EMPTY(-761, "제목이 존재하지 않습니다.",BAD_REQUEST),
     CONTENT_IS_EMPTY(-762, "본문이 존재하지 않습니다.",BAD_REQUEST),
-    ADMIN_NOTICE_CREATION_FAILED(-763, "본문이 존재하지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ADMIN_NOTICE_CREATION_FAILED(-763, "공지사항 생성 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INVALID_URL_COUNT(-764, "원본 src 개수와 CDN URL 개수가 일치하지 않아 변환을 수행할 수 없습니다.", BAD_REQUEST),
     IMAGE_COUNT_MISMATCH(-765, "이미지 파일 개수와 원본 이미지 src 개수가 일치하지 않습니다.", BAD_REQUEST),
-    IMAGE_NOT_MATCHED(-766, "HTML의 이미지 태그 개수와 원본 이미지 src 개수가 일치하지 않습니다.", BAD_REQUEST);
+    IMAGE_NOT_MATCHED(-766, "HTML의 이미지 태그 개수와 원본 이미지 src 개수가 일치하지 않습니다.", BAD_REQUEST),
+    NOT_FIND_NOTICE(-767, "Notice의 정보를 찾을 수 없습니다.", BAD_REQUEST),
+    ADMIN_NOTICE_UPDATE_FAILED(-768, "공지사항 수정 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
 
     private final int code;
     private final String message;

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationApi.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationApi.java
@@ -2,7 +2,9 @@ package com.bbangle.bbangle.notification.admin.controller;
 
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationUpdateRequest;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationCreateResponse;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -16,6 +18,14 @@ public interface AdminNotificationApi {
     SingleResult<AdminNotificationCreateResponse> registerNotification(
         Long adminId,
         AdminNotificationCreateRequest request,
+        List<MultipartFile> profileImage
+    );
+
+    @Operation(summary = "(관리자) 공지사항 수정")
+    SingleResult<AdminNotificationUpdateResponse> updateNotification(
+        Long adminId,
+        Long noticeId,
+        AdminNotificationUpdateRequest request,
         List<MultipartFile> profileImage
     );
 }

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -41,9 +42,9 @@ public class AdminNotificationController implements AdminNotificationApi {
         return responseService.getSingleResult(response);
     }
 
-    @PutMapping(value= "/admins/{adminId}/notices/{noticeId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PutMapping(value= "/{noticeId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @Override
-    public SingleResult<AdminNotificationUpdateResponse> updateNotification(@PathVariable Long adminId,
+    public SingleResult<AdminNotificationUpdateResponse> updateNotification(@RequestParam Long adminId,
                                                                             @PathVariable Long noticeId,
                                                                             @RequestPart @Valid AdminNotificationUpdateRequest request,
                                                                             @RequestPart(required = false) List<MultipartFile> profileImage) {

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -44,7 +45,7 @@ public class AdminNotificationController implements AdminNotificationApi {
 
     @PutMapping(value= "/{noticeId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @Override
-    public SingleResult<AdminNotificationUpdateResponse> updateNotification(@RequestParam Long adminId,
+    public SingleResult<AdminNotificationUpdateResponse> updateNotification(@AuthenticationPrincipal Long adminId,
                                                                             @PathVariable Long noticeId,
                                                                             @RequestPart @Valid AdminNotificationUpdateRequest request,
                                                                             @RequestPart(required = false) List<MultipartFile> profileImage) {

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
@@ -4,7 +4,9 @@ import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.AdminApiPath;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationUpdateRequest;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationCreateResponse;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationUpdateResponse;
 import com.bbangle.bbangle.notification.admin.facade.AdminNotificationFacade;
 import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
 import jakarta.validation.Valid;
@@ -30,10 +32,23 @@ public class AdminNotificationController implements AdminNotificationApi {
     @Override
     public SingleResult<AdminNotificationCreateResponse> registerNotification(@PathVariable Long adminId,
                                                                               @RequestPart @Valid AdminNotificationCreateRequest request,
-                                                                              @RequestPart List<MultipartFile> profileImage) {
+                                                                              @RequestPart(required = false) List<MultipartFile> profileImage) {
 
         NoticeInfo noticeInfo = adminNotificationFacade.createNotice(adminId, request, profileImage);
         AdminNotificationCreateResponse response = AdminNotificationCreateResponse.from(noticeInfo);
+
+        return responseService.getSingleResult(response);
+    }
+
+    @PostMapping(value= "/{adminId}/{noticeId}/update", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @Override
+    public SingleResult<AdminNotificationUpdateResponse> updateNotification(@PathVariable Long adminId,
+                                                                            @PathVariable Long noticeId,
+                                                                            @RequestPart @Valid AdminNotificationUpdateRequest request,
+                                                                            @RequestPart(required = false) List<MultipartFile> profileImage) {
+
+        NoticeInfo noticeInfo = adminNotificationFacade.updateNotice(adminId, noticeId, request, profileImage);
+        AdminNotificationUpdateResponse response = AdminNotificationUpdateResponse.from(noticeInfo);
 
         return responseService.getSingleResult(response);
     }

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,7 +41,7 @@ public class AdminNotificationController implements AdminNotificationApi {
         return responseService.getSingleResult(response);
     }
 
-    @PostMapping(value= "/{adminId}/{noticeId}/update", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PutMapping(value= "/admins/{adminId}/notices/{noticeId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @Override
     public SingleResult<AdminNotificationUpdateResponse> updateNotification(@PathVariable Long adminId,
                                                                             @PathVariable Long noticeId,

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/dto/AdminNotificationRequest.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/dto/AdminNotificationRequest.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.notification.admin.controller.dto;
 
 import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeCreateCommand;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeUpdateCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
@@ -26,7 +27,49 @@ public class AdminNotificationRequest {
                 .cdnImageLinks(imageLinks)
                 .build();
         }
+
+        public AdminNoticeCreateCommand toCreateCommand(Long adminId, String convertContext) {
+            return AdminNoticeCreateCommand.builder()
+                .adminId(adminId)
+                .title(title)
+                .content(convertContext)
+                .build();
+        }
     }
+
+
+    @Schema(description = "관리자 공지사항 수정 DTO")
+    public record AdminNotificationUpdateRequest(
+        @Schema(description = "공지사항 제목")
+        @NotBlank(message = "공지사항 제목은 필수입니다.")
+        String title,
+        @Schema(description = "공지사항 본문")
+        @NotBlank(message = "공지사항 본문은 필수입니다.")
+        String content
+    ) {
+
+        public AdminNoticeUpdateCommand toUpdateImageCommand(Long adminId, Long noticeId,String title, String convertContext , List<String> imageLinks) {
+            return AdminNoticeUpdateCommand.builder()
+                .adminId(adminId)
+                .title(title)
+                .noticeId(noticeId)
+                .content(convertContext)
+                .cdnImageLinks(imageLinks)
+                .build();
+        }
+
+
+        public AdminNoticeUpdateCommand toUpdateCommand(Long adminId, Long noticeId,String title ,String convertContext) {
+            return AdminNoticeUpdateCommand.builder()
+                .adminId(adminId)
+                .title(title)
+                .noticeId(noticeId)
+                .content(convertContext)
+                .build();
+        }
+
+    }
+
 
 
 

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/dto/AdminNotificationResponse.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/dto/AdminNotificationResponse.java
@@ -37,5 +37,34 @@ public class AdminNotificationResponse {
         }
     }
 
+    @Schema(description = "관리자 공지사항 수정 응답 DTO")
+    @Builder
+    public record AdminNotificationUpdateResponse(
+        @Schema(description = "공지사항 ID")
+        Long id,
+        @Schema(description = "제목")
+        String title,
+        @Schema(description = "내용")
+        String content,
+        @Schema(description = "이미지 링크 목록")
+        List<String> imageLinks,
+        @Schema(description = "생성 일시")
+        LocalDateTime createAt,
+        @Schema(description = "수정 일시")
+        LocalDateTime modifiedAt
+    ){
+
+        public static AdminNotificationUpdateResponse from(NoticeInfo noticeInfo) {
+            return AdminNotificationUpdateResponse.builder()
+                .id(noticeInfo.id())
+                .title(noticeInfo.title())
+                .content(noticeInfo.content())
+                .imageLinks(noticeInfo.imageLinks())
+                .createAt(noticeInfo.createAt())
+                .modifiedAt(noticeInfo.modifiedAt())
+                .build();
+        }
+    }
+
 
 }

--- a/src/main/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacade.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacade.java
@@ -5,12 +5,15 @@ import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.image.customer.service.S3Service;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationUpdateRequest;
 import com.bbangle.bbangle.notification.admin.service.AdminNotificationService;
 import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,43 +24,150 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 public class AdminNotificationFacade {
 
-     private final S3Service s3Service;
-     private final AdminNotificationService adminNotificationService;
-     private final HtmlContentProcessor htmlContentProcessor;
+    private final S3Service s3Service;
+    private final AdminNotificationService adminNotificationService;
+    private final HtmlContentProcessor htmlContentProcessor;
 
     private static final String ADMIN_NOTICE_FOLDER = "admin-notice-images";
+    private static final String CREATE_NOTICE = "공지사항 생성";
+    private static final String UPDATE_NOTICE = "공지사항 수정";
 
     // 로직 흐름
     // 이미지 저장 (uuid로 매핑) -> 본문 이미지 태그 변경 (uuid -> CDN URL) -> 공지사항 생성
     public NoticeInfo createNotice(Long adminId, AdminNotificationCreateRequest request, List<MultipartFile> images) {
-        Map<String, String> cdnUrlMap = new HashMap<>();
         List<String> uploadedImageLinks = new ArrayList<>();
 
         try {
-            // 이미지 업로드 (uuid를 키로 사용)
-            for (MultipartFile image : images) {
-                String uuid = image.getOriginalFilename(); // 프론트에서 전달받은 uuid
-                String cdnUrl = s3Service.saveAndReturnWithCdn(ADMIN_NOTICE_FOLDER, image);
-                cdnUrlMap.put(uuid, cdnUrl);
-                uploadedImageLinks.add(cdnUrl);
+            if(images == null || images.isEmpty()) {
+                return adminNotificationService.createAdminNotification(
+                    request.toCreateCommand(adminId, request.content()));
             }
 
-            // Content에서 임시 uuid를 CDN URL로 변환
+            Map<String, String> cdnUrlMap = uploadImagesToS3(images, uploadedImageLinks);
             String convertedContent = htmlContentProcessor.changeToCdn(request.content(), cdnUrlMap);
 
-            // 공지사항 생성
             return adminNotificationService.createAdminNotification(
                 request.toCreateCommand(adminId, convertedContent, uploadedImageLinks)
             );
         } catch (Exception e) {
             log.error("이미지 업로드 중 오류 발생", e);
-            // 업로드된 이미지 롤백
-            if (!uploadedImageLinks.isEmpty()) {
-                log.debug("업로드된 이미지 삭제 진행");
-                s3Service.deleteImagesCdn(uploadedImageLinks);
-            }
+            rollbackUploadedImages(uploadedImageLinks, CREATE_NOTICE);
             throw new BbangleException(BbangleErrorCode.ADMIN_NOTICE_CREATION_FAILED);
         }
     }
+
+    public NoticeInfo updateNotice(Long adminId, Long noticeId, AdminNotificationUpdateRequest request,
+                                   List<MultipartFile> images) {
+        List<String> uploadedImageLinks = new ArrayList<>();
+
+        try {
+            if (images != null && !images.isEmpty()) {
+                return updateNoticeWithImages(adminId, noticeId, request, images, uploadedImageLinks);
+            }
+            return updateNoticeWithoutImages(adminId, noticeId, request);
+        } catch (Exception e) {
+            log.error("공지사항 수정 중 오류 발생 {} ", e.getMessage());
+            rollbackUploadedImages(uploadedImageLinks, UPDATE_NOTICE);
+            throw new BbangleException(BbangleErrorCode.ADMIN_NOTICE_UPDATE_FAILED);
+        }
+    }
+
+
+    private NoticeInfo updateNoticeWithImages(Long adminId, Long noticeId, AdminNotificationUpdateRequest request,
+                                              List<MultipartFile> images, List<String> uploadedImageLinks) {
+        // 이미지 업로드 진행
+        Map<String, String> cdnUrlMap = uploadImagesToS3(images, uploadedImageLinks);
+        // 본문에 존재하는 이미지 링크를 cdn으로 교체
+        String convertedContent = htmlContentProcessor.changeToCdn(request.content(), cdnUrlMap);
+        // 전체 이미지 링크 추출
+        List<String> wholeImageLinks = htmlContentProcessor.extractImageSrc(convertedContent);
+        // 제거된 이미지 링크 확인
+        List<String> removedImages = findRemovedImages(noticeId, wholeImageLinks);
+
+        NoticeInfo result = adminNotificationService.updateAdminNotification(
+            request.toUpdateImageCommand(adminId, noticeId, request.title(), convertedContent, wholeImageLinks)
+        );
+        // 제거된 이미지 링크를 가져와 s3에서 이미지 제거 진행
+        deleteRemovedImagesFromS3(removedImages);
+
+        return result;
+    }
+
+    private NoticeInfo updateNoticeWithoutImages(Long adminId, Long noticeId, AdminNotificationUpdateRequest request) {
+        // 본문에서 현재 이미지 링크 추출
+        List<String> currentImageLinks = htmlContentProcessor.extractImageSrc(request.content());
+
+        // 기존 이미지와 비교하여 삭제된 이미지 찾기
+        List<String> removedImages = findRemovedImages(noticeId, currentImageLinks);
+
+        // DB 업데이트
+        NoticeInfo result;
+        if (!currentImageLinks.isEmpty()) {
+            // 본문에 이미지가 남아있으면 imageLinks 업데이트
+            result = adminNotificationService.updateAdminNotification(
+                request.toUpdateImageCommand(adminId, noticeId, request.title(), request.content(), currentImageLinks)
+            );
+        } else {
+            // 본문에 이미지가 없으면 일반 업데이트
+            result = adminNotificationService.updateAdminNotification(
+                request.toUpdateCommand(adminId, noticeId, request.title(), request.content())
+            );
+        }
+
+        // S3에서 삭제된 이미지 제거
+        deleteRemovedImagesFromS3(removedImages);
+
+        return result;
+    }
+
+    private Map<String, String> uploadImagesToS3(List<MultipartFile> images, List<String> uploadedImageLinks) {
+        Map<String, String> cdnUrlMap = new HashMap<>();
+
+        for (MultipartFile image : images) {
+            String uuid = image.getOriginalFilename();
+            String cdnUrl = s3Service.saveAndReturnWithCdn(ADMIN_NOTICE_FOLDER, image);
+            cdnUrlMap.put(uuid, cdnUrl);
+            uploadedImageLinks.add(cdnUrl);
+        }
+
+        return cdnUrlMap;
+    }
+
+    private List<String> findRemovedImages(Long noticeId, List<String> newImageLinks) {
+        List<String> existingImages = adminNotificationService.getExistingImageLinks(noticeId);
+        Set<String> newImageSet = new HashSet<>(newImageLinks);
+
+        return existingImages.stream()
+            .filter(img -> !newImageSet.contains(img))
+            .toList();
+    }
+
+    // 공지사항에서 제거된 이미지를 S3에서 삭제
+    private void deleteRemovedImagesFromS3(List<String> removedImages) {
+        if (removedImages.isEmpty()) {
+            return;
+        }
+
+        try {
+            s3Service.deleteImagesCdn(removedImages);
+        } catch (Exception e) {
+            log.warn("공지사항 수정 완료되었으나 S3 이미지 삭제 실패, 고아 파일이 남을 수 있습니다.", e);
+            log.warn("삭제 실패한 이미지 리스트: {}", removedImages);
+        }
+    }
+
+    // 공지사항 등록, 수정 작업 실패시 업로드 되어진 이미지를 삭제
+    private void rollbackUploadedImages(List<String> uploadedImageLinks, String operation) {
+        if (!uploadedImageLinks.isEmpty()) {
+            log.debug("{} 실패, 업로드된 이미지 삭제 진행", operation);
+            try {
+                s3Service.deleteImagesCdn(uploadedImageLinks);
+            } catch (Exception e) {
+                log.warn("{} 롤백 중 S3 이미지 삭제 실패. 고아 이미지가 남을 수 있습니다. 실패 목록: {}", operation,
+                    uploadedImageLinks, e);
+            }
+        }
+    }
+
 
 }

--- a/src/main/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationService.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationService.java
@@ -6,12 +6,18 @@ import com.bbangle.bbangle.admin.repository.AdminRepository;
 import com.bbangle.bbangle.common.service.HtmlContentProcessor;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand;
 import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeCreateCommand;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeUpdateCommand;
 import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
 import com.bbangle.bbangle.notification.domain.Notice;
 import com.bbangle.bbangle.notification.repository.NotificationRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +29,6 @@ public class AdminNotificationService {
     private final NotificationRepository notificationRepository;
     private final AdminRepository adminRepository;
     private final ObjectMapper objectMapper;
-    private final HtmlContentProcessor htmlContentProcessor;
 
     @Transactional
     public NoticeInfo createAdminNotification(AdminNoticeCreateCommand command) {
@@ -32,6 +37,12 @@ public class AdminNotificationService {
 
         try {
 
+            if (command.cdnImageLinks() == null) {
+                Notice savedNotice = notificationRepository.save(
+                    Notice.createNoticeFofAdminWithoutImage(command.title(), command.content(), admin));
+
+                return NoticeInfo.from(savedNotice);
+            }
             String imageLinksJson = objectMapper.writeValueAsString(command.cdnImageLinks());
 
             Notice notice = Notice.createNoticeForAdmin(command.title(), command.content(), imageLinksJson, admin);
@@ -44,4 +55,49 @@ public class AdminNotificationService {
     }
 
 
+    @Transactional
+    public NoticeInfo updateAdminNotification(AdminNoticeUpdateCommand command) {
+        Admin admin = adminRepository.findById(command.adminId())
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.ADMIN_NOT_FOUND));
+
+        try {
+            Notice beforeNotice = notificationRepository.findById(command.noticeId())
+                .orElseThrow(() -> new BbangleException(BbangleErrorCode.NOT_FIND_NOTICE));
+
+            if (command.cdnImageLinks() != null) {
+
+                String imageLinksJson = objectMapper.writeValueAsString(command.cdnImageLinks());
+                beforeNotice.updateNoticeContainImage(command.title(), command.content(), imageLinksJson);
+                return NoticeInfo.from(beforeNotice, objectMapper);
+            }
+
+            beforeNotice.updateNoticeWithoutImage(command.title(), command.content());
+
+            return NoticeInfo.from(beforeNotice);
+
+        } catch (JsonProcessingException e) {
+            throw new BbangleException(BbangleErrorCode.JSON_SERIALIZATION_ERROR);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> getExistingImageLinks(Long noticeId) {
+        Notice notice = notificationRepository.findById(noticeId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.NOT_FIND_NOTICE));
+
+        return deserializeImageLinks(notice.getImageLinks());
+    }
+
+    private List<String> deserializeImageLinks(String imageLinksJson) {
+        if (imageLinksJson == null) {
+            return List.of();
+        }
+
+        try {
+            return objectMapper.readValue(imageLinksJson, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new BbangleException(BbangleErrorCode.JSON_SERIALIZATION_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/notification/admin/service/model/AdminNoticeCommand.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/service/model/AdminNoticeCommand.java
@@ -14,4 +14,14 @@ public class AdminNoticeCommand {
 
 
 
+    @Builder
+    public record AdminNoticeUpdateCommand(Long adminId,
+                                           Long noticeId,
+                                           String title,
+                                           String content,
+                                           List<String> cdnImageLinks) {
+    }
+
+
+
 }

--- a/src/main/java/com/bbangle/bbangle/notification/admin/service/model/AdminNoticeInfo.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/service/model/AdminNoticeInfo.java
@@ -40,6 +40,17 @@ public class AdminNoticeInfo {
             }
         }
 
+        public static NoticeInfo from(Notice notice) {
+                return NoticeInfo.builder()
+                    .id(notice.getId())
+                    .title(notice.getTitle())
+                    .content(notice.getContent())
+                    .imageLinks(List.of())  // imageLinks를 빈 리스트로 초기화
+                    .createAt(notice.getCreatedAt())
+                    .modifiedAt(notice.getModifiedAt())
+                    .build();
+        }
+
     }
 
 

--- a/src/main/java/com/bbangle/bbangle/notification/domain/Notice.java
+++ b/src/main/java/com/bbangle/bbangle/notification/domain/Notice.java
@@ -87,7 +87,7 @@ public class Notice extends BaseEntity {
         validateField(title, content, admin);
         this.title = title;
         this.content = content;
-        this.imageLinks = imageLinks;
+        this.imageLinks = "[]";
         this.admin = admin;
     }
 

--- a/src/main/java/com/bbangle/bbangle/notification/domain/Notice.java
+++ b/src/main/java/com/bbangle/bbangle/notification/domain/Notice.java
@@ -16,8 +16,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -59,7 +59,31 @@ public class Notice extends BaseEntity {
         return new Notice(title, content, imageLinks, admin);
     }
 
+    public static Notice createNoticeFofAdminWithoutImage(String title, String content, Admin admin){
+        return new Notice(title, content, admin);
+    }
+
+
+    public void updateNoticeContainImage(String title, String content, String imageLinks){
+        this.title = Objects.requireNonNullElse(title, this.title);
+        this.content = Objects.requireNonNullElse(content, this.content);
+        this.imageLinks = Objects.requireNonNullElse(imageLinks, this.imageLinks);
+    }
+
+    public void updateNoticeWithoutImage(String title, String content){
+        this.title = Objects.requireNonNullElse(title, this.title);
+        this.content = Objects.requireNonNullElse(content, this.content);
+    }
+
     public Notice(String title, String content, String imageLinks, Admin admin) {
+        validateField(title, content, admin);
+        this.title = title;
+        this.content = content;
+        this.imageLinks = imageLinks;
+        this.admin = admin;
+    }
+
+    public Notice(String title, String content,  Admin admin){
         validateField(title, content, admin);
         this.title = title;
         this.content = content;

--- a/src/test/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacadeIntegrationTest.java
@@ -16,7 +16,9 @@ import com.bbangle.bbangle.admin.repository.AdminRepository;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.image.customer.service.S3Service;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationUpdateRequest;
 import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
+import com.bbangle.bbangle.notification.domain.Notice;
 import com.bbangle.bbangle.notification.repository.NotificationRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
@@ -241,5 +243,244 @@ public class AdminNotificationFacadeIntegrationTest {
 
         // S3Service는 호출되지 않아야 함
         verify(s3Service, times(0)).saveAndReturnWithCdn(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("이미지 없이 공지사항 제목과 본문만 수정에 성공한다")
+    void success_update_notice_without_images() {
+        // given
+        // 먼저 공지사항 생성
+        NoticeInfo createdNotice = adminNotificationFacade.createNotice(
+            testAdminId,
+            new AdminNotificationCreateRequest("원본 제목", "원본 내용"),
+            List.of()
+        );
+        em.flush();
+        em.clear();
+
+        AdminNotificationUpdateRequest request = new AdminNotificationUpdateRequest(
+            "수정된 제목",
+            "수정된 내용"
+        );
+
+        // when
+        NoticeInfo updatedNotice = adminNotificationFacade.updateNotice(
+            testAdminId,
+            createdNotice.id(),
+            request,
+            List.of()
+        );
+
+        // then
+        assertThat(updatedNotice).isNotNull();
+        assertThat(updatedNotice.id()).isEqualTo(createdNotice.id());
+        assertThat(updatedNotice.title()).isEqualTo("수정된 제목");
+        assertThat(updatedNotice.content()).isEqualTo("수정된 내용");
+        assertThat(updatedNotice.imageLinks()).isEmpty();
+
+        // DB에서 직접 확인
+        Notice notice = notificationRepository.findById(createdNotice.id()).orElseThrow();
+        assertThat(notice.getTitle()).isEqualTo("수정된 제목");
+        assertThat(notice.getContent()).isEqualTo("수정된 내용");
+    }
+
+    @Test
+    @DisplayName("새로운 이미지를 추가하여 공지사항 수정에 성공한다")
+    void success_update_notice_with_new_images() {
+        // given
+        // 먼저 이미지 없는 공지사항 생성
+        NoticeInfo createdNotice = adminNotificationFacade.createNotice(
+            testAdminId,
+            new AdminNotificationCreateRequest("원본 제목", "원본 내용"),
+            List.of()
+        );
+        em.flush();
+        em.clear();
+
+        MockMultipartFile newImage = new MockMultipartFile(
+            "images",
+            "uuid-1",
+            MediaType.IMAGE_JPEG_VALUE,
+            "new image content".getBytes()
+        );
+        List<MultipartFile> images = List.of(newImage);
+
+        String newImageUrl = "https://cdn.example.com/new-image.jpg";
+        when(s3Service.saveAndReturnWithCdn(eq("admin-notice-images"), eq(newImage)))
+            .thenReturn(newImageUrl);
+
+        AdminNotificationUpdateRequest request = new AdminNotificationUpdateRequest(
+            "수정된 제목",
+            "<div><img src=\"uuid-1\"></div>"
+        );
+
+        // when
+        NoticeInfo updatedNotice = adminNotificationFacade.updateNotice(
+            testAdminId,
+            createdNotice.id(),
+            request,
+            images
+        );
+
+        // then
+        assertThat(updatedNotice).isNotNull();
+        assertThat(updatedNotice.imageLinks()).hasSize(1);
+        // HTML 컨텐츠에서 추출된 실제 이미지 링크 확인
+        assertThat(updatedNotice.content()).contains("uuid-1");
+
+        // S3 호출 검증
+        verify(s3Service, times(1)).saveAndReturnWithCdn(eq("admin-notice-images"), eq(newImage));
+    }
+
+    @Test
+    @DisplayName("기존 이미지를 삭제하고 공지사항 수정에 성공한다")
+    void success_update_notice_removing_existing_images() {
+        // given
+        // 먼저 이미지 있는 공지사항 생성
+        MockMultipartFile originalImage = new MockMultipartFile(
+            "images",
+            "uuid-original",
+            MediaType.IMAGE_JPEG_VALUE,
+            "original image".getBytes()
+        );
+
+        String originalImageUrl = "https://cdn.example.com/original-image.jpg";
+        when(s3Service.saveAndReturnWithCdn(eq("admin-notice-images"), eq(originalImage)))
+            .thenReturn(originalImageUrl);
+
+        NoticeInfo createdNotice = adminNotificationFacade.createNotice(
+            testAdminId,
+            new AdminNotificationCreateRequest("원본 제목", "<div><img src=\"uuid-original\"></div>"),
+            List.of(originalImage)
+        );
+        em.flush();
+        em.clear();
+
+        AdminNotificationUpdateRequest request = new AdminNotificationUpdateRequest(
+            "수정된 제목",
+            "<div>이미지 삭제됨</div>"
+        );
+
+        // when
+        NoticeInfo updatedNotice = adminNotificationFacade.updateNotice(
+            testAdminId,
+            createdNotice.id(),
+            request,
+            List.of()
+        );
+
+        // then
+        assertThat(updatedNotice).isNotNull();
+        assertThat(updatedNotice.content()).isEqualTo("<div>이미지 삭제됨</div>");
+
+        // 이미지가 제거되었는지 확인
+        assertThat(updatedNotice.content()).doesNotContain("uuid-original");
+    }
+
+    @Test
+    @DisplayName("기존 이미지를 새 이미지로 교체하여 수정에 성공한다")
+    void success_update_notice_replacing_images() {
+        // given
+        // 먼저 이미지 있는 공지사항 생성
+        MockMultipartFile originalImage = new MockMultipartFile(
+            "images",
+            "uuid-original",
+            MediaType.IMAGE_JPEG_VALUE,
+            "original image".getBytes()
+        );
+
+        String originalImageUrl = "https://cdn.example.com/original-image.jpg";
+        when(s3Service.saveAndReturnWithCdn(eq("admin-notice-images"), eq(originalImage)))
+            .thenReturn(originalImageUrl);
+
+        NoticeInfo createdNotice = adminNotificationFacade.createNotice(
+            testAdminId,
+            new AdminNotificationCreateRequest("원본 제목", "<div><img src=\"uuid-original\"></div>"),
+            List.of(originalImage)
+        );
+        em.flush();
+        em.clear();
+
+        // 새 이미지로 교체
+        MockMultipartFile newImage = new MockMultipartFile(
+            "images",
+            "uuid-new",
+            MediaType.IMAGE_JPEG_VALUE,
+            "new image".getBytes()
+        );
+
+        String newImageUrl = "https://cdn.example.com/new-image.jpg";
+        when(s3Service.saveAndReturnWithCdn(eq("admin-notice-images"), eq(newImage)))
+            .thenReturn(newImageUrl);
+
+        AdminNotificationUpdateRequest request = new AdminNotificationUpdateRequest(
+            "수정된 제목",
+            "<div><img src=\"uuid-new\"></div>"
+        );
+
+        // when
+        NoticeInfo updatedNotice = adminNotificationFacade.updateNotice(
+            testAdminId,
+            createdNotice.id(),
+            request,
+            List.of(newImage)
+        );
+
+        // then
+        assertThat(updatedNotice).isNotNull();
+        assertThat(updatedNotice.imageLinks()).hasSize(1);
+        assertThat(updatedNotice.content()).contains("uuid-new");
+        assertThat(updatedNotice.content()).doesNotContain("uuid-original");
+
+        // S3 호출 검증
+        verify(s3Service, times(1)).saveAndReturnWithCdn(eq("admin-notice-images"), eq(newImage));
+        // S3에서 기존 이미지 삭제 호출되었는지 확인
+        verify(s3Service, times(1)).deleteImagesCdn(List.of(originalImageUrl));
+    }
+
+    @Test
+    @DisplayName("DB 업데이트 실패 시 새로 업로드된 이미지를 롤백한다")
+    void rollback_new_images_when_update_fails() {
+        // given
+        // 먼저 공지사항 생성
+        NoticeInfo createdNotice = adminNotificationFacade.createNotice(
+            testAdminId,
+            new AdminNotificationCreateRequest("원본 제목", "원본 내용"),
+            List.of()
+        );
+        em.flush();
+        em.clear();
+
+        // 존재하지 않는 noticeId로 수정 시도
+        Long invalidNoticeId = 99999L;
+
+        MockMultipartFile newImage = new MockMultipartFile(
+            "images",
+            "uuid-1",
+            MediaType.IMAGE_JPEG_VALUE,
+            "new image".getBytes()
+        );
+
+        String newImageUrl = "https://cdn.example.com/new-image.jpg";
+        when(s3Service.saveAndReturnWithCdn(eq("admin-notice-images"), eq(newImage)))
+            .thenReturn(newImageUrl);
+
+        AdminNotificationUpdateRequest request = new AdminNotificationUpdateRequest(
+            "수정된 제목",
+            "<div><img src=\"uuid-1\"></div>"
+        );
+
+        // when & then
+        assertThatThrownBy(() ->
+            adminNotificationFacade.updateNotice(
+                testAdminId,
+                invalidNoticeId,
+                request,
+                List.of(newImage)
+            )
+        ).isInstanceOf(BbangleException.class);
+
+        // 새로 업로드된 이미지는 삭제되어야 함
+        verify(s3Service, times(1)).deleteImagesCdn(List.of(newImageUrl));
     }
 }

--- a/src/test/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/admin/facade/AdminNotificationFacadeUnitTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -15,8 +16,10 @@ import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.image.customer.service.S3Service;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationUpdateRequest;
 import com.bbangle.bbangle.notification.admin.service.AdminNotificationService;
 import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeCreateCommand;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeUpdateCommand;
 import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
 import com.bbangle.bbangle.common.service.HtmlContentProcessor;
 import java.time.LocalDateTime;
@@ -311,5 +314,321 @@ class AdminNotificationFacadeUnitTest {
             .createAdminNotification(any(AdminNoticeCreateCommand.class));
         then(s3Service).should(times(1))
             .deleteImagesCdn(eq(uploadedImageLinks));
+    }
+
+    @Test
+    @DisplayName("이미지 없이 공지사항 제목과 본문만 수정에 성공한다")
+    void success_update_notice_without_images() {
+        // given
+        Long adminId = 1L;
+        Long noticeId = 1L;
+        AdminNotificationUpdateRequest request = new AdminNotificationUpdateRequest(
+            "수정된 제목",
+            "수정된 내용"
+        );
+        List<MultipartFile> images = List.of();
+
+        given(adminNotificationService.updateAdminNotification(any(AdminNoticeUpdateCommand.class)))
+            .willReturn(NoticeInfo.builder()
+                .id(noticeId)
+                .title("수정된 제목")
+                .content("수정된 내용")
+                .imageLinks(List.of())
+                .createAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+
+        // when
+        NoticeInfo result = sut.updateNotice(adminId, noticeId, request, images);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isEqualTo("수정된 제목");
+        assertThat(result.content()).isEqualTo("수정된 내용");
+        assertThat(result.imageLinks()).isEmpty();
+        then(adminNotificationService).should(times(1))
+            .updateAdminNotification(any(AdminNoticeUpdateCommand.class));
+        then(s3Service).should(never())
+            .saveAndReturnWithCdn(anyString(), any(MultipartFile.class));
+    }
+
+    @Test
+    @DisplayName("새로운 이미지를 추가하여 공지사항 수정에 성공한다")
+    void success_update_notice_with_new_images() {
+        // given
+        Long adminId = 1L;
+        Long noticeId = 1L;
+        AdminNotificationUpdateRequest request = new AdminNotificationUpdateRequest(
+            "수정된 제목",
+            "<div><img src=\"uuid-1\"></div>"
+        );
+
+        MockMultipartFile newImage = new MockMultipartFile(
+            "images",
+            "uuid-1",
+            "image/jpeg",
+            "new image content".getBytes()
+        );
+        List<MultipartFile> images = List.of(newImage);
+
+        String uploadedImageLink = "https://cdn.example.com/admin-notice-images/new-image.jpg";
+        List<String> existingImageLinks = List.of();
+        List<String> wholeImageLinks = List.of(uploadedImageLink);
+
+        given(s3Service.saveAndReturnWithCdn(eq("admin-notice-images"), eq(newImage)))
+            .willReturn(uploadedImageLink);
+        given(htmlContentProcessor.changeToCdn(anyString(), any(Map.class)))
+            .willReturn("<div><img src=\"" + uploadedImageLink + "\"></div>");
+        given(htmlContentProcessor.extractImageSrc(anyString()))
+            .willReturn(wholeImageLinks);
+        given(adminNotificationService.getExistingImageLinks(noticeId))
+            .willReturn(existingImageLinks);
+        given(adminNotificationService.updateAdminNotification(any(AdminNoticeUpdateCommand.class)))
+            .willReturn(NoticeInfo.builder()
+                .id(noticeId)
+                .title("수정된 제목")
+                .content("<div><img src=\"" + uploadedImageLink + "\"></div>")
+                .imageLinks(wholeImageLinks)
+                .createAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+
+        // when
+        NoticeInfo result = sut.updateNotice(adminId, noticeId, request, images);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isEqualTo("수정된 제목");
+        assertThat(result.imageLinks()).containsExactly(uploadedImageLink);
+        then(s3Service).should(times(1))
+            .saveAndReturnWithCdn(eq("admin-notice-images"), eq(newImage));
+        then(adminNotificationService).should(times(1))
+            .updateAdminNotification(any(AdminNoticeUpdateCommand.class));
+    }
+
+    @Test
+    @DisplayName("이미지 없이 본문만 수정해도 기존 이미지를 조회하여 삭제 처리한다")
+    void success_update_notice_without_images_checks_existing_images() {
+        // given
+        Long adminId = 1L;
+        Long noticeId = 1L;
+        AdminNotificationUpdateRequest request = new AdminNotificationUpdateRequest(
+            "수정된 제목",
+            "<div>이미지가 없는 내용</div>"
+        );
+
+        List<MultipartFile> images = List.of();
+        List<String> existingImages = List.of("https://cdn.example.com/old-image.jpg");
+
+        given(htmlContentProcessor.extractImageSrc(request.content()))
+            .willReturn(List.of());
+        given(adminNotificationService.getExistingImageLinks(noticeId))
+            .willReturn(existingImages);
+        given(adminNotificationService.updateAdminNotification(any(AdminNoticeUpdateCommand.class)))
+            .willReturn(NoticeInfo.builder()
+                .id(noticeId)
+                .title("수정된 제목")
+                .content("<div>이미지가 없는 내용</div>")
+                .imageLinks(List.of())
+                .createAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+
+        // when
+        NoticeInfo result = sut.updateNotice(adminId, noticeId, request, images);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.imageLinks()).isEmpty();
+        then(adminNotificationService).should(times(1))
+            .updateAdminNotification(any(AdminNoticeUpdateCommand.class));
+        // 이미지가 없어도 기존 이미지 조회함
+        then(adminNotificationService).should(times(1))
+            .getExistingImageLinks(noticeId);
+        // 기존 이미지가 삭제되어야 함
+        then(s3Service).should(times(1))
+            .deleteImagesCdn(existingImages);
+    }
+
+    @Test
+    @DisplayName("기존 이미지 일부 유지하고 새 이미지 추가하여 수정에 성공한다")
+    void success_update_notice_keeping_some_and_adding_new_images() {
+        // given
+        Long adminId = 1L;
+        Long noticeId = 1L;
+        String oldImageLink = "https://cdn.example.com/admin-notice-images/old-image.jpg";
+        String newImageLink = "https://cdn.example.com/admin-notice-images/new-image.jpg";
+
+        AdminNotificationUpdateRequest request = new AdminNotificationUpdateRequest(
+            "수정된 제목",
+            "<div><img src=\"old-url\"><img src=\"uuid-1\"></div>"
+        );
+
+        MockMultipartFile newImage = new MockMultipartFile(
+            "images",
+            "uuid-1",
+            "image/jpeg",
+            "new image content".getBytes()
+        );
+        List<MultipartFile> images = List.of(newImage);
+
+        List<String> existingImageLinks = List.of(oldImageLink);
+        List<String> wholeImageLinks = List.of(oldImageLink, newImageLink);
+
+        given(s3Service.saveAndReturnWithCdn(eq("admin-notice-images"), eq(newImage)))
+            .willReturn(newImageLink);
+        given(htmlContentProcessor.changeToCdn(anyString(), any(Map.class)))
+            .willReturn("<div><img src=\"" + oldImageLink + "\"><img src=\"" + newImageLink + "\"></div>");
+        given(htmlContentProcessor.extractImageSrc(anyString()))
+            .willReturn(wholeImageLinks);
+        given(adminNotificationService.getExistingImageLinks(noticeId))
+            .willReturn(existingImageLinks);
+        given(adminNotificationService.updateAdminNotification(any(AdminNoticeUpdateCommand.class)))
+            .willReturn(NoticeInfo.builder()
+                .id(noticeId)
+                .title("수정된 제목")
+                .content("<div><img src=\"" + oldImageLink + "\"><img src=\"" + newImageLink + "\"></div>")
+                .imageLinks(wholeImageLinks)
+                .createAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+
+        // when
+        NoticeInfo result = sut.updateNotice(adminId, noticeId, request, images);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.imageLinks()).containsExactly(oldImageLink, newImageLink);
+        then(s3Service).should(times(1))
+            .saveAndReturnWithCdn(eq("admin-notice-images"), eq(newImage));
+    }
+
+    @Test
+    @DisplayName("이미지 업로드 실패 시 업로드된 이미지를 삭제하고 적절한 에러를 발생시킨다")
+    void fail_update_notice_when_image_upload_fails_then_rollback() {
+        // given
+        Long adminId = 1L;
+        Long noticeId = 1L;
+        AdminNotificationUpdateRequest request = new AdminNotificationUpdateRequest(
+            "수정된 제목",
+            "<div><img src=\"uuid-1\"></div>"
+        );
+
+        MockMultipartFile newImage = new MockMultipartFile(
+            "images",
+            "uuid-1",
+            "image/jpeg",
+            "new image content".getBytes()
+        );
+        List<MultipartFile> images = List.of(newImage);
+
+        given(s3Service.saveAndReturnWithCdn(eq("admin-notice-images"), eq(newImage)))
+            .willThrow(new RuntimeException("S3 upload failed"));
+
+        // when & then
+        assertThatThrownBy(() -> sut.updateNotice(adminId, noticeId, request, images))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.ADMIN_NOTICE_UPDATE_FAILED.getMessage());
+
+        then(s3Service).should(never())
+            .deleteImagesCdn(anyList());
+        then(adminNotificationService).should(never())
+            .updateAdminNotification(any(AdminNoticeUpdateCommand.class));
+    }
+
+    @Test
+    @DisplayName("DB 업데이트 실패 시 업로드된 새 이미지를 삭제한다")
+    void fail_update_notice_when_db_update_fails_then_delete_uploaded_images() {
+        // given
+        Long adminId = 1L;
+        Long noticeId = 1L;
+        AdminNotificationUpdateRequest request = new AdminNotificationUpdateRequest(
+            "수정된 제목",
+            "<div><img src=\"uuid-1\"></div>"
+        );
+
+        MockMultipartFile newImage = new MockMultipartFile(
+            "images",
+            "uuid-1",
+            "image/jpeg",
+            "new image content".getBytes()
+        );
+        List<MultipartFile> images = List.of(newImage);
+
+        String uploadedImageLink = "https://cdn.example.com/admin-notice-images/new-image.jpg";
+        List<String> wholeImageLinks = List.of(uploadedImageLink);
+
+        given(s3Service.saveAndReturnWithCdn(eq("admin-notice-images"), eq(newImage)))
+            .willReturn(uploadedImageLink);
+        given(htmlContentProcessor.changeToCdn(anyString(), any(Map.class)))
+            .willReturn("<div><img src=\"" + uploadedImageLink + "\"></div>");
+        given(htmlContentProcessor.extractImageSrc(anyString()))
+            .willReturn(wholeImageLinks);
+        given(adminNotificationService.getExistingImageLinks(noticeId))
+            .willReturn(List.of());
+        given(adminNotificationService.updateAdminNotification(any(AdminNoticeUpdateCommand.class)))
+            .willThrow(new BbangleException(BbangleErrorCode.NOT_FIND_NOTICE));
+
+        // when & then
+        assertThatThrownBy(() -> sut.updateNotice(adminId, noticeId, request, images))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.ADMIN_NOTICE_UPDATE_FAILED.getMessage());
+
+        then(s3Service).should(times(1))
+            .deleteImagesCdn(List.of(uploadedImageLink));
+    }
+
+    @Test
+    @DisplayName("기존 이미지 삭제와 새 이미지 추가를 동시에 수행하여 수정에 성공한다")
+    void success_update_notice_removing_old_and_adding_new_images() {
+        // given
+        Long adminId = 1L;
+        Long noticeId = 1L;
+        String oldImageLink = "https://cdn.example.com/admin-notice-images/old-image.jpg";
+        String newImageLink = "https://cdn.example.com/admin-notice-images/new-image.jpg";
+
+        AdminNotificationUpdateRequest request = new AdminNotificationUpdateRequest(
+            "수정된 제목",
+            "<div><img src=\"uuid-1\"></div>"
+        );
+
+        MockMultipartFile newImage = new MockMultipartFile(
+            "images",
+            "uuid-1",
+            "image/jpeg",
+            "new image content".getBytes()
+        );
+        List<MultipartFile> images = List.of(newImage);
+
+        List<String> existingImageLinks = List.of(oldImageLink);
+        List<String> wholeImageLinks = List.of(newImageLink);
+
+        given(s3Service.saveAndReturnWithCdn(eq("admin-notice-images"), eq(newImage)))
+            .willReturn(newImageLink);
+        given(htmlContentProcessor.changeToCdn(anyString(), any(Map.class)))
+            .willReturn("<div><img src=\"" + newImageLink + "\"></div>");
+        given(htmlContentProcessor.extractImageSrc(anyString()))
+            .willReturn(wholeImageLinks);
+        given(adminNotificationService.getExistingImageLinks(noticeId))
+            .willReturn(existingImageLinks);
+        given(adminNotificationService.updateAdminNotification(any(AdminNoticeUpdateCommand.class)))
+            .willReturn(NoticeInfo.builder()
+                .id(noticeId)
+                .title("수정된 제목")
+                .content("<div><img src=\"" + newImageLink + "\"></div>")
+                .imageLinks(wholeImageLinks)
+                .createAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+
+        // when
+        NoticeInfo result = sut.updateNotice(adminId, noticeId, request, images);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.imageLinks()).containsExactly(newImageLink);
+        assertThat(result.imageLinks()).doesNotContain(oldImageLink);
+        then(s3Service).should(times(1))
+            .deleteImagesCdn(List.of(oldImageLink));
     }
 }

--- a/src/test/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationServiceIntegrationTest.java
@@ -8,6 +8,8 @@ import com.bbangle.bbangle.admin.repository.AdminRepository;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeCreateCommand;
+import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeUpdateCommand;
 import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
 import com.bbangle.bbangle.notification.domain.Notice;
 import com.bbangle.bbangle.notification.repository.NotificationRepository;
@@ -217,6 +219,291 @@ class AdminNotificationServiceIntegrationTest {
         assertThatThrownBy(() -> sut.createAdminNotification(command))
             .isInstanceOf(BbangleException.class)
             .hasMessage(BbangleErrorCode.CONTENT_IS_EMPTY.getMessage());
+    }
+
+    @Test
+    @DisplayName("이미지 포함하여 공지사항 수정에 성공한다")
+    void success_updateAdminNotification_WithImages() throws JsonProcessingException {
+        // given - 먼저 공지사항 생성
+        String originalTitle = "원본 제목";
+        String originalContent = "<div>원본 내용</div>";
+        List<String> originalImageLinks = List.of("https://cdn.example.com/old-image.jpg");
+
+        var createCommand = new AdminNoticeCreateCommand(
+            testAdminId,
+            originalTitle,
+            originalContent,
+            originalImageLinks
+        );
+        NoticeInfo createdNotice = sut.createAdminNotification(createCommand);
+        em.flush();
+        em.clear();
+
+        // 수정할 데이터
+        String updatedTitle = "수정된 제목";
+        String updatedContent = "<div>수정된 내용</div>";
+        List<String> updatedImageLinks = List.of(
+            "https://cdn.example.com/new-image1.jpg",
+            "https://cdn.example.com/new-image2.jpg"
+        );
+
+        var updateCommand = AdminNoticeUpdateCommand.builder()
+            .adminId(testAdminId)
+            .noticeId(createdNotice.id())
+            .title(updatedTitle)
+            .content(updatedContent)
+            .cdnImageLinks(updatedImageLinks)
+            .build();
+
+        // when
+        NoticeInfo result = sut.updateAdminNotification(updateCommand);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(createdNotice.id());
+        assertThat(result.title()).isEqualTo(updatedTitle);
+        assertThat(result.content()).isEqualTo(updatedContent);
+        assertThat(result.imageLinks()).containsExactlyElementsOf(updatedImageLinks);
+
+        // DB에서 직접 확인 (Dirty Checking 검증)
+        em.flush();
+        em.clear();
+        Notice updatedNotice = notificationRepository.findById(createdNotice.id()).orElseThrow();
+        assertThat(updatedNotice.getTitle()).isEqualTo(updatedTitle);
+        assertThat(updatedNotice.getContent()).isEqualTo(updatedContent);
+
+        List<String> savedImageLinks = objectMapper.readValue(
+            updatedNotice.getImageLinks(),
+            new TypeReference<List<String>>() {}
+        );
+        assertThat(savedImageLinks).containsExactlyElementsOf(updatedImageLinks);
+    }
+
+    @Test
+    @DisplayName("이미지 없이 공지사항 수정에 성공한다")
+    void success_updateAdminNotification_WithoutImages() {
+        // given - 먼저 공지사항 생성
+        String originalTitle = "원본 제목";
+        String originalContent = "<div>원본 내용</div>";
+
+        var createCommand = new AdminNoticeCreateCommand(
+            testAdminId,
+            originalTitle,
+            originalContent,
+            List.of()
+        );
+        NoticeInfo createdNotice = sut.createAdminNotification(createCommand);
+        em.flush();
+        em.clear();
+
+        // 수정할 데이터
+        String updatedTitle = "수정된 제목";
+        String updatedContent = "<div>수정된 내용</div>";
+
+        var updateCommand = AdminNoticeUpdateCommand.builder()
+            .adminId(testAdminId)
+            .noticeId(createdNotice.id())
+            .title(updatedTitle)
+            .content(updatedContent)
+            .build();
+
+        // when
+        NoticeInfo result = sut.updateAdminNotification(updateCommand);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(createdNotice.id());
+        assertThat(result.title()).isEqualTo(updatedTitle);
+        assertThat(result.content()).isEqualTo(updatedContent);
+
+        // DB에서 직접 확인 (Dirty Checking 검증)
+        em.flush();
+        em.clear();
+        Notice updatedNotice = notificationRepository.findById(createdNotice.id()).orElseThrow();
+        assertThat(updatedNotice.getTitle()).isEqualTo(updatedTitle);
+        assertThat(updatedNotice.getContent()).isEqualTo(updatedContent);
+    }
+
+    @Test
+    @DisplayName("JPA Dirty Checking을 통해 자동으로 DB에 업데이트된다")
+    void success_updateAdminNotification_DirtyCheckingWorks() throws JsonProcessingException {
+        // given - 먼저 공지사항 생성
+        var createCommand = new AdminNoticeCreateCommand(
+            testAdminId,
+            "원본 제목",
+            "<div>원본 내용</div>",
+            List.of("https://cdn.example.com/image.jpg")
+        );
+        NoticeInfo createdNotice = sut.createAdminNotification(createCommand);
+        Long noticeId = createdNotice.id();
+        em.flush();
+        em.clear();
+
+        // when - 수정 실행 (트랜잭션 내에서)
+        var updateCommand = AdminNoticeUpdateCommand.builder()
+            .adminId(testAdminId)
+            .noticeId(noticeId)
+            .title("수정된 제목")
+            .content("<div>수정된 내용</div>")
+            .cdnImageLinks(List.of("https://cdn.example.com/new-image.jpg"))
+            .build();
+
+        NoticeInfo updatedResult = sut.updateAdminNotification(updateCommand);
+
+        // 명시적으로 save()를 호출하지 않았지만 Dirty Checking으로 자동 업데이트
+        em.flush();
+        em.clear();
+
+        // then - DB에서 재조회하여 변경사항이 반영되었는지 확인
+        Notice savedNotice = notificationRepository.findById(noticeId).orElseThrow();
+        assertThat(savedNotice.getTitle()).isEqualTo("수정된 제목");
+        assertThat(savedNotice.getContent()).isEqualTo("<div>수정된 내용</div>");
+
+        List<String> savedImageLinks = objectMapper.readValue(
+            savedNotice.getImageLinks(),
+            new TypeReference<List<String>>() {}
+        );
+        assertThat(savedImageLinks).containsExactly("https://cdn.example.com/new-image.jpg");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Admin으로 공지사항 수정 시 실패한다")
+    void fail_updateAdminNotification_WithNonExistentAdmin() {
+        // given - 먼저 공지사항 생성
+        var createCommand = new AdminNoticeCreateCommand(
+            testAdminId,
+            "원본 제목",
+            "<div>원본 내용</div>",
+            List.of()
+        );
+        NoticeInfo createdNotice = sut.createAdminNotification(createCommand);
+        em.flush();
+        em.clear();
+
+        // 존재하지 않는 Admin ID로 수정 시도
+        Long invalidAdminId = 99999L;
+        var updateCommand = AdminNoticeUpdateCommand.builder()
+            .adminId(invalidAdminId)
+            .noticeId(createdNotice.id())
+            .title("수정된 제목")
+            .content("<div>수정된 내용</div>")
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> sut.updateAdminNotification(updateCommand))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.ADMIN_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Notice로 수정 시 실패한다")
+    void fail_updateAdminNotification_WithNonExistentNotice() {
+        // given
+        Long invalidNoticeId = 99999L;
+        var updateCommand = AdminNoticeUpdateCommand.builder()
+            .adminId(testAdminId)
+            .noticeId(invalidNoticeId)
+            .title("수정된 제목")
+            .content("<div>수정된 내용</div>")
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> sut.updateAdminNotification(updateCommand))
+            .isInstanceOf(BbangleException.class)
+            .hasMessage(BbangleErrorCode.NOT_FIND_NOTICE.getMessage());
+    }
+
+    @Test
+    @DisplayName("이미지 링크를 null에서 빈 리스트로 변경할 수 있다")
+    void success_updateAdminNotification_ImageLinks_FromNullToEmpty() {
+        // given - 먼저 이미지가 있는 공지사항 생성
+        var createCommand = new AdminNoticeCreateCommand(
+            testAdminId,
+            "원본 제목",
+            "<div>원본 내용</div>",
+            List.of("https://cdn.example.com/image.jpg")
+        );
+        NoticeInfo createdNotice = sut.createAdminNotification(createCommand);
+        em.flush();
+        em.clear();
+
+        // 이미지를 제거하는 수정 (cdnImageLinks를 null로 설정)
+        var updateCommand = AdminNoticeUpdateCommand.builder()
+            .adminId(testAdminId)
+            .noticeId(createdNotice.id())
+            .title("수정된 제목")
+            .content("<div>이미지 없는 내용</div>")
+            .cdnImageLinks(null)  // 이미지 제거
+            .build();
+
+        // when
+        NoticeInfo result = sut.updateAdminNotification(updateCommand);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isEqualTo("수정된 제목");
+        assertThat(result.content()).isEqualTo("<div>이미지 없는 내용</div>");
+
+        // DB 확인
+        em.flush();
+        em.clear();
+        Notice updatedNotice = notificationRepository.findById(createdNotice.id()).orElseThrow();
+        assertThat(updatedNotice.getTitle()).isEqualTo("수정된 제목");
+        assertThat(updatedNotice.getContent()).isEqualTo("<div>이미지 없는 내용</div>");
+    }
+
+    @Test
+    @DisplayName("여러 필드를 동시에 수정할 수 있다")
+    void success_updateAdminNotification_MultipleFieldsAtOnce() throws JsonProcessingException {
+        // given - 먼저 공지사항 생성
+        var createCommand = new AdminNoticeCreateCommand(
+            testAdminId,
+            "원본 제목",
+            "<div>원본 내용</div>",
+            List.of("https://cdn.example.com/old1.jpg", "https://cdn.example.com/old2.jpg")
+        );
+        NoticeInfo createdNotice = sut.createAdminNotification(createCommand);
+        em.flush();
+        em.clear();
+
+        // 모든 필드 수정
+        String newTitle = "완전히 새로운 제목";
+        String newContent = "<div><h1>완전히 새로운 내용</h1></div>";
+        List<String> newImageLinks = List.of(
+            "https://cdn.example.com/new1.jpg",
+            "https://cdn.example.com/new2.jpg",
+            "https://cdn.example.com/new3.jpg"
+        );
+
+        var updateCommand = AdminNoticeUpdateCommand.builder()
+            .adminId(testAdminId)
+            .noticeId(createdNotice.id())
+            .title(newTitle)
+            .content(newContent)
+            .cdnImageLinks(newImageLinks)
+            .build();
+
+        // when
+        NoticeInfo result = sut.updateAdminNotification(updateCommand);
+
+        // then - 모든 필드가 업데이트되었는지 확인
+        assertThat(result.title()).isEqualTo(newTitle);
+        assertThat(result.content()).isEqualTo(newContent);
+        assertThat(result.imageLinks()).hasSize(3);
+        assertThat(result.imageLinks()).containsExactlyElementsOf(newImageLinks);
+
+        // DB 확인
+        em.flush();
+        em.clear();
+        Notice updatedNotice = notificationRepository.findById(createdNotice.id()).orElseThrow();
+        assertThat(updatedNotice.getTitle()).isEqualTo(newTitle);
+        assertThat(updatedNotice.getContent()).isEqualTo(newContent);
+
+        List<String> savedImageLinks = objectMapper.readValue(
+            updatedNotice.getImageLinks(),
+            new TypeReference<List<String>>() {}
+        );
+        assertThat(savedImageLinks).containsExactlyElementsOf(newImageLinks);
     }
 
 }


### PR DESCRIPTION
## History

리뷰어 (2팀)
- 형재님
- 현호님

연관된 이슈 :
* Resolves #492
<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

1. 관리자 공지사항 수정 기능 개발
2. 관리자 공지사항 수정 기능을 개발하면서 등록 부분의 로직 리펙터링 진행
3. 수정사항에 따른 테스트 코드 작성

주요 커밋 리스트
- [[Feat] AdminNotificationFacade에 공지사항 수정 기능 추가 및 기존 로직 리펙터링 진행](https://github.com/eco-dessert-platform/backend/pull/552/commits/c8f00c0c7ef12ec7ddc25c575102c797b283ee4f)
- [[Feat] AdminNotificationService에 공지사항 수정 기능 추가 및 리펙터링 진행](https://github.com/eco-dessert-platform/backend/pull/552/commits/5fe7406f22a30c713d43d0e6ff78e63e8ab5fced)
- [[Refactor] Notice 엔티티에 수정에 대한 책임 부여](https://github.com/eco-dessert-platform/backend/pull/552/commits/e96688bf96a1f4d86be4f4adb1f8721b1dec564d)

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->

1. Notice 엔티티에 수정의 책임을 가지게 하는게 객체지향적인 설계라고 생각하여 진행하였습니다.
2. 공지사항 등록과, 수정기능에서 공통적으로 사용되어지는 부분들을 Helper 메서드로 추출하여 캡슐화를 진행하였습니다.
