### PR TITLE
[Fix] OAuth2 로그인 이후 콜백 URL에서 403 에러가 뜨는 문제 수정

### DIFF
--- a/src/main/java/com/bbangle/bbangle/config/security/PublicApiPath.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/PublicApiPath.java
@@ -13,6 +13,7 @@ public class PublicApiPath {
         "/api/v1/stores/**",
         "/api/v1/health/**",
         "/api/v1/push/**",
+        "/login/oauth2/code/**"
     };
 
     public static final String[] GET_ONLY = {


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
이슈 번호 : #554 

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
OAuth2 로그인 이후 콜백 URL 이동 시 403 에러가 뜨는 문제를 수정하였습니다.

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
