### PR TITLE
[Feature] (관리자) 상품 옵션 재고 상태 변경 API

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/AdminProductController.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/AdminProductController.java
@@ -1,0 +1,37 @@
+package com.bbangle.bbangle.board.admin.controller;
+
+import com.bbangle.bbangle.board.admin.controller.dto.AdminEditStockRequest;
+import com.bbangle.bbangle.board.admin.controller.swagger.AdminProductApi;
+import com.bbangle.bbangle.board.admin.service.AdminProductService;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.AdminApiPath;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping(AdminApiPath.PREFIX + "/options")
+@RestController
+public class AdminProductController implements AdminProductApi {
+    private final AdminProductService adminProductService;
+    private final ResponseService responseService;
+
+    @Override
+    @PatchMapping("{optionId}/stock")
+    public CommonResult editProductOptionStock(
+        @PathVariable Long optionId,
+        @RequestBody @NotNull AdminEditStockRequest adminEditStockRequest
+    ) {
+        adminProductService.editProductStock(
+            optionId,
+            adminEditStockRequest.amount(),
+            adminEditStockRequest.editStockFlag()
+        );
+        return responseService.getSuccessResult();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/AdminProductController.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/AdminProductController.java
@@ -6,7 +6,7 @@ import com.bbangle.bbangle.board.admin.service.AdminProductService;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.AdminApiPath;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,7 +25,7 @@ public class AdminProductController implements AdminProductApi {
     @PatchMapping("{optionId}/stock")
     public CommonResult editProductOptionStock(
         @PathVariable Long optionId,
-        @RequestBody @NotNull AdminEditStockRequest adminEditStockRequest
+        @RequestBody @Valid AdminEditStockRequest adminEditStockRequest
     ) {
         adminProductService.editProductStock(
             optionId,

--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/dto/AdminEditStockRequest.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/dto/AdminEditStockRequest.java
@@ -1,0 +1,21 @@
+package com.bbangle.bbangle.board.admin.controller.dto;
+
+import static com.bbangle.bbangle.exception.BbangleErrorCode.INVALID_STOCK_AMOUNT;
+
+import com.bbangle.bbangle.board.domain.EditStockFlag;
+import com.bbangle.bbangle.exception.BbangleException;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 재고 변경 요청")
+public record AdminEditStockRequest(
+    @Schema(description = "재고 조작 Flag")
+    EditStockFlag editStockFlag,
+    @Schema(description = "조작 수량")
+    int amount
+) {
+    public AdminEditStockRequest {
+        if (amount < 0) {
+            throw new BbangleException(INVALID_STOCK_AMOUNT);
+        }
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/swagger/AdminProductApi.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/swagger/AdminProductApi.java
@@ -5,7 +5,7 @@ import com.bbangle.bbangle.common.dto.CommonResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "AdminOptions", description = "(관리자) 상품 옵션 관련 API")
@@ -18,6 +18,6 @@ public interface AdminProductApi {
     CommonResult editProductOptionStock(
         @Parameter(description = "재고를 수정할 상품 옵션ID", example = "1")
         Long optionId,
-        @RequestBody @NotNull AdminEditStockRequest adminEditStockRequest
+        @RequestBody @Valid AdminEditStockRequest adminEditStockRequest
     );
 }

--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/swagger/AdminProductApi.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/swagger/AdminProductApi.java
@@ -1,0 +1,23 @@
+package com.bbangle.bbangle.board.admin.controller.swagger;
+
+import com.bbangle.bbangle.board.admin.controller.dto.AdminEditStockRequest;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "AdminOptions", description = "(관리자) 상품 옵션 관련 API")
+public interface AdminProductApi {
+
+    @Operation(
+        summary = "관리자 상품옵션 재고 수정",
+        description = "관리자가 선택한 상품옵션의 재고를 수정합니다."
+    )
+    CommonResult editProductOptionStock(
+        @Parameter(description = "재고를 수정할 상품 옵션ID", example = "1")
+        Long optionId,
+        @RequestBody @NotNull AdminEditStockRequest adminEditStockRequest
+    );
+}

--- a/src/main/java/com/bbangle/bbangle/board/admin/service/AdminProductService.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/service/AdminProductService.java
@@ -1,0 +1,25 @@
+package com.bbangle.bbangle.board.admin.service;
+
+import com.bbangle.bbangle.board.domain.EditStockFlag;
+import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.board.repository.ProductRepository;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class AdminProductService {
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public void editProductStock(Long productId, int amount, EditStockFlag editStockFlag) {
+        Product product = productRepository.findById(productId).orElseThrow(
+            () -> new BbangleException(BbangleErrorCode.NOT_FOUND_OPTION)
+        );
+        product.editStock(amount, editStockFlag);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/board/admin/service/AdminProductService.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/service/AdminProductService.java
@@ -17,9 +17,11 @@ public class AdminProductService {
 
     @Transactional
     public void editProductStock(Long productId, int amount, EditStockFlag editStockFlag) {
-        Product product = productRepository.findById(productId).orElseThrow(
+        // Pessimistic Lock으로 조회하여 동시성 제어
+        Product product = productRepository.findWithLockById(productId).orElseThrow(
             () -> new BbangleException(BbangleErrorCode.NOT_FOUND_OPTION)
         );
         product.editStock(amount, editStockFlag);
     }
+
 }

--- a/src/main/java/com/bbangle/bbangle/board/domain/EditStockFlag.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/EditStockFlag.java
@@ -1,0 +1,12 @@
+package com.bbangle.bbangle.board.domain;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum EditStockFlag {
+    INCREASE("재고 증가"),
+    DECREASE("재고 감소"),
+    SOLDOUT("재고 품절처리");
+
+    private final String description;
+}

--- a/src/main/java/com/bbangle/bbangle/board/domain/Product.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Product.java
@@ -108,6 +108,9 @@ public class Product extends SoftDeleteBaseEntity {
     @Column(name = "order_end_date")
     private LocalDateTime orderEndDate;
 
+    @Column(name = "is_deleted", columnDefinition = "tinyint")
+    private boolean isDeleted;
+
     @NotNull
     @Column(name = "is_soldout", columnDefinition = "tinyint")
     private boolean soldout;
@@ -148,6 +151,7 @@ public class Product extends SoftDeleteBaseEntity {
         this.sunday = sunday;
         this.nutrition = nutrition;
         this.soldout = false;
+        this.isDeleted = false;
     }
 
     private void validate(String title,

--- a/src/main/java/com/bbangle/bbangle/board/domain/Product.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Product.java
@@ -186,6 +186,9 @@ public class Product extends SoftDeleteBaseEntity {
     public void editStock(int amount, EditStockFlag editStockFlag) {
         if (editStockFlag == EditStockFlag.INCREASE) {
             this.stock = this.stock + amount;
+            if (this.soldout) {
+                this.soldout = false;
+            }
         } else if (editStockFlag == EditStockFlag.DECREASE) {
             if (this.stock < amount) {
                 throw new BbangleException(BbangleErrorCode.INVALID_DECREASE_STOCK_AMOUNT);

--- a/src/main/java/com/bbangle/bbangle/board/domain/Product.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Product.java
@@ -187,4 +187,20 @@ public class Product extends SoftDeleteBaseEntity {
         return PushType.WEEK;
     }
 
+    public void editStock(int amount, EditStockFlag editStockFlag) {
+        if (editStockFlag == EditStockFlag.INCREASE) {
+            this.stock = this.stock + amount;
+        } else if (editStockFlag == EditStockFlag.DECREASE) {
+            if (this.stock < amount) {
+                throw new BbangleException(BbangleErrorCode.INVALID_DECREASE_STOCK_AMOUNT);
+            }
+            this.stock = this.stock - amount;
+            if (this.stock == 0) {
+                this.soldout = true;
+            }
+        } else if (editStockFlag == EditStockFlag.SOLDOUT) {
+            this.stock = 0;
+            this.soldout = true;
+        }
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/board/domain/Product.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Product.java
@@ -108,9 +108,6 @@ public class Product extends SoftDeleteBaseEntity {
     @Column(name = "order_end_date")
     private LocalDateTime orderEndDate;
 
-    @Column(name = "is_deleted", columnDefinition = "tinyint")
-    private boolean isDeleted;
-
     @NotNull
     @Column(name = "is_soldout", columnDefinition = "tinyint")
     private boolean soldout;
@@ -151,7 +148,6 @@ public class Product extends SoftDeleteBaseEntity {
         this.sunday = sunday;
         this.nutrition = nutrition;
         this.soldout = false;
-        this.isDeleted = false;
     }
 
     private void validate(String title,

--- a/src/main/java/com/bbangle/bbangle/board/repository/ProductRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/ProductRepository.java
@@ -1,13 +1,19 @@
 package com.bbangle.bbangle.board.repository;
 
 import com.bbangle.bbangle.board.domain.Product;
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductQueryDSLRepository {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Product> findWithLockById(Long id);
 
     @Query("SELECT p FROM Board b JOIN b.products p WHERE b.id = :boardId")
     List<Product> findByBoardId(@Param("boardId") Long boardId);

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -75,7 +75,7 @@ public enum BbangleErrorCode {
     NOT_VALID_INDEX(-58, "유효하지 않은 CSV 컬럼값 입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INPUT_STREAM_NOT_CLOSE(-59, "InputStream이 정상적으로 종료되지 않았습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INVALID_REMOVE_PRODUCTS_REQUEST(-60, "옵션 전체삭제가 아닌경우 옵션 ID가 하나라도 있어야합니다.", BAD_REQUEST),
-
+    INVALID_STOCK_AMOUNT(-61, "재고 수량은 0이상이여야 합니다.", BAD_REQUEST),
     NOT_FOUND_OPTION(-62, "존재하지 않는 상품 옵션입니다", NOT_FOUND),
     INVALID_DECREASE_STOCK_AMOUNT(-63, "감소하려는 수보다 현재 재고가 더 작습니다.", BAD_REQUEST),
     //AWS Error (600)

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -76,6 +76,7 @@ public enum BbangleErrorCode {
     INPUT_STREAM_NOT_CLOSE(-59, "InputStream이 정상적으로 종료되지 않았습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INVALID_REMOVE_PRODUCTS_REQUEST(-60, "옵션 전체삭제가 아닌경우 옵션 ID가 하나라도 있어야합니다.", BAD_REQUEST),
 
+    NOT_FOUND_OPTION(-62, "존재하지 않는 상품 옵션입니다", NOT_FOUND),
     INVALID_DECREASE_STOCK_AMOUNT(-63, "감소하려는 수보다 현재 재고가 더 작습니다.", BAD_REQUEST),
     //AWS Error (600)
     AWS_ERROR(-600, "AWS S3 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -76,6 +76,7 @@ public enum BbangleErrorCode {
     INPUT_STREAM_NOT_CLOSE(-59, "InputStream이 정상적으로 종료되지 않았습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INVALID_REMOVE_PRODUCTS_REQUEST(-60, "옵션 전체삭제가 아닌경우 옵션 ID가 하나라도 있어야합니다.", BAD_REQUEST),
 
+    INVALID_DECREASE_STOCK_AMOUNT(-63, "감소하려는 수보다 현재 재고가 더 작습니다.", BAD_REQUEST),
     //AWS Error (600)
     AWS_ERROR(-600, "AWS S3 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     AWS_CLIENT_ERROR(-601, "AWS SDK 클라이언트 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/test/java/com/bbangle/bbangle/board/admin/service/AdminProductServiceConcurrencyTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/admin/service/AdminProductServiceConcurrencyTest.java
@@ -1,0 +1,328 @@
+package com.bbangle.bbangle.board.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.EditStockFlag;
+import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.board.repository.BoardRepository;
+import com.bbangle.bbangle.board.repository.ProductRepository;
+import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
+import com.bbangle.bbangle.fixture.board.domain.ProductFixture;
+import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.repository.StoreRepository;
+import jakarta.persistence.EntityManager;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@DisplayName("[동시성 테스트] AdminProductService - 상품 재고 상태 변경")
+@SpringBootTest
+@ActiveProfiles("test")
+class AdminProductServiceConcurrencyTest {
+
+    @Autowired
+    private AdminProductService adminProductService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private Store store;
+    private Board board;
+    private Product product;
+
+    @BeforeEach
+    void setUp() {
+        resetTable();
+        initializeTestData();
+    }
+
+    private void resetTable() {
+        transactionTemplate.executeWithoutResult(status -> {
+            em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+            em.createNativeQuery("TRUNCATE TABLE store").executeUpdate();
+            em.createNativeQuery("TRUNCATE TABLE product_board").executeUpdate();
+            em.createNativeQuery("TRUNCATE TABLE product").executeUpdate();
+            em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+        });
+    }
+
+    private void initializeTestData() {
+        transactionTemplate.executeWithoutResult(status -> {
+            store = storeRepository.save(StoreFixture.defaultStore());
+            board = boardRepository.save(BoardFixture.defaultBoardWithStore(store, "테스트 상품"));
+            product = productRepository.save(ProductFixture.create(board, "테스트 상품"));
+        });
+    }
+
+    @Test
+    @DisplayName("동시에 2개 스레드가 재고를 감소시킬 때 Lost Update가 발생하지 않는다")
+    void concurrentDecrease_twoThreads_preventsLostUpdate() throws InterruptedException {
+        // given
+        int initialStock = 100;
+        transactionTemplate.executeWithoutResult(status -> {
+            product.editStock(initialStock - product.getStock(), EditStockFlag.INCREASE);
+            productRepository.save(product);
+        });
+
+        int decreaseAmount = 30;
+        int threadCount = 2;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ConcurrentHashMap<String, Exception> errors = new ConcurrentHashMap<>();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executor.submit(() -> {
+                try {
+                    adminProductService.editProductStock(
+                        product.getId(), decreaseAmount, EditStockFlag.DECREASE);
+                } catch (Exception e) {
+                    errors.put("Thread-" + threadId, e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executor.shutdown();
+
+        // then
+        // - 모든 스레드가 성공 (에러 없음)
+        assertThat(errors).isEmpty();
+
+        // - stock = 100 - 30 - 30 = 40
+        Product result = productRepository.findById(product.getId()).get();
+        assertThat(result.getStock()).isEqualTo(initialStock - (decreaseAmount * threadCount));
+    }
+
+    @Test
+    @DisplayName("동시에 2개 스레드가 재고를 증가시킬 때 Lost Update가 발생하지 않는다")
+    void concurrentIncrease_twoThreads_preventsLostUpdate() throws InterruptedException {
+        // given
+        int initialStock = product.getStock();
+        int increaseAmount = 50;
+        int threadCount = 2;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ConcurrentHashMap<String, Exception> errors = new ConcurrentHashMap<>();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executor.submit(() -> {
+                try {
+                    adminProductService.editProductStock(
+                        product.getId(), increaseAmount, EditStockFlag.INCREASE);
+                } catch (Exception e) {
+                    errors.put("Thread-" + threadId, e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executor.shutdown();
+
+        // then
+        // - 모든 스레드가 성공 (에러 없음)
+        assertThat(errors).isEmpty();
+
+        // - stock = initial + 50 + 50 = initial + 100
+        Product result = productRepository.findById(product.getId()).get();
+        assertThat(result.getStock()).isEqualTo(initialStock + (increaseAmount * threadCount));
+    }
+
+    @Test
+    @DisplayName("동시에 증가와 감소 작업이 혼합될 때 정확한 결과를 보장한다")
+    void concurrentMixedOperations_preventsLostUpdate() throws InterruptedException {
+        // given
+        int initialStock = 100;
+        transactionTemplate.executeWithoutResult(status -> {
+            product.editStock(initialStock - product.getStock(), EditStockFlag.INCREASE);
+            productRepository.save(product);
+        });
+
+        int threadCount = 4;  // 2개는 증가, 2개는 감소
+        int amountPerThread = 25;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ConcurrentHashMap<String, Exception> errors = new ConcurrentHashMap<>();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            final EditStockFlag flag = (i % 2 == 0) ? EditStockFlag.INCREASE : EditStockFlag.DECREASE;
+            executor.submit(() -> {
+                try {
+                    adminProductService.editProductStock(
+                        product.getId(), amountPerThread, flag);
+                } catch (Exception e) {
+                    errors.put("Thread-" + threadId, e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executor.shutdown();
+
+        // then
+        // - 모든 스레드가 성공 (에러 없음)
+        assertThat(errors).isEmpty();
+
+        // - stock = 100 + 25 - 25 + 25 - 25 = 100 (2개 증가, 2개 감소)
+        Product result = productRepository.findById(product.getId()).get();
+        assertThat(result.getStock()).isEqualTo(initialStock);
+    }
+
+    @Test
+    @DisplayName("동시 감소 시 재고가 음수가 되지 않는다")
+    void concurrentDecrease_preventNegativeStock() throws InterruptedException {
+        // given
+        int initialStock = 50;
+        transactionTemplate.executeWithoutResult(status -> {
+            product.editStock(initialStock - product.getStock(), EditStockFlag.INCREASE);
+            productRepository.save(product);
+        });
+
+        int decreaseAmount = 30;
+        int threadCount = 2;  // 2개 스레드가 각각 30씩 감소 시도 (총 60, 초기값 50)
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ConcurrentHashMap<Integer, Exception> errors = new ConcurrentHashMap<>();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executor.submit(() -> {
+                try {
+                    adminProductService.editProductStock(
+                        product.getId(), decreaseAmount, EditStockFlag.DECREASE);
+                } catch (Exception e) {
+                    errors.put(threadId, e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executor.shutdown();
+
+        // then - 두 번째 스레드는 예외 발생해야 함
+        assertThat(errors).hasSize(1);
+
+        // - stock은 음수가 아님 (첫 번째만 감소: 50 - 30 = 20)
+        Product result = productRepository.findById(product.getId()).get();
+        assertThat(result.getStock()).isGreaterThanOrEqualTo(0);
+        assertThat(result.getStock()).isEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("부하 테스트: 100개 스레드가 동시에 재고를 감소시킬 때 정확한 결과를 보장한다")
+    void loadTest_concurrentDecrease_hundredThreads() throws InterruptedException {
+        // given
+        int initialStock = 10000;
+        transactionTemplate.executeWithoutResult(status -> {
+            product.editStock(initialStock - product.getStock(), EditStockFlag.INCREASE);
+            productRepository.save(product);
+        });
+
+        int threadCount = 100;
+        int decreaseAmount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ConcurrentHashMap<String, Exception> errors = new ConcurrentHashMap<>();
+
+        // when
+        long startTime = System.currentTimeMillis();
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executor.submit(() -> {
+                try {
+                    adminProductService.editProductStock(
+                        product.getId(), decreaseAmount, EditStockFlag.DECREASE);
+                } catch (Exception e) {
+                    errors.put("Thread-" + threadId, e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        long endTime = System.currentTimeMillis();
+        executor.shutdown();
+
+        // then
+        // - 모든 스레드가 성공 (에러 없음)
+        assertThat(errors).isEmpty();
+
+        // - stock = 10000 - (10 * 100) = 9000
+        Product result = productRepository.findById(product.getId()).get();
+        assertThat(result.getStock()).isEqualTo(initialStock - (decreaseAmount * threadCount));
+
+        // - 성능 기록 (5초 이내 완료)
+        long duration = endTime - startTime;
+        System.out.println("100 threads completed in " + duration + "ms");
+        assertThat(duration).isLessThan(5000);
+    }
+
+    @Test
+    @DisplayName("부하 테스트: 100개 스레드가 동시에 재고를 증가시킬 때 정확한 결과를 보장한다")
+    void loadTest_concurrentIncrease_hundredThreads() throws InterruptedException {
+        // given
+        int initialStock = product.getStock();
+        int threadCount = 100;
+        int increaseAmount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ConcurrentHashMap<String, Exception> errors = new ConcurrentHashMap<>();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executor.submit(() -> {
+                try {
+                    adminProductService.editProductStock(
+                        product.getId(), increaseAmount, EditStockFlag.INCREASE);
+                } catch (Exception e) {
+                    errors.put("Thread-" + threadId, e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executor.shutdown();
+
+        // then
+        // - 모든 스레드가 성공 (에러 없음)
+        assertThat(errors).isEmpty();
+
+        // - stock = initial + (10 * 100) = initial + 1000
+        Product result = productRepository.findById(product.getId()).get();
+        assertThat(result.getStock()).isEqualTo(initialStock + (increaseAmount * threadCount));
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/board/admin/service/AdminProductServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/admin/service/AdminProductServiceIntegrationTest.java
@@ -1,0 +1,148 @@
+package com.bbangle.bbangle.board.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.EditStockFlag;
+import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.board.repository.BoardRepository;
+import com.bbangle.bbangle.board.repository.ProductRepository;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
+import com.bbangle.bbangle.fixture.board.domain.ProductFixture;
+import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.repository.StoreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[통합 테스트] AdminProductService")
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class AdminProductServiceIntegrationTest {
+
+    @Autowired
+    private AdminProductService adminProductService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Nested
+    @DisplayName("editProductStock 메서드")
+    class EditProductStock {
+
+        @Test
+        @DisplayName("INCREASE: 상품 조회 후 재고를 증가시키면 DB에 반영된다")
+        void increase_persistsToDatabase() {
+            // given
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            Board board = boardRepository.save(BoardFixture.crawlingActiveBoardWithStore(store, "테스트게시글"));
+            Product product = productRepository.save(ProductFixture.createWithStock(board, "테스트상품", 10));
+
+            // when
+            adminProductService.editProductStock(product.getId(), 5, EditStockFlag.INCREASE);
+            productRepository.flush();
+
+            // then
+            Product updatedProduct = productRepository.findById(product.getId()).orElseThrow();
+            assertThat(updatedProduct.getStock()).isEqualTo(15);
+            assertThat(updatedProduct.isSoldout()).isFalse();
+        }
+
+        @Test
+        @DisplayName("DECREASE: 상품 조회 후 재고를 감소시키면 DB에 반영된다")
+        void decrease_persistsToDatabase() {
+            // given
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            Board board = boardRepository.save(BoardFixture.crawlingActiveBoardWithStore(store, "테스트게시글"));
+            Product product = productRepository.save(ProductFixture.createWithStock(board, "테스트상품", 10));
+
+            // when
+            adminProductService.editProductStock(product.getId(), 3, EditStockFlag.DECREASE);
+            productRepository.flush();
+
+            // then
+            Product updatedProduct = productRepository.findById(product.getId()).orElseThrow();
+            assertThat(updatedProduct.getStock()).isEqualTo(7);
+            assertThat(updatedProduct.isSoldout()).isFalse();
+        }
+
+        @Test
+        @DisplayName("DECREASE: 재고가 0이 되면 품절 상태가 DB에 반영된다")
+        void decrease_toZero_setsSoldoutInDatabase() {
+            // given
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            Board board = boardRepository.save(BoardFixture.crawlingActiveBoardWithStore(store, "테스트게시글"));
+            Product product = productRepository.save(ProductFixture.createWithStock(board, "테스트상품", 5));
+
+            // when
+            adminProductService.editProductStock(product.getId(), 5, EditStockFlag.DECREASE);
+            productRepository.flush();
+
+            // then
+            Product updatedProduct = productRepository.findById(product.getId()).orElseThrow();
+            assertThat(updatedProduct.getStock()).isZero();
+            assertThat(updatedProduct.isSoldout()).isTrue();
+        }
+
+        @Test
+        @DisplayName("DECREASE: 재고보다 많은 수량 감소 시 예외가 발생하고 DB는 변경되지 않는다")
+        void decrease_exceedsStock_throwsExceptionAndRollback() {
+            // given
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            Board board = boardRepository.save(BoardFixture.crawlingActiveBoardWithStore(store, "테스트게시글"));
+            Product product = productRepository.save(ProductFixture.createWithStock(board, "테스트상품", 5));
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminProductService.editProductStock(product.getId(), 10, EditStockFlag.DECREASE)
+            ).isInstanceOf(BbangleException.class);
+
+            Product unchangedProduct = productRepository.findById(product.getId()).orElseThrow();
+            assertThat(unchangedProduct.getStock()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("SOLDOUT: 품절 처리하면 재고가 0이 되고 품절 상태가 DB에 반영된다")
+        void soldout_persistsToDatabase() {
+            // given
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            Board board = boardRepository.save(BoardFixture.crawlingActiveBoardWithStore(store, "테스트게시글"));
+            Product product = productRepository.save(ProductFixture.createWithStock(board, "테스트상품", 100));
+
+            // when
+            adminProductService.editProductStock(product.getId(), 0, EditStockFlag.SOLDOUT);
+            productRepository.flush();
+
+            // then
+            Product updatedProduct = productRepository.findById(product.getId()).orElseThrow();
+            assertThat(updatedProduct.getStock()).isZero();
+            assertThat(updatedProduct.isSoldout()).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상품 ID로 요청하면 예외가 발생한다")
+        void notFoundProduct_throwsException() {
+            // given
+            Long nonExistentProductId = 99999L;
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminProductService.editProductStock(nonExistentProductId, 10, EditStockFlag.INCREASE)
+            ).isInstanceOf(BbangleException.class);
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/board/domain/ProductTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/domain/ProductTest.java
@@ -1,0 +1,113 @@
+package com.bbangle.bbangle.board.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.board.domain.ProductFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[단위 테스트] Product 도메인")
+class ProductTest {
+
+    @Nested
+    @DisplayName("editStock 메서드")
+    class EditStock {
+
+        @Test
+        @DisplayName("INCREASE: 재고가 지정된 수량만큼 증가한다")
+        void increase_addsStock() {
+            // given
+            Product product = ProductFixture.createWithStock(null, "테스트상품", 10);
+
+            // when
+            product.editStock(5, EditStockFlag.INCREASE);
+
+            // then
+            assertThat(product.getStock()).isEqualTo(15);
+            assertThat(product.isSoldout()).isFalse();
+        }
+
+        @Test
+        @DisplayName("INCREASE: 재고가 0인 상태에서도 증가시킬 수 있다")
+        void increase_fromZeroStock() {
+            // given
+            Product product = ProductFixture.createWithStock(null, "테스트상품", 0);
+
+            // when
+            product.editStock(10, EditStockFlag.INCREASE);
+
+            // then
+            assertThat(product.getStock()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("DECREASE: 재고가 지정된 수량만큼 감소한다")
+        void decrease_subtractsStock() {
+            // given
+            Product product = ProductFixture.createWithStock(null, "테스트상품", 10);
+
+            // when
+            product.editStock(3, EditStockFlag.DECREASE);
+
+            // then
+            assertThat(product.getStock()).isEqualTo(7);
+            assertThat(product.isSoldout()).isFalse();
+        }
+
+        @Test
+        @DisplayName("DECREASE: 재고보다 많은 수량을 감소시키면 예외가 발생한다")
+        void decrease_throwsExceptionWhenAmountExceedsStock() {
+            // given
+            Product product = ProductFixture.createWithStock(null, "테스트상품", 5);
+
+            // when & then
+            assertThatThrownBy(() -> product.editStock(10, EditStockFlag.DECREASE))
+                .isInstanceOf(BbangleException.class);
+        }
+
+        @Test
+        @DisplayName("DECREASE: 재고와 동일한 수량을 감소시키면 재고가 0이 되고 품절 처리된다")
+        void decrease_setsZeroAndSoldoutWhenStockBecomesZero() {
+            // given
+            Product product = ProductFixture.createWithStock(null, "테스트상품", 5);
+
+            // when
+            product.editStock(5, EditStockFlag.DECREASE);
+
+            // then
+            assertThat(product.getStock()).isZero();
+            assertThat(product.isSoldout()).isTrue();
+        }
+
+        @Test
+        @DisplayName("SOLDOUT: 재고가 0이 되고 품절 처리된다")
+        void soldout_setsZeroStockAndSoldoutTrue() {
+            // given
+            Product product = ProductFixture.createWithStock(null, "테스트상품", 100);
+
+            // when
+            product.editStock(0, EditStockFlag.SOLDOUT);
+
+            // then
+            assertThat(product.getStock()).isZero();
+            assertThat(product.isSoldout()).isTrue();
+        }
+
+        @Test
+        @DisplayName("SOLDOUT: 이미 재고가 0인 상품도 품절 처리할 수 있다")
+        void soldout_worksWithZeroStock() {
+            // given
+            Product product = ProductFixture.createWithStock(null, "테스트상품", 0);
+
+            // when
+            product.editStock(0, EditStockFlag.SOLDOUT);
+
+            // then
+            assertThat(product.getStock()).isZero();
+            assertThat(product.isSoldout()).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/fixture/board/domain/ProductFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/board/domain/ProductFixture.java
@@ -14,4 +14,13 @@ public final class ProductFixture {
             .build();
         return product;
     }
+
+    public static Product createWithStock(Board board, String title, int stock) {
+        return Product.builder()
+            .title(title)
+            .board(board)
+            .stock(stock)
+            .soldout(false)
+            .build();
+    }
 }


### PR DESCRIPTION
## History
* Resolves #542 #541 

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
- AdminProductService, AdminProductController 추가
- 상품 재고 증가, 감소, 품절 처리 API 구현
- 동시성 제어를 위해 DB 비관락 적용(select for update)

## 📷 Test Image
<img width="1123" height="936" alt="image" src="https://github.com/user-attachments/assets/f89e01d4-0a0a-495a-bf45-12eb1d8cbb8a" />

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 상품 재고 관리 기능이 추가되었습니다. 상품 옵션별로 재고를 증가·감소하거나 품절 처리할 수 있으며, 음수 재고 방지 및 부족 시 예외 처리를 포함한 입력 검증이 적용됩니다.
* **테스트**
  * 단위·통합 테스트와 동시성 테스트가 추가되어 다양한 재고 조작 시나리오(증가/감소/품절/동시 작업)를 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->