### PR TITLE
[Feat] (판매자) 서류 등록 API 기능 추가 

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -102,6 +102,8 @@ public enum BbangleErrorCode {
     SELLER_DOCUMENT_TYPE_REQUIRED(-711, "서류 타입은 필수입니다.", BAD_REQUEST),
     INVALID_DOCUMENT_FILE_EXTENSION(-712, "서류 파일은 jpg, jpeg, png, pdf 형식만 가능합니다.", BAD_REQUEST),
     SELLER_NOT_FOUND(-713, "존재하지 않는 판매자입니다.", NOT_FOUND),
+    ACCOUNT_VERIFICATION_NOT_FOUND(-714, "존재하지 않는 인증정보입니다.", NOT_FOUND),
+    ACCOUNT_NOT_VERIFIED(-715, "인증되지 않은 계좌입니다.", BAD_REQUEST),
 
     // Store Error (721~740)
     INVALID_STORE(-721, "유효하지 않은 스토어 객체입니다.", BAD_REQUEST),

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -83,7 +83,7 @@ public enum BbangleErrorCode {
     STREAM_CLOSING_ERROR(-605, "Stream 파일 닫기에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     GOOGLE_AUTHENTICATION_ERROR(-995, "구글 인증 토큰 발행 중 에러가 발생했습니다.",
-            HttpStatus.INTERNAL_SERVER_ERROR),
+        HttpStatus.INTERNAL_SERVER_ERROR),
     JSON_SERIALIZATION_ERROR(-996, "json 변환 중 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     FCM_INITIALIZATION_ERROR(-997, "Firebase 초기화 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     FCM_CONNECTION_ERROR(-998, "FCM 서버 요청 중 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
@@ -97,6 +97,11 @@ public enum BbangleErrorCode {
     INVALID_CERTIFICATION_STATUS(-705, "승인 상태가 비어 있습니다.", BAD_REQUEST),
     INVALID_PROFILE(-706, "프로필 이미지 경로가 비어있습니다.", BAD_REQUEST),
     SELLER_CREATION_FAILED(-708, "Seller 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    SELLER_DOCUMENT_NAME_REQUIRED(-709, "서류 파일명은 필수입니다.", BAD_REQUEST),
+    SELLER_DOCUMENT_URL_REQUIRED(-710, "서류 URL은 필수입니다.", BAD_REQUEST),
+    SELLER_DOCUMENT_TYPE_REQUIRED(-711, "서류 타입은 필수입니다.", BAD_REQUEST),
+    INVALID_DOCUMENT_FILE_EXTENSION(-712, "서류 파일은 jpg, jpeg, png, pdf 형식만 가능합니다.", BAD_REQUEST),
+    SELLER_NOT_FOUND(-713, "존재하지 않는 판매자입니다.", NOT_FOUND),
 
     // Store Error (721~740)
     INVALID_STORE(-721, "유효하지 않은 스토어 객체입니다.", BAD_REQUEST),
@@ -113,8 +118,8 @@ public enum BbangleErrorCode {
     MISSING_NAME_NICKNAME(-745, "이름 또는 닉네임이 비공개 상태입니다.", HttpStatus.UNPROCESSABLE_ENTITY),
 
     // NOTICE Error(761~770)
-    TITLE_IS_EMPTY(-761, "제목이 존재하지 않습니다.",BAD_REQUEST),
-    CONTENT_IS_EMPTY(-762, "본문이 존재하지 않습니다.",BAD_REQUEST),
+    TITLE_IS_EMPTY(-761, "제목이 존재하지 않습니다.", BAD_REQUEST),
+    CONTENT_IS_EMPTY(-762, "본문이 존재하지 않습니다.", BAD_REQUEST),
     ADMIN_NOTICE_CREATION_FAILED(-763, "본문이 존재하지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INVALID_URL_COUNT(-764, "원본 src 개수와 CDN URL 개수가 일치하지 않아 변환을 수행할 수 없습니다.", BAD_REQUEST),
     IMAGE_COUNT_MISMATCH(-765, "이미지 파일 개수와 원본 이미지 src 개수가 일치하지 않습니다.", BAD_REQUEST),
@@ -126,17 +131,17 @@ public enum BbangleErrorCode {
 
     public static BbangleErrorCode of(int code) {
         return Stream.of(BbangleErrorCode.values())
-                .filter(message -> message.getCode() == code)
-                .findFirst()
-                .orElseThrow(BbangleException::new);
+            .filter(message -> message.getCode() == code)
+            .findFirst()
+            .orElseThrow(BbangleException::new);
     }
 
     public static BbangleErrorCode of(String message) {
         return Stream.of(BbangleErrorCode.values())
-                .filter(error -> error.getMessage()
-                        .equals(message))
-                .findFirst()
-                .orElseThrow(BbangleException::new);
+            .filter(error -> error.getMessage()
+                .equals(message))
+            .findFirst()
+            .orElseThrow(BbangleException::new);
     }
 
 

--- a/src/main/java/com/bbangle/bbangle/seller/domain/AccountVerification.java
+++ b/src/main/java/com/bbangle/bbangle/seller/domain/AccountVerification.java
@@ -40,4 +40,12 @@ public class AccountVerification extends BaseEntity {
     @JoinColumn(name = "seller_id")
     private Seller seller;
 
+    public AccountVerification(String bankName, String accountNumber, String accountHolder, boolean verified,
+                               Seller seller) {
+        this.bankName = bankName;
+        this.accountNumber = accountNumber;
+        this.accountHolder = accountHolder;
+        this.verified = verified;
+        this.seller = seller;
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/domain/SellerDocument.java
+++ b/src/main/java/com/bbangle/bbangle/seller/domain/SellerDocument.java
@@ -1,8 +1,17 @@
 package com.bbangle.bbangle.seller.domain;
 
+import static com.bbangle.bbangle.exception.BbangleErrorCode.INVALID_DOCUMENT_FILE_EXTENSION;
+import static com.bbangle.bbangle.exception.BbangleErrorCode.SELLER_DOCUMENT_NAME_REQUIRED;
+import static com.bbangle.bbangle.exception.BbangleErrorCode.SELLER_DOCUMENT_TYPE_REQUIRED;
+import static com.bbangle.bbangle.exception.BbangleErrorCode.SELLER_DOCUMENT_URL_REQUIRED;
+import static com.bbangle.bbangle.exception.BbangleErrorCode.SELLER_NOT_FOUND;
+
 import com.bbangle.bbangle.common.domain.BaseEntity;
+import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import com.bbangle.bbangle.seller.domain.model.DocumentType;
+import java.util.Arrays;
+import java.util.List;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,6 +24,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,6 +33,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "seller_documents")
 @Entity
 public class SellerDocument extends BaseEntity {
+
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png", "pdf");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,8 +51,57 @@ public class SellerDocument extends BaseEntity {
     @Column(name = "url", columnDefinition = "VARCHAR(255)")
     private String url;
 
+    @Column(name = "name", columnDefinition = "VARCHAR(60)")
+    private String name;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", columnDefinition = "VARCHAR(30)")
     private CertificationStatus status;
 
+    @Builder
+    private SellerDocument(String name, String url, DocumentType type, Seller seller, CertificationStatus status) {
+        this.name = name;
+        this.url = url;
+        this.type = type;
+        this.seller = seller;
+        this.status = status;
+    }
+
+    public static SellerDocument create(String name, String url, DocumentType type, Seller seller) {
+        createValidate(name, url, type, seller);
+        return SellerDocument.builder()
+            .name(name)
+            .url(url)
+            .type(type)
+            .seller(seller)
+            .status(CertificationStatus.PENDING)
+            .build();
+    }
+
+    private static void createValidate(String name, String url, DocumentType type, Seller seller) {
+        if (name == null || name.isBlank()) {
+            throw new BbangleException(SELLER_DOCUMENT_NAME_REQUIRED);
+        }
+        validateFileExtension(name);
+        if (url == null || url.isBlank()) {
+            throw new BbangleException(SELLER_DOCUMENT_URL_REQUIRED);
+        }
+        if (type == null) {
+            throw new BbangleException(SELLER_DOCUMENT_TYPE_REQUIRED);
+        }
+        if (seller == null) {
+            throw new BbangleException(SELLER_NOT_FOUND);
+        }
+    }
+
+    private static void validateFileExtension(String fileName) {
+        int lastDotIndex = fileName.lastIndexOf(".");
+        if (lastDotIndex == -1 || lastDotIndex == fileName.length() - 1) {
+            throw new BbangleException(INVALID_DOCUMENT_FILE_EXTENSION);
+        }
+        String extension = fileName.substring(lastDotIndex + 1).toLowerCase();
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new BbangleException(INVALID_DOCUMENT_FILE_EXTENSION);
+        }
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/domain/SellerDocument.java
+++ b/src/main/java/com/bbangle/bbangle/seller/domain/SellerDocument.java
@@ -10,8 +10,6 @@ import com.bbangle.bbangle.common.domain.BaseEntity;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import com.bbangle.bbangle.seller.domain.model.DocumentType;
-import java.util.Arrays;
-import java.util.List;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -23,6 +21,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.Arrays;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -67,18 +67,18 @@ public class SellerDocument extends BaseEntity {
         this.status = status;
     }
 
-    public static SellerDocument create(String name, String url, DocumentType type, Seller seller) {
+    public static SellerDocument create(String name, String url, String type, Seller seller) {
         createValidate(name, url, type, seller);
         return SellerDocument.builder()
             .name(name)
             .url(url)
-            .type(type)
+            .type(DocumentType.valueOf(type))
             .seller(seller)
             .status(CertificationStatus.PENDING)
             .build();
     }
 
-    private static void createValidate(String name, String url, DocumentType type, Seller seller) {
+    private static void createValidate(String name, String url, String type, Seller seller) {
         if (name == null || name.isBlank()) {
             throw new BbangleException(SELLER_DOCUMENT_NAME_REQUIRED);
         }

--- a/src/main/java/com/bbangle/bbangle/seller/domain/SellerDocument.java
+++ b/src/main/java/com/bbangle/bbangle/seller/domain/SellerDocument.java
@@ -45,7 +45,7 @@ public class SellerDocument extends BaseEntity {
     private Seller seller;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "type", columnDefinition = "VARCHAR(30)")
+    @Column(name = "type", columnDefinition = "VARCHAR(60)")
     private DocumentType type;
 
     @Column(name = "url", columnDefinition = "VARCHAR(255)")

--- a/src/main/java/com/bbangle/bbangle/seller/repository/AccountVerificationRepository.java
+++ b/src/main/java/com/bbangle/bbangle/seller/repository/AccountVerificationRepository.java
@@ -1,0 +1,8 @@
+package com.bbangle.bbangle.seller.repository;
+
+
+import com.bbangle.bbangle.seller.domain.AccountVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountVerificationRepository extends JpaRepository<AccountVerification, Long> {
+}

--- a/src/main/java/com/bbangle/bbangle/seller/repository/SellerDocumentRepository.java
+++ b/src/main/java/com/bbangle/bbangle/seller/repository/SellerDocumentRepository.java
@@ -1,0 +1,7 @@
+package com.bbangle.bbangle.seller.repository;
+
+import com.bbangle.bbangle.seller.domain.SellerDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SellerDocumentRepository extends JpaRepository<SellerDocument, Long> {
+}

--- a/src/main/java/com/bbangle/bbangle/seller/seller/controller/SellerController.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/controller/SellerController.java
@@ -37,11 +37,10 @@ public class SellerController implements SellerApi {
 
     @PostMapping(value = "/documents", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public CommonResult registerDocuments(
-        @ModelAttribute SellerDocumentsRegisterRequest request,
+        @Valid @ModelAttribute SellerDocumentsRegisterRequest request,
         @AuthenticationPrincipal Long sellerId
     ) {
-        // TODO: 구현 필요
-        return responseService.getSuccessResult();
+        return responseService.getListResult(sellerFacade.registerDocuments(request.toCommand(sellerId)));
     }
 
 

--- a/src/main/java/com/bbangle/bbangle/seller/seller/controller/dto/SellerRequest.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/controller/dto/SellerRequest.java
@@ -2,9 +2,14 @@ package com.bbangle.bbangle.seller.seller.controller.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import com.bbangle.bbangle.seller.seller.facade.command.RegisterDocumentsCommand;
 import com.bbangle.bbangle.seller.seller.service.command.SellerCreateCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -13,18 +18,36 @@ public class SellerRequest {
 
     public record SellerDocumentsRegisterRequest(
         @Schema(description = "사업자 등록증", requiredMode = REQUIRED, type = "string", format = "binary")
+        @NotNull(message = "사업자 등록증은 필수 입니다.")
         MultipartFile businessLicense,
 
         @Schema(description = "통신판매업 신고증", requiredMode = REQUIRED, type = "string", format = "binary")
+        @NotNull(message = "통신판매업 신고증은 필수 입니다.")
         MultipartFile mailOrderLicense,
 
         @Schema(description = "개인명의 통장 사본", requiredMode = REQUIRED, type = "string", format = "binary")
+        @NotNull(message = "통장 사본은 필수 입니다.")
         MultipartFile bankbookCopy,
 
         @Schema(description = "즉석식품제조가공업 & 식품제조업", requiredMode = REQUIRED, type = "string", format = "binary")
-        MultipartFile foodManufactureLicense
+        @NotNull(message = "즉석식품제조가공업 & 식품제조업은 필수 입니다.")
+        MultipartFile foodManufactureLicense,
+
+        @Schema(description = "계좌인증 ID", requiredMode = REQUIRED)
+        @NotNull(message = "계좌인증 ID는 필수 입니다")
+        Long accountVerificationId
     ) {
 
+        public RegisterDocumentsCommand toCommand(Long sellerId) {
+            return RegisterDocumentsCommand.builder()
+                .businessLicense(businessLicense)
+                .mailOrderLicense(mailOrderLicense)
+                .bankbookCopy(bankbookCopy)
+                .foodManufactureLicense(foodManufactureLicense)
+                .accountVerificationId(accountVerificationId)
+                .sellerId(sellerId)
+                .build();
+        }
     }
 
     @Schema(description = "계좌 정보 변경 요청 DTO")
@@ -128,7 +151,7 @@ public class SellerRequest {
         @Size(max = 50, message = "상세 주소는 50자까지 입력 가능합니다.") // 주석 반영
         String originAddressDetail,
 
-        @Schema(description = "중복검사 후 선택한 스토어의 아이디값", example = "1" )
+        @Schema(description = "중복검사 후 선택한 스토어의 아이디값", example = "1")
         Long storeId
     ) {
 

--- a/src/main/java/com/bbangle/bbangle/seller/seller/controller/swagger/SellerApi.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/controller/swagger/SellerApi.java
@@ -21,7 +21,59 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "Seller", description = "(판매자) 판매자 API")
 public interface SellerApi {
 
-    @Operation(summary = "(판매자) 판매자 서류 등록")
+    @Operation(
+        summary = "(판매자) 판매자 서류 등록",
+        description = """
+            판매자 입점에 필요한 서류를 등록합니다.
+            - 사업자 등록증
+            - 통신판매업 신고증
+            - 개인명의 통장 사본
+            - 즉석식품제조가공업 & 식품제조업 등록증
+            - 계좌인증 ID
+            
+            모든 서류는 필수이며, 이미지(jpg, jpeg, png) 또는 PDF 형식으로 업로드 가능합니다.
+            """
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "서류 등록 성공",
+            content = @Content(
+                schema = @Schema(implementation = CommonResult.class),
+                examples = @ExampleObject(
+                    name = "successResponse",
+                    summary = "성공응답 예시",
+                    value = """
+                        {
+                            "success": true,
+                            "code": 0,
+                            "message": "SUCCESS",
+                            "list": [
+                                {
+                                    "sellerDocumentId": 1,
+                                    "sellerId": 1,
+                                    "url": "https://s3.amazonaws.com/bbangle/documents/business_license.pdf",
+                                    "documentName": "business_license.pdf",
+                                    "documentType": "BUSINESS_REGISTRATION_CERTIFICATE",
+                                    "status": "PENDING",
+                                    "createdAt": "2024-01-14T10:30:00"
+                                },
+                                {
+                                    "sellerDocumentId": 2,
+                                    "sellerId": 1,
+                                    "url": "https://s3.amazonaws.com/bbangle/documents/mail_order.pdf",
+                                    "documentName": "mail_order.pdf",
+                                    "documentType": "MAIL_ORDER_SALES_REPORT",
+                                    "status": "PENDING",
+                                    "createdAt": "2024-01-14T10:30:00"
+                                }
+                            ]
+                        }
+                        """
+                )
+            )
+        )
+    })
     CommonResult registerDocuments(
         SellerDocumentsRegisterRequest request,
         Long sellerId

--- a/src/main/java/com/bbangle/bbangle/seller/seller/facade/SellerFacade.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/facade/SellerFacade.java
@@ -11,6 +11,7 @@ import com.bbangle.bbangle.seller.seller.service.SellerDocumentService;
 import com.bbangle.bbangle.seller.seller.service.SellerService;
 import com.bbangle.bbangle.seller.seller.service.command.RegisterDocumentCommand;
 import com.bbangle.bbangle.seller.seller.service.command.SellerCreateCommand;
+import com.bbangle.bbangle.seller.seller.service.info.SellerDocumentInfo;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +45,9 @@ public class SellerFacade {
     }
 
     @Transactional
-    public void registerDocuments(RegisterDocumentsCommand command) {
+    public List<SellerDocumentInfo> registerDocuments(RegisterDocumentsCommand command) {
+
+        List<SellerDocumentInfo> sellerDocumentInfos = new ArrayList<>();
         // 1. 계좌 인증 확인
         accountVerificationService.confirmAccount(command.accountVerificationId());
 
@@ -68,7 +71,7 @@ public class SellerFacade {
 
             // 4. DB 저장
             for (UploadedDocument uploaded : uploadedDocuments) {
-                sellerDocumentService.registerDocument(
+                SellerDocumentInfo sellerDocumentInfo = sellerDocumentService.registerDocument(
                     new RegisterDocumentCommand(
                         command.sellerId(),
                         uploaded.filePath(),
@@ -76,8 +79,9 @@ public class SellerFacade {
                         uploaded.type()
                     )
                 );
+                sellerDocumentInfos.add(sellerDocumentInfo);
             }
-
+            return sellerDocumentInfos;
         } catch (Exception e) {
             // 5. 롤백: 업로드된 모든 파일 삭제
             uploadedDocuments.forEach(doc -> {

--- a/src/main/java/com/bbangle/bbangle/seller/seller/facade/SellerFacade.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/facade/SellerFacade.java
@@ -3,11 +3,20 @@ package com.bbangle.bbangle.seller.seller.facade;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.image.customer.service.S3Service;
+import com.bbangle.bbangle.seller.seller.facade.command.RegisterDocumentsCommand;
+import com.bbangle.bbangle.seller.seller.facade.dto.DocumentUploadInfo;
+import com.bbangle.bbangle.seller.seller.facade.dto.UploadedDocument;
+import com.bbangle.bbangle.seller.seller.service.AccountVerificationService;
+import com.bbangle.bbangle.seller.seller.service.SellerDocumentService;
 import com.bbangle.bbangle.seller.seller.service.SellerService;
+import com.bbangle.bbangle.seller.seller.service.command.RegisterDocumentCommand;
 import com.bbangle.bbangle.seller.seller.service.command.SellerCreateCommand;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -17,21 +26,65 @@ public class SellerFacade {
 
     private final SellerService sellerService;
     private final S3Service s3Service;
+    private final SellerDocumentService sellerDocumentService;
+    private final AccountVerificationService accountVerificationService;
 
     private static final String SELLER_IMAGE_FOLDER = "seller-images";
+    private static final String SELLER_DOCUMENT_FOLDER = "seller-documents";
 
     public void registerSeller(SellerCreateCommand command, MultipartFile profileImage, Long storeId) {
-        // 1. S3에 이미지 업로드 (먼저 수행)
         String profileImagePath = s3Service.saveAndReturnWithCdn(SELLER_IMAGE_FOLDER, profileImage);
         try {
-            // 2. 셀러 생성 (DB 작업)
             sellerService.createSeller(command, profileImagePath, storeId);
         } catch (Exception e) {
-            // 3. [보상 트랜잭션] DB 저장 실패 시, S3에 올라간 이미지 삭제
             log.error("Seller 생성 실패로 인한 S3 이미지 롤백: {}", profileImagePath);
             s3Service.deleteImage(profileImagePath);
-            // 4. 예외를 다시 던져서 Transactional이 동작하게 함
             throw new BbangleException(BbangleErrorCode.SELLER_CREATION_FAILED);
+        }
+    }
+
+    @Transactional
+    public void registerDocuments(RegisterDocumentsCommand command) {
+        // 1. 계좌 인증 확인
+        accountVerificationService.confirmAccount(command.accountVerificationId());
+
+        // 2. 문서 정보 매핑 (타입과 파일을 쌍으로 관리)
+        List<DocumentUploadInfo> documents = List.of(
+            new DocumentUploadInfo("BUSINESS_REGISTRATION_CERTIFICATE", command.businessLicense()),
+            new DocumentUploadInfo("MAIL_ORDER_SALES_REPORT", command.mailOrderLicense()),
+            new DocumentUploadInfo("BANKBOOK_COPY", command.bankbookCopy()),
+            new DocumentUploadInfo("INSTANT_FOOD_MANUFACTURING_PROCESSING_REGISTRATION",
+                command.foodManufactureLicense())
+        );
+
+        // 3. S3 업로드 및 경로 저장
+        List<UploadedDocument> uploadedDocuments = new ArrayList<>();
+        try {
+            for (DocumentUploadInfo doc : documents) {
+                String filePath = s3Service.saveAndReturnWithCdn(SELLER_DOCUMENT_FOLDER, doc.file());
+                String fileName = doc.file().getOriginalFilename();
+                uploadedDocuments.add(new UploadedDocument(doc.type(), filePath, fileName));
+            }
+
+            // 4. DB 저장
+            for (UploadedDocument uploaded : uploadedDocuments) {
+                sellerDocumentService.registerDocument(
+                    new RegisterDocumentCommand(
+                        command.sellerId(),
+                        uploaded.filePath(),
+                        uploaded.fileName(),
+                        uploaded.type()
+                    )
+                );
+            }
+
+        } catch (Exception e) {
+            // 5. 롤백: 업로드된 모든 파일 삭제
+            uploadedDocuments.forEach(doc -> {
+                log.error("Document 생성 실패로 인한 S3 문서 롤백: {}", doc.filePath());
+                s3Service.deleteImage(doc.filePath());
+            });
+            throw e;
         }
     }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/seller/facade/command/RegisterDocumentsCommand.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/facade/command/RegisterDocumentsCommand.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.seller.seller.facade.command;
 
+import lombok.Builder;
 import org.springframework.web.multipart.MultipartFile;
 
 public record RegisterDocumentsCommand(
@@ -15,4 +16,15 @@ public record RegisterDocumentsCommand(
 
     Long sellerId
 ) {
+    @Builder
+    public RegisterDocumentsCommand(MultipartFile businessLicense, MultipartFile mailOrderLicense,
+                                    MultipartFile bankbookCopy, MultipartFile foodManufactureLicense,
+                                    Long accountVerificationId, Long sellerId) {
+        this.businessLicense = businessLicense;
+        this.mailOrderLicense = mailOrderLicense;
+        this.bankbookCopy = bankbookCopy;
+        this.foodManufactureLicense = foodManufactureLicense;
+        this.accountVerificationId = accountVerificationId;
+        this.sellerId = sellerId;
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/seller/facade/command/RegisterDocumentsCommand.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/facade/command/RegisterDocumentsCommand.java
@@ -1,0 +1,18 @@
+package com.bbangle.bbangle.seller.seller.facade.command;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record RegisterDocumentsCommand(
+    MultipartFile businessLicense,
+
+    MultipartFile mailOrderLicense,
+
+    MultipartFile bankbookCopy,
+
+    MultipartFile foodManufactureLicense,
+
+    Long accountVerificationId,
+
+    Long sellerId
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/seller/seller/facade/dto/DocumentUploadInfo.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/facade/dto/DocumentUploadInfo.java
@@ -1,0 +1,9 @@
+package com.bbangle.bbangle.seller.seller.facade.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record DocumentUploadInfo(
+    String type,
+    MultipartFile file
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/seller/seller/facade/dto/UploadedDocument.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/facade/dto/UploadedDocument.java
@@ -1,0 +1,8 @@
+package com.bbangle.bbangle.seller.seller.facade.dto;
+
+public record UploadedDocument(
+    String type,
+    String filePath,
+    String fileName
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationService.java
@@ -1,0 +1,28 @@
+package com.bbangle.bbangle.seller.seller.service;
+
+import static com.bbangle.bbangle.exception.BbangleErrorCode.ACCOUNT_NOT_VERIFIED;
+import static com.bbangle.bbangle.exception.BbangleErrorCode.ACCOUNT_VERIFICATION_NOT_FOUND;
+
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.seller.domain.AccountVerification;
+import com.bbangle.bbangle.seller.repository.AccountVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AccountVerificationService {
+
+    private final AccountVerificationRepository accountVerificationRepository;
+
+    public void confirmAccount(Long accountVerificationId) {
+        AccountVerification accountVerification = accountVerificationRepository.findById(accountVerificationId)
+            .orElseThrow(() -> new BbangleException(ACCOUNT_VERIFICATION_NOT_FOUND));
+
+        if (!accountVerification.isVerified()) {
+            throw new BbangleException(ACCOUNT_NOT_VERIFIED);
+        }
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/SellerDocumentService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/SellerDocumentService.java
@@ -1,0 +1,35 @@
+package com.bbangle.bbangle.seller.seller.service;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.domain.SellerDocument;
+import com.bbangle.bbangle.seller.repository.SellerDocumentRepository;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
+import com.bbangle.bbangle.seller.seller.service.command.RegisterDocumentCommand;
+import com.bbangle.bbangle.seller.seller.service.info.SellerDocumentInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SellerDocumentService {
+
+    private final SellerRepository sellerRepository;
+    private final SellerDocumentRepository sellerDocumentRepository;
+
+    @Transactional
+    public SellerDocumentInfo registerDocument(RegisterDocumentCommand command) {
+
+        Seller seller = sellerRepository.findById(command.sellerId())
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.SELLER_NOT_FOUND));
+
+        SellerDocument sellerDocument = SellerDocument.create(command.name(), command.url(), command.type(), seller);
+
+        sellerDocumentRepository.save(sellerDocument);
+
+        return SellerDocumentInfo.from(sellerDocument);
+    }
+
+}

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/command/RegisterDocumentCommand.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/command/RegisterDocumentCommand.java
@@ -6,4 +6,10 @@ public record RegisterDocumentCommand(
     String name,
     String type
 ) {
+    public RegisterDocumentCommand(Long sellerId, String url, String name, String type) {
+        this.sellerId = sellerId;
+        this.url = url;
+        this.name = name;
+        this.type = type;
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/command/RegisterDocumentCommand.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/command/RegisterDocumentCommand.java
@@ -1,0 +1,9 @@
+package com.bbangle.bbangle.seller.seller.service.command;
+
+public record RegisterDocumentCommand(
+    Long sellerId,
+    String url,
+    String name,
+    String type
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/info/SellerDocumentInfo.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/info/SellerDocumentInfo.java
@@ -1,0 +1,36 @@
+package com.bbangle.bbangle.seller.seller.service.info;
+
+import com.bbangle.bbangle.seller.domain.SellerDocument;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+public record SellerDocumentInfo(
+    Long sellerId,
+    String url,
+    String documentName,
+    String documentType,
+    String status,
+    LocalDateTime createdAt
+) {
+
+    @Builder
+    public SellerDocumentInfo(Long sellerId, String url, String documentName, String documentType, String status,
+                              LocalDateTime createdAt) {
+        this.sellerId = sellerId;
+        this.url = url;
+        this.documentName = documentName;
+        this.documentType = documentType;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    public static SellerDocumentInfo from(SellerDocument sellerDocument) {
+        return SellerDocumentInfo.builder()
+            .sellerId(sellerDocument.getId())
+            .url(sellerDocument.getUrl())
+            .documentType(sellerDocument.getType().name())
+            .documentName(sellerDocument.getName())
+            .createdAt(sellerDocument.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/info/SellerDocumentInfo.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/info/SellerDocumentInfo.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 
 public record SellerDocumentInfo(
+    Long sellerDocumentId,
     Long sellerId,
     String url,
     String documentName,
@@ -14,8 +15,10 @@ public record SellerDocumentInfo(
 ) {
 
     @Builder
-    public SellerDocumentInfo(Long sellerId, String url, String documentName, String documentType, String status,
+    public SellerDocumentInfo(Long sellerDocumentId, Long sellerId, String url, String documentName,
+                              String documentType, String status,
                               LocalDateTime createdAt) {
+        this.sellerDocumentId = sellerDocumentId;
         this.sellerId = sellerId;
         this.url = url;
         this.documentName = documentName;
@@ -26,10 +29,12 @@ public record SellerDocumentInfo(
 
     public static SellerDocumentInfo from(SellerDocument sellerDocument) {
         return SellerDocumentInfo.builder()
-            .sellerId(sellerDocument.getId())
+            .sellerDocumentId(sellerDocument.getId())
+            .sellerId(sellerDocument.getSeller().getId())
             .url(sellerDocument.getUrl())
             .documentType(sellerDocument.getType().name())
             .documentName(sellerDocument.getName())
+            .status(sellerDocument.getStatus().name())
             .createdAt(sellerDocument.getCreatedAt())
             .build();
     }

--- a/src/main/resources/flyway/V29__app.sql
+++ b/src/main/resources/flyway/V29__app.sql
@@ -1,3 +1,5 @@
 ALTER TABLE seller_documents
     ADD COLUMN name VARCHAR(60) NOT NULL;
 
+ALTER TABLE seller_documents
+    MODIFY COLUMN type VARCHAR(60);

--- a/src/main/resources/flyway/V29__app.sql
+++ b/src/main/resources/flyway/V29__app.sql
@@ -1,0 +1,3 @@
+ALTER TABLE seller_documents
+    ADD COLUMN name VARCHAR(60) NOT NULL;
+

--- a/src/test/java/com/bbangle/bbangle/seller/domain/SellerDocumentTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/domain/SellerDocumentTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
@@ -30,7 +29,7 @@ public class SellerDocumentTest {
         // arrange
         String name = "business_registration.pdf";
         String url = "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf";
-        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+        String type = "BUSINESS_REGISTRATION_CERTIFICATE";
 
         // act
         SellerDocument document = SellerDocument.create(name, url, type, seller);
@@ -39,15 +38,20 @@ public class SellerDocumentTest {
         assertThat(document).isNotNull();
         assertThat(document.getName()).isEqualTo(name);
         assertThat(document.getUrl()).isEqualTo(url);
-        assertThat(document.getType()).isEqualTo(type);
+        assertThat(document.getType()).isEqualTo(DocumentType.BUSINESS_REGISTRATION_CERTIFICATE);
         assertThat(document.getSeller()).isEqualTo(seller);
         assertThat(document.getStatus()).isEqualTo(CertificationStatus.PENDING);
     }
 
     @ParameterizedTest
-    @EnumSource(DocumentType.class)
+    @ValueSource(strings = {
+        "BUSINESS_REGISTRATION_CERTIFICATE",
+        "MAIL_ORDER_SALES_REPORT",
+        "INSTANT_FOOD_MANUFACTURING_PROCESSING_REGISTRATION",
+        "BANKBOOK_COPY"
+    })
     @DisplayName("모든 서류 타입으로 판매자 서류 생성에 성공한다")
-    void success_create_seller_document_with_all_document_types(DocumentType documentType) {
+    void success_create_seller_document_with_all_document_types(String documentType) {
         // arrange
         String name = "document.pdf";
         String url = "https://s3.amazonaws.com/bbangle/documents/document.pdf";
@@ -57,7 +61,7 @@ public class SellerDocumentTest {
 
         // assert
         assertThat(document).isNotNull();
-        assertThat(document.getType()).isEqualTo(documentType);
+        assertThat(document.getType()).isEqualTo(DocumentType.valueOf(documentType));
         assertThat(document.getStatus()).isEqualTo(CertificationStatus.PENDING);
     }
 
@@ -67,7 +71,7 @@ public class SellerDocumentTest {
     void fail_create_seller_document_with_null_or_empty_name(String invalidName) {
         // arrange
         String url = "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf";
-        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+        String type = "BUSINESS_REGISTRATION_CERTIFICATE";
 
         // act & assert
         assertThatThrownBy(() -> SellerDocument.create(invalidName, url, type, seller))
@@ -81,7 +85,7 @@ public class SellerDocumentTest {
     void fail_create_seller_document_with_whitespace_name(String whitespaceName) {
         // arrange
         String url = "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf";
-        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+        String type = "BUSINESS_REGISTRATION_CERTIFICATE";
 
         // act & assert
         assertThatThrownBy(() -> SellerDocument.create(whitespaceName, url, type, seller))
@@ -96,7 +100,7 @@ public class SellerDocumentTest {
     void fail_create_seller_document_with_invalid_url(String invalidUrl) {
         // arrange
         String name = "business_registration.pdf";
-        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+        String type = "BUSINESS_REGISTRATION_CERTIFICATE";
 
         // act & assert
         assertThatThrownBy(() -> SellerDocument.create(name, invalidUrl, type, seller))
@@ -117,13 +121,26 @@ public class SellerDocumentTest {
             .hasMessageContaining(BbangleErrorCode.SELLER_DOCUMENT_TYPE_REQUIRED.getMessage());
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"INVALID_TYPE", "UNKNOWN", "TEST", ""})
+    @DisplayName("판매자 서류 생성 시 유효하지 않은 서류 타입이면 실패한다")
+    void fail_create_seller_document_with_invalid_type(String invalidType) {
+        // arrange
+        String name = "business_registration.pdf";
+        String url = "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf";
+
+        // act & assert
+        assertThatThrownBy(() -> SellerDocument.create(name, url, invalidType, seller))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
     @Test
     @DisplayName("판매자 서류 생성 시 판매자가 null이면 실패한다")
     void fail_create_seller_document_with_null_seller() {
         // arrange
         String name = "business_registration.pdf";
         String url = "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf";
-        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+        String type = "BUSINESS_REGISTRATION_CERTIFICATE";
 
         // act & assert
         assertThatThrownBy(() -> SellerDocument.create(name, url, type, null))
@@ -137,7 +154,7 @@ public class SellerDocumentTest {
         // arrange
         String name = "business_registration.pdf";
         String url = "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf";
-        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+        String type = "BUSINESS_REGISTRATION_CERTIFICATE";
 
         // act
         SellerDocument document = SellerDocument.create(name, url, type, seller);
@@ -158,7 +175,7 @@ public class SellerDocumentTest {
     void success_create_seller_document_with_various_file_names(String fileName) {
         // arrange
         String url = "https://s3.amazonaws.com/bbangle/documents/" + fileName;
-        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+        String type = "BUSINESS_REGISTRATION_CERTIFICATE";
 
         // act
         SellerDocument document = SellerDocument.create(fileName, url, type, seller);
@@ -183,7 +200,7 @@ public class SellerDocumentTest {
     void success_create_seller_document_with_allowed_extensions(String fileName) {
         // arrange
         String url = "https://s3.amazonaws.com/bbangle/documents/" + fileName;
-        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+        String type = "BUSINESS_REGISTRATION_CERTIFICATE";
 
         // act
         SellerDocument document = SellerDocument.create(fileName, url, type, seller);
@@ -208,7 +225,7 @@ public class SellerDocumentTest {
     void fail_create_seller_document_with_not_allowed_extensions(String fileName) {
         // arrange
         String url = "https://s3.amazonaws.com/bbangle/documents/" + fileName;
-        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+        String type = "BUSINESS_REGISTRATION_CERTIFICATE";
 
         // act & assert
         assertThatThrownBy(() -> SellerDocument.create(fileName, url, type, seller))
@@ -227,7 +244,7 @@ public class SellerDocumentTest {
     void fail_create_seller_document_with_no_extension(String fileName) {
         // arrange
         String url = "https://s3.amazonaws.com/bbangle/documents/" + fileName;
-        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+        String type = "BUSINESS_REGISTRATION_CERTIFICATE";
 
         // act & assert
         assertThatThrownBy(() -> SellerDocument.create(fileName, url, type, seller))

--- a/src/test/java/com/bbangle/bbangle/seller/domain/SellerDocumentTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/domain/SellerDocumentTest.java
@@ -1,0 +1,238 @@
+package com.bbangle.bbangle.seller.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
+import com.bbangle.bbangle.seller.domain.model.DocumentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[단위 테스트] SellerDocument")
+@ExtendWith(MockitoExtension.class)
+public class SellerDocumentTest {
+
+    @Mock
+    private Seller seller;
+
+    @Test
+    @DisplayName("판매자 서류 생성에 성공한다")
+    void success_create_seller_document() {
+        // arrange
+        String name = "business_registration.pdf";
+        String url = "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf";
+        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+
+        // act
+        SellerDocument document = SellerDocument.create(name, url, type, seller);
+
+        // assert
+        assertThat(document).isNotNull();
+        assertThat(document.getName()).isEqualTo(name);
+        assertThat(document.getUrl()).isEqualTo(url);
+        assertThat(document.getType()).isEqualTo(type);
+        assertThat(document.getSeller()).isEqualTo(seller);
+        assertThat(document.getStatus()).isEqualTo(CertificationStatus.PENDING);
+    }
+
+    @ParameterizedTest
+    @EnumSource(DocumentType.class)
+    @DisplayName("모든 서류 타입으로 판매자 서류 생성에 성공한다")
+    void success_create_seller_document_with_all_document_types(DocumentType documentType) {
+        // arrange
+        String name = "document.pdf";
+        String url = "https://s3.amazonaws.com/bbangle/documents/document.pdf";
+
+        // act
+        SellerDocument document = SellerDocument.create(name, url, documentType, seller);
+
+        // assert
+        assertThat(document).isNotNull();
+        assertThat(document.getType()).isEqualTo(documentType);
+        assertThat(document.getStatus()).isEqualTo(CertificationStatus.PENDING);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @DisplayName("판매자 서류 생성 시 서류 파일명이 null 또는 빈 문자열이면 실패한다")
+    void fail_create_seller_document_with_null_or_empty_name(String invalidName) {
+        // arrange
+        String url = "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf";
+        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+
+        // act & assert
+        assertThatThrownBy(() -> SellerDocument.create(invalidName, url, type, seller))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.SELLER_DOCUMENT_NAME_REQUIRED.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" ", "  ", "\t", "\n"})
+    @DisplayName("판매자 서류 생성 시 서류 파일명이 공백 문자열이면 실패한다")
+    void fail_create_seller_document_with_whitespace_name(String whitespaceName) {
+        // arrange
+        String url = "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf";
+        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+
+        // act & assert
+        assertThatThrownBy(() -> SellerDocument.create(whitespaceName, url, type, seller))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.SELLER_DOCUMENT_NAME_REQUIRED.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "  ", "\t"})
+    @DisplayName("판매자 서류 생성 시 URL이 null, 빈 문자열 또는 공백이면 실패한다")
+    void fail_create_seller_document_with_invalid_url(String invalidUrl) {
+        // arrange
+        String name = "business_registration.pdf";
+        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+
+        // act & assert
+        assertThatThrownBy(() -> SellerDocument.create(name, invalidUrl, type, seller))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.SELLER_DOCUMENT_URL_REQUIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("판매자 서류 생성 시 서류 타입이 null이면 실패한다")
+    void fail_create_seller_document_with_null_type() {
+        // arrange
+        String name = "business_registration.pdf";
+        String url = "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf";
+
+        // act & assert
+        assertThatThrownBy(() -> SellerDocument.create(name, url, null, seller))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.SELLER_DOCUMENT_TYPE_REQUIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("판매자 서류 생성 시 판매자가 null이면 실패한다")
+    void fail_create_seller_document_with_null_seller() {
+        // arrange
+        String name = "business_registration.pdf";
+        String url = "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf";
+        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+
+        // act & assert
+        assertThatThrownBy(() -> SellerDocument.create(name, url, type, null))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.SELLER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("생성된 판매자 서류의 초기 상태는 PENDING이다")
+    void seller_document_initial_status_is_pending() {
+        // arrange
+        String name = "business_registration.pdf";
+        String url = "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf";
+        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+
+        // act
+        SellerDocument document = SellerDocument.create(name, url, type, seller);
+
+        // assert
+        assertThat(document.getStatus()).isEqualTo(CertificationStatus.PENDING);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "business_registration.pdf",
+        "사업자등록증.pdf",
+        "document_with_underscore.jpg",
+        "document-with-dash.png",
+        "123456789.pdf"
+    })
+    @DisplayName("다양한 형식의 파일명으로 판매자 서류 생성에 성공한다")
+    void success_create_seller_document_with_various_file_names(String fileName) {
+        // arrange
+        String url = "https://s3.amazonaws.com/bbangle/documents/" + fileName;
+        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+
+        // act
+        SellerDocument document = SellerDocument.create(fileName, url, type, seller);
+
+        // assert
+        assertThat(document).isNotNull();
+        assertThat(document.getName()).isEqualTo(fileName);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "document.jpg",
+        "document.jpeg",
+        "document.png",
+        "document.pdf",
+        "document.JPG",
+        "document.JPEG",
+        "document.PNG",
+        "document.PDF"
+    })
+    @DisplayName("허용된 확장자(jpg, jpeg, png, pdf)로 판매자 서류 생성에 성공한다")
+    void success_create_seller_document_with_allowed_extensions(String fileName) {
+        // arrange
+        String url = "https://s3.amazonaws.com/bbangle/documents/" + fileName;
+        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+
+        // act
+        SellerDocument document = SellerDocument.create(fileName, url, type, seller);
+
+        // assert
+        assertThat(document).isNotNull();
+        assertThat(document.getName()).isEqualTo(fileName);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "document.txt",
+        "document.doc",
+        "document.docx",
+        "document.xls",
+        "document.xlsx",
+        "document.zip",
+        "document.exe",
+        "document.hwp"
+    })
+    @DisplayName("허용되지 않은 확장자로 판매자 서류 생성 시 실패한다")
+    void fail_create_seller_document_with_not_allowed_extensions(String fileName) {
+        // arrange
+        String url = "https://s3.amazonaws.com/bbangle/documents/" + fileName;
+        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+
+        // act & assert
+        assertThatThrownBy(() -> SellerDocument.create(fileName, url, type, seller))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.INVALID_DOCUMENT_FILE_EXTENSION.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "document",
+        "document.",
+        "no_extension_file",
+        "."
+    })
+    @DisplayName("확장자가 없거나 잘못된 형식의 파일명으로 판매자 서류 생성 시 실패한다")
+    void fail_create_seller_document_with_no_extension(String fileName) {
+        // arrange
+        String url = "https://s3.amazonaws.com/bbangle/documents/" + fileName;
+        DocumentType type = DocumentType.BUSINESS_REGISTRATION_CERTIFICATE;
+
+        // act & assert
+        assertThatThrownBy(() -> SellerDocument.create(fileName, url, type, seller))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.INVALID_DOCUMENT_FILE_EXTENSION.getMessage());
+    }
+
+}

--- a/src/test/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationServiceIntegrationTest.java
@@ -1,0 +1,131 @@
+package com.bbangle.bbangle.seller.seller.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.seller.domain.AccountVerification;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
+import com.bbangle.bbangle.seller.repository.AccountVerificationRepository;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.repository.StoreRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[통합테스트] AccountVerificationServiceIntegrationTest")
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class AccountVerificationServiceIntegrationTest {
+
+    @Autowired
+    private AccountVerificationService accountVerificationService;
+
+    @Autowired
+    private AccountVerificationRepository accountVerificationRepository;
+
+    @Autowired
+    private SellerRepository sellerRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Seller testSeller;
+
+    @BeforeEach
+    void setUp() {
+        // arrange: 테스트용 스토어와 판매자 생성
+        Store store = Store.builder()
+            .name("테스트 스토어")
+            .build();
+        storeRepository.save(store);
+
+        testSeller = Seller.create(
+            "01012345678",
+            "01087654321",
+            "test@example.com",
+            "서울특별시 강남구 테헤란로 123",
+            "456호",
+            "https://example.com/profile.jpg",
+            CertificationStatus.PENDING,
+            store
+        );
+        sellerRepository.save(testSeller);
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("인증된 계좌 확인에 성공한다")
+    void success_confirm_verified_account() {
+        // arrange: 인증된 계좌 정보 생성
+        AccountVerification accountVerification = createAccountVerification(testSeller, true);
+        em.flush();
+        em.clear();
+
+        // act & assert
+        assertThatCode(() -> accountVerificationService.confirmAccount(accountVerification.getId()))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 계좌 확인 시 예외가 발생한다")
+    void fail_confirm_unverified_account() {
+        // arrange: 인증되지 않은 계좌 정보 생성
+        AccountVerification accountVerification = createAccountVerification(testSeller, false);
+        em.flush();
+        em.clear();
+
+        // act & assert
+        assertThatThrownBy(() -> accountVerificationService.confirmAccount(accountVerification.getId()))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.ACCOUNT_NOT_VERIFIED.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 계좌 인증 ID로 확인 시 예외가 발생한다")
+    void fail_confirm_with_non_existent_id() {
+        // arrange
+        Long nonExistentId = 99999L;
+
+        // act & assert
+        assertThatThrownBy(() -> accountVerificationService.confirmAccount(nonExistentId))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.ACCOUNT_VERIFICATION_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("null ID로 계좌 확인 시 예외가 발생한다")
+    void fail_confirm_with_null_id() {
+        // act & assert
+        assertThatThrownBy(() -> accountVerificationService.confirmAccount(null))
+            .isInstanceOf(Exception.class);
+    }
+
+    /**
+     * 테스트용 AccountVerification 생성 헬퍼 메서드
+     */
+    private AccountVerification createAccountVerification(Seller seller, boolean verified) {
+        AccountVerification accountVerification = new AccountVerification(
+            "테스트은행",
+            "1234567890",
+            "홍길동",
+            verified,
+            seller
+        );
+        return accountVerificationRepository.save(accountVerification);
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/seller/seller/service/SellerDocumentServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/service/SellerDocumentServiceIntegrationTest.java
@@ -91,14 +91,16 @@ class SellerDocumentServiceIntegrationTest {
 
         // assert
         assertThat(result).isNotNull();
-        assertThat(result.sellerId()).isNotNull();
+        assertThat(result.sellerDocumentId()).isNotNull();
+        assertThat(result.sellerId()).isEqualTo(testSeller.getId());
         assertThat(result.url()).isEqualTo(command.url());
         assertThat(result.documentName()).isEqualTo(command.name());
         assertThat(result.documentType()).isEqualTo(command.type());
+        assertThat(result.status()).isEqualTo(CertificationStatus.PENDING.name());
         assertThat(result.createdAt()).isNotNull();
 
         // DB 검증
-        SellerDocument savedDocument = sellerDocumentRepository.findById(result.sellerId())
+        SellerDocument savedDocument = sellerDocumentRepository.findById(result.sellerDocumentId())
             .orElseThrow();
         assertThat(savedDocument.getName()).isEqualTo(command.name());
         assertThat(savedDocument.getUrl()).isEqualTo(command.url());
@@ -134,7 +136,7 @@ class SellerDocumentServiceIntegrationTest {
         assertThat(result.documentType()).isEqualTo(documentType);
 
         // DB 검증
-        SellerDocument savedDocument = sellerDocumentRepository.findById(result.sellerId())
+        SellerDocument savedDocument = sellerDocumentRepository.findById(result.sellerDocumentId())
             .orElseThrow();
         assertThat(savedDocument.getType().name()).isEqualTo(documentType);
     }
@@ -166,7 +168,7 @@ class SellerDocumentServiceIntegrationTest {
         assertThat(result.documentName()).isEqualTo(fileName);
 
         // DB 검증
-        SellerDocument savedDocument = sellerDocumentRepository.findById(result.sellerId())
+        SellerDocument savedDocument = sellerDocumentRepository.findById(result.sellerDocumentId())
             .orElseThrow();
         assertThat(savedDocument.getName()).isEqualTo(fileName);
     }
@@ -352,7 +354,7 @@ class SellerDocumentServiceIntegrationTest {
         // assert
         assertThat(result1).isNotNull();
         assertThat(result2).isNotNull();
-        assertThat(result1.sellerId()).isNotEqualTo(result2.sellerId());
+        assertThat(result1.sellerDocumentId()).isNotEqualTo(result2.sellerDocumentId());
 
         // DB 검증
         assertThat(sellerDocumentRepository.findAll()).hasSize(2);

--- a/src/test/java/com/bbangle/bbangle/seller/seller/service/SellerDocumentServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/service/SellerDocumentServiceIntegrationTest.java
@@ -1,0 +1,360 @@
+package com.bbangle.bbangle.seller.seller.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.domain.SellerDocument;
+import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
+import com.bbangle.bbangle.seller.repository.SellerDocumentRepository;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
+import com.bbangle.bbangle.seller.seller.service.command.RegisterDocumentCommand;
+import com.bbangle.bbangle.seller.seller.service.info.SellerDocumentInfo;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.repository.StoreRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[통합테스트] SellerDocumentServiceIntegrationTest")
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class SellerDocumentServiceIntegrationTest {
+
+    @Autowired
+    private SellerDocumentService sellerDocumentService;
+
+    @Autowired
+    private SellerRepository sellerRepository;
+
+    @Autowired
+    private SellerDocumentRepository sellerDocumentRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Seller testSeller;
+
+    @BeforeEach
+    void setUp() {
+        // arrange: 테스트용 스토어와 판매자 생성
+        Store store = Store.builder()
+            .name("테스트 스토어")
+            .build();
+        storeRepository.save(store);
+
+        testSeller = Seller.create(
+            "01012345678",
+            "01087654321",
+            "test@example.com",
+            "서울특별시 강남구 테헤란로 123",
+            "456호",
+            "https://example.com/profile.jpg",
+            CertificationStatus.PENDING,
+            store
+        );
+        sellerRepository.save(testSeller);
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("판매자 서류 등록에 성공한다")
+    void success_register_seller_document() {
+        // arrange
+        RegisterDocumentCommand command = new RegisterDocumentCommand(
+            testSeller.getId(),
+            "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf",
+            "business_registration.pdf",
+            "BUSINESS_REGISTRATION_CERTIFICATE"
+        );
+
+        // act
+        SellerDocumentInfo result = sellerDocumentService.registerDocument(command);
+        em.flush();
+        em.clear();
+
+        // assert
+        assertThat(result).isNotNull();
+        assertThat(result.sellerId()).isNotNull();
+        assertThat(result.url()).isEqualTo(command.url());
+        assertThat(result.documentName()).isEqualTo(command.name());
+        assertThat(result.documentType()).isEqualTo(command.type());
+        assertThat(result.createdAt()).isNotNull();
+
+        // DB 검증
+        SellerDocument savedDocument = sellerDocumentRepository.findById(result.sellerId())
+            .orElseThrow();
+        assertThat(savedDocument.getName()).isEqualTo(command.name());
+        assertThat(savedDocument.getUrl()).isEqualTo(command.url());
+        assertThat(savedDocument.getType().name()).isEqualTo(command.type());
+        assertThat(savedDocument.getSeller().getId()).isEqualTo(testSeller.getId());
+        assertThat(savedDocument.getStatus()).isEqualTo(CertificationStatus.PENDING);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "BUSINESS_REGISTRATION_CERTIFICATE",
+        "MAIL_ORDER_SALES_REPORT",
+        "INSTANT_FOOD_MANUFACTURING_PROCESSING_REGISTRATION",
+        "BANKBOOK_COPY"
+    })
+    @DisplayName("모든 서류 타입으로 판매자 서류 등록에 성공한다")
+    void success_register_seller_document_with_all_document_types(String documentType) {
+        // arrange
+        RegisterDocumentCommand command = new RegisterDocumentCommand(
+            testSeller.getId(),
+            "https://s3.amazonaws.com/bbangle/documents/document.pdf",
+            "document.pdf",
+            documentType
+        );
+
+        // act
+        SellerDocumentInfo result = sellerDocumentService.registerDocument(command);
+        em.flush();
+        em.clear();
+
+        // assert
+        assertThat(result).isNotNull();
+        assertThat(result.documentType()).isEqualTo(documentType);
+
+        // DB 검증
+        SellerDocument savedDocument = sellerDocumentRepository.findById(result.sellerId())
+            .orElseThrow();
+        assertThat(savedDocument.getType().name()).isEqualTo(documentType);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "document.jpg",
+        "document.jpeg",
+        "document.png",
+        "document.pdf"
+    })
+    @DisplayName("허용된 파일 확장자로 판매자 서류 등록에 성공한다")
+    void success_register_seller_document_with_allowed_extensions(String fileName) {
+        // arrange
+        RegisterDocumentCommand command = new RegisterDocumentCommand(
+            testSeller.getId(),
+            "https://s3.amazonaws.com/bbangle/documents/" + fileName,
+            fileName,
+            "BUSINESS_REGISTRATION_CERTIFICATE"
+        );
+
+        // act
+        SellerDocumentInfo result = sellerDocumentService.registerDocument(command);
+        em.flush();
+        em.clear();
+
+        // assert
+        assertThat(result).isNotNull();
+        assertThat(result.documentName()).isEqualTo(fileName);
+
+        // DB 검증
+        SellerDocument savedDocument = sellerDocumentRepository.findById(result.sellerId())
+            .orElseThrow();
+        assertThat(savedDocument.getName()).isEqualTo(fileName);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 판매자 ID로 서류 등록 시 실패한다")
+    void fail_register_document_with_non_existent_seller_id() {
+        // arrange
+        Long nonExistentSellerId = 99999L;
+        RegisterDocumentCommand command = new RegisterDocumentCommand(
+            nonExistentSellerId,
+            "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf",
+            "business_registration.pdf",
+            "BUSINESS_REGISTRATION_CERTIFICATE"
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sellerDocumentService.registerDocument(command))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.SELLER_NOT_FOUND.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @DisplayName("파일명이 null 또는 빈 문자열인 경우 서류 등록에 실패한다")
+    void fail_register_document_with_null_or_empty_name(String invalidName) {
+        // arrange
+        RegisterDocumentCommand command = new RegisterDocumentCommand(
+            testSeller.getId(),
+            "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf",
+            invalidName,
+            "BUSINESS_REGISTRATION_CERTIFICATE"
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sellerDocumentService.registerDocument(command))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.SELLER_DOCUMENT_NAME_REQUIRED.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" ", "  ", "\t", "\n"})
+    @DisplayName("파일명이 공백 문자열인 경우 서류 등록에 실패한다")
+    void fail_register_document_with_whitespace_name(String whitespaceName) {
+        // arrange
+        RegisterDocumentCommand command = new RegisterDocumentCommand(
+            testSeller.getId(),
+            "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf",
+            whitespaceName,
+            "BUSINESS_REGISTRATION_CERTIFICATE"
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sellerDocumentService.registerDocument(command))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.SELLER_DOCUMENT_NAME_REQUIRED.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "  ", "\t"})
+    @DisplayName("URL이 null, 빈 문자열 또는 공백인 경우 서류 등록에 실패한다")
+    void fail_register_document_with_invalid_url(String invalidUrl) {
+        // arrange
+        RegisterDocumentCommand command = new RegisterDocumentCommand(
+            testSeller.getId(),
+            invalidUrl,
+            "business_registration.pdf",
+            "BUSINESS_REGISTRATION_CERTIFICATE"
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sellerDocumentService.registerDocument(command))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.SELLER_DOCUMENT_URL_REQUIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("서류 타입이 null인 경우 서류 등록에 실패한다")
+    void fail_register_document_with_null_type() {
+        // arrange
+        RegisterDocumentCommand command = new RegisterDocumentCommand(
+            testSeller.getId(),
+            "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf",
+            "business_registration.pdf",
+            null
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sellerDocumentService.registerDocument(command))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.SELLER_DOCUMENT_TYPE_REQUIRED.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"INVALID_TYPE", "UNKNOWN", "TEST", ""})
+    @DisplayName("유효하지 않은 서류 타입인 경우 서류 등록에 실패한다")
+    void fail_register_document_with_invalid_type(String invalidType) {
+        // arrange
+        RegisterDocumentCommand command = new RegisterDocumentCommand(
+            testSeller.getId(),
+            "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf",
+            "business_registration.pdf",
+            invalidType
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sellerDocumentService.registerDocument(command))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "document.txt",
+        "document.doc",
+        "document.docx",
+        "document.exe",
+        "document.hwp"
+    })
+    @DisplayName("허용되지 않은 파일 확장자인 경우 서류 등록에 실패한다")
+    void fail_register_document_with_not_allowed_extension(String invalidFileName) {
+        // arrange
+        RegisterDocumentCommand command = new RegisterDocumentCommand(
+            testSeller.getId(),
+            "https://s3.amazonaws.com/bbangle/documents/" + invalidFileName,
+            invalidFileName,
+            "BUSINESS_REGISTRATION_CERTIFICATE"
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sellerDocumentService.registerDocument(command))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.INVALID_DOCUMENT_FILE_EXTENSION.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "document",
+        "document.",
+        "no_extension_file",
+        "."
+    })
+    @DisplayName("확장자가 없거나 잘못된 형식의 파일명인 경우 서류 등록에 실패한다")
+    void fail_register_document_with_no_extension(String invalidFileName) {
+        // arrange
+        RegisterDocumentCommand command = new RegisterDocumentCommand(
+            testSeller.getId(),
+            "https://s3.amazonaws.com/bbangle/documents/" + invalidFileName,
+            invalidFileName,
+            "BUSINESS_REGISTRATION_CERTIFICATE"
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> sellerDocumentService.registerDocument(command))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.INVALID_DOCUMENT_FILE_EXTENSION.getMessage());
+    }
+
+    @Test
+    @DisplayName("여러 서류를 순차적으로 등록할 수 있다")
+    void success_register_multiple_documents() {
+        // arrange
+        RegisterDocumentCommand command1 = new RegisterDocumentCommand(
+            testSeller.getId(),
+            "https://s3.amazonaws.com/bbangle/documents/business_registration.pdf",
+            "business_registration.pdf",
+            "BUSINESS_REGISTRATION_CERTIFICATE"
+        );
+
+        RegisterDocumentCommand command2 = new RegisterDocumentCommand(
+            testSeller.getId(),
+            "https://s3.amazonaws.com/bbangle/documents/bankbook.jpg",
+            "bankbook.jpg",
+            "BANKBOOK_COPY"
+        );
+
+        // act
+        SellerDocumentInfo result1 = sellerDocumentService.registerDocument(command1);
+        SellerDocumentInfo result2 = sellerDocumentService.registerDocument(command2);
+        em.flush();
+        em.clear();
+
+        // assert
+        assertThat(result1).isNotNull();
+        assertThat(result2).isNotNull();
+        assertThat(result1.sellerId()).isNotEqualTo(result2.sellerId());
+
+        // DB 검증
+        assertThat(sellerDocumentRepository.findAll()).hasSize(2);
+    }
+}


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

리뷰어 (1팀)

- 경민님
- 민수님

연관된 이슈 :

* Resolves #550

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

판매자 서류 등록 기능 개발
- 판매자 입점에 필요한 4가지 서류(사업자등록증, 통신판매업신고증, 통장사본, 식품제조업등록증) 업로드 및 등록 기능 개발
- MultipartFile을 받아 S3에 업로드 후 SellerDocument 엔티티로 저장하는 전체 플로우 구현

계좌인증 확인 기능 개발
- AccountVerification 엔티티와의 연동을 통한 계좌 인증 검증 로직 추가
- 인증되지 않은 계좌로 서류 등록 시도 시 예외 처리

SellerDocument 도메인 로직 강화
- 파일 확장자 검증, 서류 타입 검증 등 도메인 책임을 엔티티에 부여
- 허용된 파일 형식(jpg, jpeg, png, pdf)에 대한 검증 로직 추가

SellerFacade 패턴 도입
- 파일 업로드와 서류 등록 로직을 Facade 패턴으로 통합 관리

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
