### PR TITLE
[Feat] (판매자) 발주 확인 API 기능 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -97,6 +97,8 @@ public enum BbangleErrorCode {
     INVALID_CERTIFICATION_STATUS(-705, "승인 상태가 비어 있습니다.", BAD_REQUEST),
     INVALID_PROFILE(-706, "프로필 이미지 경로가 비어있습니다.", BAD_REQUEST),
     SELLER_CREATION_FAILED(-708, "Seller 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ORDER_NOT_FOUND(-709, "존재하지 않는 주문입니다.", NOT_FOUND),
+    ORDER_ITEM_NOT_FOUND(-710, "존재하지 않는 주문상품입니다.", NOT_FOUND),
 
     // Store Error (721~740)
     INVALID_STORE(-721, "유효하지 않은 스토어 객체입니다.", BAD_REQUEST),

--- a/src/main/java/com/bbangle/bbangle/order/controller/SellerOrderController.java
+++ b/src/main/java/com/bbangle/bbangle/order/controller/SellerOrderController.java
@@ -7,11 +7,15 @@ import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.SellerApiPath;
 import com.bbangle.bbangle.order.controller.dto.request.CompletedOrderFilter;
 import com.bbangle.bbangle.order.controller.dto.request.OrderRequest.OrderSearchRequest;
+import com.bbangle.bbangle.order.controller.dto.request.SellerOrderRequest;
 import com.bbangle.bbangle.order.controller.dto.response.CompletedOrderResponse.OrderSummary;
 import com.bbangle.bbangle.order.controller.dto.response.OrderDetailResponse.OrderDetail;
 import com.bbangle.bbangle.order.controller.dto.response.OrderResponse.OrderItemDetailResponse;
 import com.bbangle.bbangle.order.controller.dto.response.OrderResponse.OrderSearchResponse;
+import com.bbangle.bbangle.order.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
 import com.bbangle.bbangle.order.controller.swagger.SellerOrderApi;
+import com.bbangle.bbangle.order.service.SellerOrderService;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -38,6 +42,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class SellerOrderController implements SellerOrderApi {
 
     private final ResponseService responseService;
+
+    private final SellerOrderService sellerOrderService;
 
     @Override
     @GetMapping("/completed")
@@ -149,6 +155,17 @@ public class SellerOrderController implements SellerOrderApi {
         Page<OrderSearchResponse> resultPage = new PageImpl<>(mockOrders, pageable, 480);
         BbanglePageResponse<OrderSearchResponse> res = BbanglePageResponse.of(resultPage);
         return responseService.getSingleResult(res);
+    }
+
+    @PostMapping("/{orderId}/confirm")
+    @Override
+    public SingleResult<OrderConfirmResponse> confirmOrder(
+        @AuthenticationPrincipal Long sellerId,
+        @PathVariable Long orderId,
+        @Valid @RequestBody SellerOrderRequest.OrderConfirmRequest request
+    ) {
+        var result = sellerOrderService.confirmOrder(request.toCommand(sellerId, orderId));
+        return responseService.getSingleResult(result);
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/order/controller/dto/request/SellerOrderRequest.java
+++ b/src/main/java/com/bbangle/bbangle/order/controller/dto/request/SellerOrderRequest.java
@@ -1,0 +1,27 @@
+package com.bbangle.bbangle.order.controller.dto.request;
+
+import com.bbangle.bbangle.order.service.model.SellerOrderCommand.OrderConfirmCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public class SellerOrderRequest {
+
+    @Schema(description = "판매자 주문상품 발주 확인 요청 DTO")
+    public record OrderConfirmRequest(
+
+        @Schema(description = "발주 확인 대상 주문상품 ID 목록")
+        @NotEmpty(message = "orderItemIds는 필수입니다.")
+        List<Long> orderItemIds
+
+    ) {
+
+        public OrderConfirmCommand toCommand(Long sellerId, Long orderId) {
+            return OrderConfirmCommand.builder()
+                .sellerId(sellerId)
+                .orderId(orderId)
+                .orderItemIds(orderItemIds)
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/controller/dto/response/SellerOrderResponse.java
+++ b/src/main/java/com/bbangle/bbangle/order/controller/dto/response/SellerOrderResponse.java
@@ -1,0 +1,37 @@
+package com.bbangle.bbangle.order.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+public class SellerOrderResponse {
+
+    @Builder
+    @Schema(description = "판매자 주문상품 발주 확인 응답 DTO")
+    public record OrderConfirmResponse(
+
+        @Schema(description = "주문 ID")
+        Long orderId,
+
+        @Schema(description = "발주 확인 완료된 주문상품 ID 목록")
+        List<Long> confirmedOrderItemIds,
+
+        @Schema(description = "발주 확인 일시")
+        LocalDateTime confirmedAt
+
+    ) {
+
+        public static OrderConfirmResponse of(
+            Long orderId,
+            List<Long> confirmedOrderItemIds,
+            LocalDateTime confirmedAt
+        ) {
+            return OrderConfirmResponse.builder()
+                .orderId(orderId)
+                .confirmedOrderItemIds(confirmedOrderItemIds)
+                .confirmedAt(confirmedAt)
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/controller/dto/response/SellerOrderResponse.java
+++ b/src/main/java/com/bbangle/bbangle/order/controller/dto/response/SellerOrderResponse.java
@@ -1,7 +1,6 @@
 package com.bbangle.bbangle.order.controller.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 
@@ -15,22 +14,17 @@ public class SellerOrderResponse {
         Long orderId,
 
         @Schema(description = "발주 확인 완료된 주문상품 ID 목록")
-        List<Long> confirmedOrderItemIds,
-
-        @Schema(description = "발주 확인 일시")
-        LocalDateTime confirmedAt
+        List<Long> confirmedOrderItemIds
 
     ) {
 
         public static OrderConfirmResponse of(
             Long orderId,
-            List<Long> confirmedOrderItemIds,
-            LocalDateTime confirmedAt
+            List<Long> confirmedOrderItemIds
         ) {
             return OrderConfirmResponse.builder()
                 .orderId(orderId)
                 .confirmedOrderItemIds(confirmedOrderItemIds)
-                .confirmedAt(confirmedAt)
                 .build();
         }
     }

--- a/src/main/java/com/bbangle/bbangle/order/controller/swagger/SellerOrderApi.java
+++ b/src/main/java/com/bbangle/bbangle/order/controller/swagger/SellerOrderApi.java
@@ -7,10 +7,12 @@ import com.bbangle.bbangle.exception.ErrorResponse;
 import com.bbangle.bbangle.exception.GlobalControllerAdvice;
 import com.bbangle.bbangle.order.controller.dto.request.CompletedOrderFilter;
 import com.bbangle.bbangle.order.controller.dto.request.OrderRequest;
+import com.bbangle.bbangle.order.controller.dto.request.SellerOrderRequest;
 import com.bbangle.bbangle.order.controller.dto.response.CompletedOrderResponse.OrderSummary;
 import com.bbangle.bbangle.order.controller.dto.response.OrderDetailResponse.OrderDetail;
 import com.bbangle.bbangle.order.controller.dto.response.OrderResponse.OrderItemDetailResponse;
 import com.bbangle.bbangle.order.controller.dto.response.OrderResponse.OrderSearchResponse;
+import com.bbangle.bbangle.order.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -23,6 +25,10 @@ import jakarta.validation.Valid;
 import java.util.List;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Seller Order", description = "(판매자) 주문 API")
 public interface SellerOrderApi {
@@ -173,4 +179,10 @@ public interface SellerOrderApi {
         @Valid
         OrderRequest.OrderSearchRequest request);
 
+    @PostMapping("/{orderId}/confirm")
+    SingleResult<OrderConfirmResponse> confirmOrder(
+        @AuthenticationPrincipal Long sellerId,
+        @PathVariable Long orderId,
+        @Valid @RequestBody SellerOrderRequest.OrderConfirmRequest request
+    );
 }

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -57,4 +57,11 @@ public class OrderItem extends BaseEntity {
     @JoinColumn(name = "product_id")
     private Product product;
 
+    public void confirmOrder() {
+        if (this.orderStatus != OrderStatus.PAYMENT_COMPLETED) {
+            throw new IllegalStateException("결제 완료 상태에서만 발주 확인이 가능합니다.");
+        }
+        this.orderStatus = OrderStatus.ORDER_CONFIRMED;
+    }
+
 }

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -57,11 +57,13 @@ public class OrderItem extends BaseEntity {
     @JoinColumn(name = "product_id")
     private Product product;
 
-    public void confirmOrder() {
+    public boolean confirmOrder() {
         if (this.orderStatus != OrderStatus.PAYMENT_COMPLETED) {
-            throw new IllegalStateException("결제 완료 상태에서만 발주 확인이 가능합니다.");
+            return false;
         }
         this.orderStatus = OrderStatus.ORDER_CONFIRMED;
+        return true;
     }
+
 
 }

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderItemRepository.java
@@ -1,0 +1,10 @@
+package com.bbangle.bbangle.order.repository;
+
+import com.bbangle.bbangle.order.domain.OrderItem;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+    List<OrderItem> findByOrderIdAndIdIn(Long orderId, List<Long> ids);
+}

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.bbangle.bbangle.order.repository;
+
+import com.bbangle.bbangle.order.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/bbangle/bbangle/order/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/service/SellerOrderService.java
@@ -1,0 +1,45 @@
+package com.bbangle.bbangle.order.service;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.order.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.repository.OrderItemRepository;
+import com.bbangle.bbangle.order.repository.OrderRepository;
+import com.bbangle.bbangle.order.service.model.SellerOrderCommand.OrderConfirmCommand;
+import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SellerOrderService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    @Transactional
+    public OrderConfirmResponse confirmOrder(OrderConfirmCommand command) {
+
+        Order order = orderRepository.findById(command.orderId())
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
+
+        List<OrderItem> orderItems = orderItemRepository.findByOrderIdAndIdIn(
+            order.getId(),
+            command.orderItemIds()
+        );
+
+        List<Long> confirmedOrderItemIds = new ArrayList<>();
+
+        for (OrderItem orderItem : orderItems) {
+            if (orderItem.confirmOrder()) {
+                confirmedOrderItemIds.add(orderItem.getId());
+            }
+        }
+
+        return OrderConfirmResponse.of(order.getId(), confirmedOrderItemIds);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/service/SellerOrderService.java
@@ -9,7 +9,6 @@ import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.order.repository.OrderRepository;
 import com.bbangle.bbangle.order.service.model.SellerOrderCommand.OrderConfirmCommand;
 import jakarta.transaction.Transactional;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,13 +31,10 @@ public class SellerOrderService {
             command.orderItemIds()
         );
 
-        List<Long> confirmedOrderItemIds = new ArrayList<>();
-
-        for (OrderItem orderItem : orderItems) {
-            if (orderItem.confirmOrder()) {
-                confirmedOrderItemIds.add(orderItem.getId());
-            }
-        }
+        List<Long> confirmedOrderItemIds = orderItems.stream()
+            .filter(OrderItem::confirmOrder)
+            .map(OrderItem::getId)
+            .toList();
 
         return OrderConfirmResponse.of(order.getId(), confirmedOrderItemIds);
     }

--- a/src/main/java/com/bbangle/bbangle/order/service/model/SellerOrderCommand.java
+++ b/src/main/java/com/bbangle/bbangle/order/service/model/SellerOrderCommand.java
@@ -1,0 +1,15 @@
+package com.bbangle.bbangle.order.service.model;
+
+import java.util.List;
+import lombok.Builder;
+
+public class SellerOrderCommand {
+
+    @Builder
+    public record OrderConfirmCommand(
+        Long sellerId,
+        Long orderId,
+        List<Long> orderItemIds
+    ) {
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/order/controller/SellerOrderControllerSliceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/controller/SellerOrderControllerSliceTest.java
@@ -1,0 +1,149 @@
+package com.bbangle.bbangle.order.controller;
+
+import static com.bbangle.bbangle.common.service.ResponseService.CommonResponse.SUCCESS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.JsonDataEncoder;
+import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.exception.GlobalControllerAdvice;
+import com.bbangle.bbangle.order.controller.dto.request.SellerOrderRequest.OrderConfirmRequest;
+import com.bbangle.bbangle.order.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
+import com.bbangle.bbangle.order.service.SellerOrderService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("[컨트롤러] SellerOrderController")
+@Import({
+    TestSlackAdaptorConfig.class,
+    JsonDataEncoder.class,
+    TokenProvider.class,
+    TestJwtPropertiesConfig.class,
+    ResponseService.class
+})
+@WebMvcTest(controllers = SellerOrderController.class)
+class SellerOrderControllerSliceTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private JsonDataEncoder jsonDataEncoder;
+
+    @SpyBean
+    private ResponseService responseService;
+
+    @SpyBean
+    private GlobalControllerAdvice globalControllerAdvice;
+
+    @MockBean
+    private SellerOrderService sellerOrderService;
+
+    @DisplayName("발주 확인 API - 성공")
+    @Test
+    void givenValidRequest_whenConfirmOrder_thenReturnsSuccess() throws Exception {
+        // Given
+        Long sellerId = 1L;
+        Long orderId = 10L;
+
+        OrderConfirmRequest request = new OrderConfirmRequest(List.of(100L, 101L, 102L));
+
+        // 부분 성공 정책 예시: 100, 102만 확정됨
+        OrderConfirmResponse serviceResponse = OrderConfirmResponse.of(orderId, List.of(100L, 102L));
+
+        given(sellerOrderService.confirmOrder(any())).willReturn(serviceResponse);
+
+        // When & Then
+        mvc.perform(post("/api/v1/seller/orders/{orderId}/confirm", orderId)
+                .with(authentication(new UsernamePasswordAuthenticationToken(
+                    1L,
+                    "N/A",
+                    List.of(new SimpleGrantedAuthority("ROLE_SELLER"))
+                )))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonDataEncoder.encode(request)))
+
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
+            .andExpect(jsonPath("$.result.orderId").value(orderId))
+            .andExpect(jsonPath("$.result.confirmedOrderItemIds[0]").value(100))
+            .andExpect(jsonPath("$.result.confirmedOrderItemIds[1]").value(102));
+
+        then(sellerOrderService).should(times(1)).confirmOrder(any());
+        then(responseService).should(times(1)).getSingleResult(serviceResponse);
+    }
+
+    @DisplayName("발주 확인 API - 실패(주문 없음)")
+    @Test
+    void givenNonExistingOrder_whenConfirmOrder_thenReturns4xx() throws Exception {
+        // Given
+        Long orderId = -1L;
+        OrderConfirmRequest request = new OrderConfirmRequest(List.of(100L));
+
+        given(sellerOrderService.confirmOrder(any()))
+            .willThrow(new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
+
+        // When & Then
+        mvc.perform(post("/api/v1/seller/orders/{orderId}/confirm", orderId)
+                .with(authentication(new UsernamePasswordAuthenticationToken(
+                    1L,
+                    "N/A",
+                    List.of(new SimpleGrantedAuthority("ROLE_SELLER"))
+                )))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonDataEncoder.encode(request)))
+
+            .andExpect(status().is4xxClientError())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value(BbangleErrorCode.ORDER_NOT_FOUND.getCode()))
+            .andExpect(jsonPath("$.message").value(BbangleErrorCode.ORDER_NOT_FOUND.getMessage()));
+
+        then(sellerOrderService).should(times(1)).confirmOrder(any());
+        then(globalControllerAdvice).should(times(1))
+            .handleBbangleException(any(HttpServletRequest.class), any(BbangleException.class));
+        then(responseService).should(times(1)).getFailResult(any(), any());
+    }
+
+    @DisplayName("발주 확인 API - 실패(orderItemIds 비어있음 -> validation 400)")
+    @Test
+    void givenEmptyOrderItemIds_whenConfirmOrder_thenReturns400() throws Exception {
+        // Given
+        Long orderId = 10L;
+        OrderConfirmRequest request = new OrderConfirmRequest(List.of()); // @NotEmpty 위반
+
+        // When & Then
+        mvc.perform(post("/api/v1/seller/orders/{orderId}/confirm", orderId)
+                .with(user("seller").roles("SELLER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonDataEncoder.encode(request)))
+            .andExpect(status().is4xxClientError());
+
+        // validation에서 막히면 service 호출 안 되는 게 정상
+        then(sellerOrderService).should(times(0)).confirmOrder(any());
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/order/service/SellerOrderServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/service/SellerOrderServiceTest.java
@@ -1,0 +1,121 @@
+package com.bbangle.bbangle.order.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.order.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderItemRepository;
+import com.bbangle.bbangle.order.repository.OrderRepository;
+import com.bbangle.bbangle.order.service.model.SellerOrderCommand.OrderConfirmCommand;
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("[비즈니스 로직] SellerOrderService")
+@ExtendWith(MockitoExtension.class)
+class SellerOrderServiceTest {
+
+    @InjectMocks
+    private SellerOrderService sut;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private OrderItemRepository orderItemRepository;
+
+    @DisplayName("주문이 존재하지 않으면 ORDER_NOT_FOUND 예외가 발생한다.")
+    @Test
+    void givenNonExistingOrderId_whenConfirmOrder_thenThrowsException() {
+        // given
+        Long orderId = 999L;
+        OrderConfirmCommand command = OrderConfirmCommand.builder()
+            .sellerId(1L) // 지금은 검증 안 해도 command 형태 맞추려고 넣어둠
+            .orderId(orderId)
+            .orderItemIds(List.of(1L, 2L))
+            .build();
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.empty());
+
+        // when
+        BbangleException result = assertThrows(BbangleException.class,
+            () -> sut.confirmOrder(command));
+
+        // then
+        then(orderRepository).should(times(1)).findById(orderId);
+        assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_NOT_FOUND);
+    }
+
+    @DisplayName("결제 완료(PAYMENT_COMPLETED)인 주문상품만 발주확인(ORDER_CONFIRMED)되고, 나머지는 부분 성공으로 스킵된다.")
+    @Test
+    void givenMixedOrderItems_whenConfirmOrder_thenConfirmOnlyPaymentCompleted() {
+        // given
+        Long orderId = 1L;
+
+        Order order = newEntity(Order.class);
+        ReflectionTestUtils.setField(order, "id", orderId);
+
+        OrderItem okItem = newEntity(OrderItem.class);
+        ReflectionTestUtils.setField(okItem, "id", 10L);
+        ReflectionTestUtils.setField(okItem, "orderStatus", OrderStatus.PAYMENT_COMPLETED);
+        ReflectionTestUtils.setField(okItem, "order", order);
+
+        OrderItem skipItem = newEntity(OrderItem.class);
+        ReflectionTestUtils.setField(skipItem, "id", 11L);
+        ReflectionTestUtils.setField(skipItem, "orderStatus", OrderStatus.ORDER_CONFIRMED); // 이미 확정된 상태라고 가정
+        ReflectionTestUtils.setField(skipItem, "order", order);
+
+        OrderConfirmCommand command = OrderConfirmCommand.builder()
+            .sellerId(1L)
+            .orderId(orderId)
+            .orderItemIds(List.of(10L, 11L))
+            .build();
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(orderItemRepository.findByOrderIdAndIdIn(orderId, List.of(10L, 11L)))
+            .willReturn(List.of(okItem, skipItem));
+
+        // when
+        OrderConfirmResponse result = sut.confirmOrder(command);
+
+        // then
+        then(orderRepository).should(times(1)).findById(orderId);
+        then(orderItemRepository).should(times(1)).findByOrderIdAndIdIn(orderId, List.of(10L, 11L));
+
+        // 응답 검증: PAYMENT_COMPLETED였던 것만 포함
+        assertThat(result).isNotNull();
+        assertThat(result.orderId()).isEqualTo(orderId);
+        assertThat(result.confirmedOrderItemIds())
+            .asList()
+            .containsExactly(10L);
+
+        // 상태 변경 검증
+        assertThat(okItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED);
+        assertThat(skipItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED); // 원래부터 confirmed였으면 그대로
+    }
+
+    private <T> T newEntity(Class<T> clazz) {
+        try {
+            Constructor<T> constructor = clazz.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## History
- 리뷰어 : 형재님, 현호님
- 연관된 이슈 : #504 

## 🚀 Major Changes & Explanations
- 발주 확인을 위한 판매자 주문 조회 API 추가
- 응답 DTO(SellerOrderResponse)로 API 응답 스펙 고정
- Swagger 인터페이스(SellerOrderApi)로 문서화
- 판매자 권한이 없는 경우 / 주문이 존재하지 않는 경우 등 ErrorCode 기반 처리 (BbangIeErrorCode)

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

- OAuth2 설정이 없는 로컬 환경에서 ClientRegistrationRepository 빈 누락으로 앱 실행 실패 이슈가 있어, 필터 조건부 등록 여부 확인 필요
