### PR TITLE
[Feature] (판매자) 토큰 재발급 및 로그아웃

### DIFF
--- a/src/main/java/com/bbangle/bbangle/auth/oauth/client/dto/TokenClaimsDTO.java
+++ b/src/main/java/com/bbangle/bbangle/auth/oauth/client/dto/TokenClaimsDTO.java
@@ -1,0 +1,11 @@
+package com.bbangle.bbangle.auth.oauth.client.dto;
+
+import com.bbangle.bbangle.common.role.Role;
+import lombok.Builder;
+
+@Builder
+public record TokenClaimsDTO(
+    Long id,
+    Role role
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/auth/oauth/client/dto/TokenResponse.java
+++ b/src/main/java/com/bbangle/bbangle/auth/oauth/client/dto/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.bbangle.bbangle.auth.oauth.client.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record TokenResponse(
+    @Schema(description = "Refresh 토큰") String refreshToken,
+    @Schema(description = "Access 토큰") String accessToken
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
@@ -76,7 +76,7 @@ public class SellerOauthController implements SellerOauthApi {
         String refreshToken,
         HttpServletResponse response
     ) {
-        if (refreshToken != null) oAuthSellerService.logout(refreshToken);
+        if (refreshToken != null) oAuthSellerService.deleteRefreshToken(refreshToken);
         response.addHeader(HttpHeaders.SET_COOKIE, createCookie("", Duration.ofMillis(1)).toString());
 
         return responseService.getSuccessResult();

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.auth.seller.controller;
 
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
 import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
+import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenRequest;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.swagger.SellerOauthApi;
 import com.bbangle.bbangle.auth.seller.facade.OAuth2SellerFacade;
@@ -13,25 +14,23 @@ import com.bbangle.bbangle.exception.BbangleException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping(SellerApiPath.PREFIX + "/oauth2")
-@Validated
 public class SellerOauthController implements SellerOauthApi {
 
     private final ResponseService responseService;
@@ -44,13 +43,13 @@ public class SellerOauthController implements SellerOauthApi {
     ) {}
 
     @Override
-    @GetMapping("/tokens")
+    @PostMapping("/tokens")
     public SingleResult<GenerateTokenResponse> sellerToken(
-        @RequestParam(value = "generateToken", required = false)
-        @NotBlank(message = "generateToken은 필수입니다.")
-        String code
+        @RequestBody @Valid GenerateTokenRequest request
     ) {
-        return responseService.getSingleResult(oAuth2SellerFacade.generateToken(code));
+        return responseService.getSingleResult(
+            oAuth2SellerFacade.generateToken(request.generateToken())
+        );
     }
 
     // TODO : Test

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
@@ -6,21 +6,19 @@ import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenRequest;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.swagger.SellerOauthApi;
 import com.bbangle.bbangle.auth.seller.facade.OAuth2SellerFacade;
+import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
+import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.SellerApiPath;
-import com.bbangle.bbangle.exception.BbangleErrorCode;
-import com.bbangle.bbangle.exception.BbangleException;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,6 +33,7 @@ public class SellerOauthController implements SellerOauthApi {
 
     private final ResponseService responseService;
     private final OAuth2SellerFacade oAuth2SellerFacade;
+    private final OAuthSellerService oAuthSellerService;
 
     @Override
     @GetMapping("/authorization/{oauthServerType}")
@@ -52,30 +51,34 @@ public class SellerOauthController implements SellerOauthApi {
         );
     }
 
-    // TODO : Test
     @Override
     @PostMapping("/reissue")
-    public SingleResult<String> reissueToken(
-        HttpServletRequest request,
+    public CommonResult reissueToken(
+        @CookieValue(value = "refreshToken", required = false)
+        String refreshToken,
         HttpServletResponse response
     ) {
-
-        // 쿠키에서 Refresh Token 추출
-        String refresh = Arrays.stream(Optional.ofNullable(request.getCookies()).orElse(new Cookie[0]))
-            .filter(cookie -> "refreshToken".equals(cookie.getName()))
-            .map(Cookie::getValue)
-            .findFirst()
-            .orElseThrow(() -> new BbangleException(BbangleErrorCode._UNAUTHORIZED));
-
-        // Token 생성
-        TokenResponse dto = oAuth2SellerFacade.reissueToken(refresh);
+        TokenResponse dto = oAuth2SellerFacade.reissueToken(refreshToken);
         response.setHeader("Authorization", "Bearer " + dto.accessToken());
         response.addHeader(HttpHeaders.SET_COOKIE, createCookie(dto.refreshToken(), Duration.ofDays(14)).toString());
 
-        return responseService.getSingleResult("새로운 토큰 발급");
+        return responseService.getSuccessResult();
     }
 
-    // TODO : 로그아웃 구현
+    // TODO : Test
+    @Override
+    @DeleteMapping("/logout")
+    public CommonResult logout(
+        @CookieValue(value = "refreshToken", required = false)
+        String refreshToken,
+        HttpServletResponse response
+    ) {
+        if (refreshToken != null) oAuthSellerService.logout(refreshToken);
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie("", Duration.ofMillis(1)).toString());
+
+        return responseService.getSuccessResult();
+    }
+
 
     private ResponseCookie createCookie(String value, Duration duration) {
         return ResponseCookie.from("refreshToken", value)

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
@@ -1,17 +1,29 @@
 package com.bbangle.bbangle.auth.seller.controller;
 
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.swagger.SellerOauthApi;
 import com.bbangle.bbangle.auth.seller.facade.OAuth2SellerFacade;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.SellerApiPath;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,5 +51,38 @@ public class SellerOauthController implements SellerOauthApi {
         String code
     ) {
         return responseService.getSingleResult(oAuth2SellerFacade.generateToken(code));
+    }
+
+    // TODO : Test
+    @Override
+    @PostMapping("/reissue")
+    public SingleResult<String> reissueToken(
+        HttpServletRequest request,
+        HttpServletResponse response
+    ) {
+
+        // 쿠키에서 Refresh Token 추출
+        String refresh = Arrays.stream(Optional.ofNullable(request.getCookies()).orElse(new Cookie[0]))
+            .filter(cookie -> "refreshToken".equals(cookie.getName()))
+            .map(Cookie::getValue)
+            .findFirst()
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode._UNAUTHORIZED));
+
+        // Token 생성
+        TokenResponse dto = oAuth2SellerFacade.reissueToken(refresh);
+        response.setHeader("Authorization", "Bearer " + dto.accessToken());
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(dto.refreshToken()).toString());
+
+        return responseService.getSingleResult("새로운 토큰 발급");
+    }
+
+    private ResponseCookie createCookie(String value) {
+        return ResponseCookie.from("refreshToken", value)
+            .httpOnly(true)
+            //.secure(true)  // 로컬에서 사용할 때는 주석처리
+            .path("/")
+            .maxAge(Duration.ofDays(14))
+            .sameSite("Strict")
+            .build();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
@@ -70,17 +70,19 @@ public class SellerOauthController implements SellerOauthApi {
         // Token 생성
         TokenResponse dto = oAuth2SellerFacade.reissueToken(refresh);
         response.setHeader("Authorization", "Bearer " + dto.accessToken());
-        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(dto.refreshToken()).toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(dto.refreshToken(), Duration.ofDays(14)).toString());
 
         return responseService.getSingleResult("새로운 토큰 발급");
     }
 
-    private ResponseCookie createCookie(String value) {
+    // TODO : 로그아웃 구현
+
+    private ResponseCookie createCookie(String value, Duration duration) {
         return ResponseCookie.from("refreshToken", value)
             .httpOnly(true)
-            //.secure(true)  // 로컬에서 사용할 때는 주석처리
+            .secure(true)  // TODO : 로컬에서 사용할 때는 주석처리
             .path("/")
-            .maxAge(Duration.ofDays(14))
+            .maxAge(duration)
             .sameSite("Strict")
             .build();
     }

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
@@ -86,7 +86,8 @@ public class SellerOauthController implements SellerOauthApi {
     private ResponseCookie createCookie(String value, Duration duration) {
         return ResponseCookie.from("refreshToken", value)
             .httpOnly(true)
-            .secure(true)  // TODO : 로컬에서 사용할 때는 주석처리
+            // TODO : 로컬에서 사용할 때는 주석처리
+            .secure(true)
             .path("/")
             .maxAge(duration)
             .sameSite("Strict")

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
@@ -11,6 +11,8 @@ import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.SellerApiPath;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.time.Duration;
@@ -58,6 +60,8 @@ public class SellerOauthController implements SellerOauthApi {
         String refreshToken,
         HttpServletResponse response
     ) {
+        if (refreshToken == null) throw new BbangleException(BbangleErrorCode._UNAUTHORIZED);
+
         TokenResponse dto = oAuth2SellerFacade.reissueToken(refreshToken);
         response.setHeader("Authorization", "Bearer " + dto.accessToken());
         response.addHeader(HttpHeaders.SET_COOKIE, createCookie(dto.refreshToken(), Duration.ofDays(14)).toString());
@@ -65,7 +69,6 @@ public class SellerOauthController implements SellerOauthApi {
         return responseService.getSuccessResult();
     }
 
-    // TODO : Test
     @Override
     @DeleteMapping("/logout")
     public CommonResult logout(

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
@@ -82,7 +82,6 @@ public class SellerOauthController implements SellerOauthApi {
         return responseService.getSuccessResult();
     }
 
-
     private ResponseCookie createCookie(String value, Duration duration) {
         return ResponseCookie.from("refreshToken", value)
             .httpOnly(true)

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
@@ -6,6 +6,7 @@ import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenRequest;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.swagger.SellerOauthApi;
 import com.bbangle.bbangle.auth.seller.facade.OAuth2SellerFacade;
+import com.bbangle.bbangle.auth.seller.facade.dto.GenerateTokenDTO;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
@@ -46,10 +47,19 @@ public class SellerOauthController implements SellerOauthApi {
     @Override
     @PostMapping("/tokens")
     public SingleResult<GenerateTokenResponse> sellerToken(
-        @RequestBody @Valid GenerateTokenRequest request
+        @RequestBody @Valid GenerateTokenRequest request,
+        HttpServletResponse response
     ) {
+        GenerateTokenDTO dto = oAuth2SellerFacade.generateToken(request.generateToken());
+
+        response.setHeader("Authorization", "Bearer " + dto.accessToken());
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(dto.refreshToken(), Duration.ofDays(14)).toString());
+
         return responseService.getSingleResult(
-            oAuth2SellerFacade.generateToken(request.generateToken())
+            GenerateTokenResponse.builder()
+                .sellerId(dto.sellerId())
+                .status(dto.status())
+                .build()
         );
     }
 

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/dto/GenerateTokenRequest.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/dto/GenerateTokenRequest.java
@@ -1,0 +1,9 @@
+package com.bbangle.bbangle.auth.seller.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record GenerateTokenRequest(
+    @NotBlank(message = "generateToken은 필수입니다.")
+    String generateToken
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/dto/GenerateTokenResponse.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/dto/GenerateTokenResponse.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.auth.seller.controller.dto;
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "Token 발급 응답 DTO")
 public record GenerateTokenResponse(
     @Schema(description = "Refresh 토큰") String refreshToken,
     @Schema(description = "Access 토큰") String accessToken,

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/dto/GenerateTokenResponse.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/dto/GenerateTokenResponse.java
@@ -1,22 +1,14 @@
 package com.bbangle.bbangle.auth.seller.controller.dto;
 
+
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
+@Builder
 @Schema(description = "Token 발급 응답 DTO")
 public record GenerateTokenResponse(
-    @Schema(description = "Refresh 토큰") String refreshToken,
-    @Schema(description = "Access 토큰") String accessToken,
     @Schema(description = "Seller Id") Long sellerId,
     @Schema(description = "Seller 계정 상태") CertificationStatus status
-    ) {
-
-    public static GenerateTokenResponse of(
-        String refreshToken,
-        String accessToken,
-        Long sellerId,
-        CertificationStatus status
-    ) {
-        return new GenerateTokenResponse(refreshToken, accessToken, sellerId, status);
-    }
+) {
 }

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/swagger/SellerOauthApi.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/swagger/SellerOauthApi.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -99,5 +101,21 @@ public interface SellerOauthApi {
         @RequestParam(value = "generateToken", required = false)
         @NotBlank(message = "generateToken은 필수입니다.")
         String code
+    );
+
+    @Operation(
+        summary = "판매자 토큰 재발급",
+        description = """
+        ### 판매자의 Access Token을 재발급 하고 Refresh Token을 갱신
+
+        ---
+        ## ⚠️ 주의사항
+        - 서버로 요청을 보낼 때 Refresh Token을 **Cookie**에 담아서 전송해야합니다.
+        - 이 때, Cookie의 Key를 **refreshToken**으로 설정해야합니다.
+        """
+    )
+    SingleResult<String> reissueToken(
+        HttpServletRequest request,
+        HttpServletResponse response
     );
 }

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/swagger/SellerOauthApi.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/swagger/SellerOauthApi.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.auth.seller.controller.swagger;
 
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
+import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenRequest;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,9 +11,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Seller Oauth Login", description = "(판매자) 로그인 Oauth API")
 public interface SellerOauthApi {
@@ -98,9 +99,7 @@ public interface SellerOauthApi {
         """
     )
     SingleResult<GenerateTokenResponse> sellerToken(
-        @RequestParam(value = "generateToken", required = false)
-        @NotBlank(message = "generateToken은 필수입니다.")
-        String code
+        @RequestBody @Valid GenerateTokenRequest request
     );
 
     @Operation(

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/swagger/SellerOauthApi.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/swagger/SellerOauthApi.java
@@ -3,15 +3,16 @@ package com.bbangle.bbangle.auth.seller.controller.swagger;
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenRequest;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
+import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -113,8 +114,28 @@ public interface SellerOauthApi {
         - 이 때, Cookie의 Key를 **refreshToken**으로 설정해야합니다.
         """
     )
-    SingleResult<String> reissueToken(
-        HttpServletRequest request,
+    CommonResult reissueToken(
+        @Parameter(description = "Refresh Token")
+        @CookieValue(value = "refreshToken", required = false)
+        String refreshToken,
+        HttpServletResponse response
+    );
+
+    @Operation(
+        summary = "판매자 로그아웃",
+        description = """
+        ### 판매자의 Refresh Token과 쿠키를 삭제하고 로그아웃 처리
+
+        ---
+        ## ⚠️ 주의사항
+        - 서버로 요청을 보낼 때 Refresh Token을 **Cookie**에 담아서 전송해야합니다.
+        - 이 때, Cookie의 Key를 **refreshToken**으로 설정해야합니다.
+        """
+    )
+    CommonResult logout(
+        @Parameter(description = "Refresh Token")
+        @CookieValue(value = "refreshToken", required = false)
+        String refreshToken,
         HttpServletResponse response
     );
 }

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/swagger/SellerOauthApi.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/swagger/SellerOauthApi.java
@@ -38,9 +38,9 @@ public interface SellerOauthApi {
         - Redirect URL: `/callback/social?generateToken=1234-abcdefg-567890-hij`
         - 동작:
           1. OAuth2 인증 성공
-          2. 인가 코드 (generateToken) 발급
+          2. 임시 코드 (generateToken) 발급
           3. 프론트엔드로 리다이렉트
-          4. 프론트엔드의 콜백 페이지에서 인가 코드 (generateToken)를 다시 서버로 전송
+          4. 프론트엔드의 콜백 페이지에서 임시 코드(generateToken)를 다시 서버로 전송
 
         ---
         ### ❌ 로그인 실패 시
@@ -53,7 +53,7 @@ public interface SellerOauthApi {
         ⚠️ 주의사항
         - JSON 응답을 반환하지 않습니다.
         - Swagger **Try it out**으로 실행하지 마세요.
-        - 인가 코드는 URL의 쿼리 파라미터를 통해 전송됩니다.
+        - 임시 코드는 URL의 쿼리 파라미터를 통해 전송됩니다.
         - 리다이렉트로 OAuth2 과정을 진행하셔야합니다.
         """
     )
@@ -73,7 +73,7 @@ public interface SellerOauthApi {
         | Error Code | Code | 설명 |
         |-----------|------|------|
         |NOT_SUPPORTED_SERVER|-744|지원하지 않는 OAuth2 로그인 서버입니다.|
-        |MISSING_NAME_NICKNAME|-745|이름 또는 닉네임이 비공개 상태입니다.|
+        |MISSING_NAME_NICKNAME|-745|이름과 닉네임이 전부 비공개 상태입니다.|
         |INTERNAL_SERVER_ERROR|-999|서버 내부 에러입니다. (ex : DB Down)|
         |UNKNOWN_ERROR|null|에러 코드 표에 작성된 Error Code 이외의 기타 예외 상황|
         """

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/swagger/SellerOauthApi.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/swagger/SellerOauthApi.java
@@ -100,7 +100,8 @@ public interface SellerOauthApi {
         """
     )
     SingleResult<GenerateTokenResponse> sellerToken(
-        @RequestBody @Valid GenerateTokenRequest request
+        @RequestBody @Valid GenerateTokenRequest request,
+        HttpServletResponse response
     );
 
     @Operation(

--- a/src/main/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacade.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacade.java
@@ -1,15 +1,14 @@
 package com.bbangle.bbangle.auth.seller.facade;
 
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2InfoRedisDTO;
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenClaimsDTO;
 import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
-import com.bbangle.bbangle.common.role.Role;
 import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.seller.domain.OAuth2Seller;
 import com.bbangle.bbangle.seller.seller.service.OAuth2SellerService;
 import com.bbangle.bbangle.seller.seller.service.command.OAuth2ResponseCreateCommand;
-import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -58,16 +57,13 @@ public class OAuth2SellerFacade {
 
     public TokenResponse reissueToken(String refreshToken) {
 
-        Claims claims = tokenProvider.parseRefreshToken(refreshToken);
+        TokenClaimsDTO claims = tokenProvider.parseRefreshToken(refreshToken);
 
         oAuthSellerService.refreshTokenValidate(refreshToken);
         oAuthSellerService.deleteRefreshToken(refreshToken);
 
-        Long id = claims.get("id", Long.class);
-        Role role = Role.from(claims.get("role", String.class));
-
-        String newRefreshToken = oAuthSellerService.generateRefreshToken(id, role);
-        String newAccessToken = oAuthSellerService.generateAccessToken(id, role);
+        String newRefreshToken = oAuthSellerService.generateRefreshToken(claims.id(), claims.role());
+        String newAccessToken = oAuthSellerService.generateAccessToken(claims.id(), claims.role());
 
         return TokenResponse.builder()
             .refreshToken(newRefreshToken)

--- a/src/main/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacade.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacade.java
@@ -56,25 +56,18 @@ public class OAuth2SellerFacade {
         );
     }
 
-    // TODO : Test
     public TokenResponse reissueToken(String refreshToken) {
 
-        // 1. Refresh Token 분석 -> 만료된 토큰일 경우 예외 던짐
         Claims claims = tokenProvider.parseRefreshToken(refreshToken);
 
-        // 2. Refresh Token이 DB에 없을 경우 예외
         oAuthSellerService.refreshTokenValidate(refreshToken);
 
         Long id = claims.get("id", Long.class);
         Role role = Role.from(claims.get("role", String.class));
 
-        // 3. 만료되지 않았을 경우 Refresh Token 새로 생성
         String newRefreshToken = oAuthSellerService.generateRefreshToken(id, role);
-
-        // 4. 만료되지 않았을 경우 Access Token 새로 생성
         String newAccessToken = oAuthSellerService.generateAccessToken(id, role);
 
-        // 5. DTO 생성 및 반환
         return TokenResponse.builder()
             .refreshToken(newRefreshToken)
             .accessToken(newAccessToken)

--- a/src/main/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacade.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacade.java
@@ -3,7 +3,7 @@ package com.bbangle.bbangle.auth.seller.facade;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2InfoRedisDTO;
 import com.bbangle.bbangle.auth.oauth.client.dto.TokenClaimsDTO;
 import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
-import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
+import com.bbangle.bbangle.auth.seller.facade.dto.GenerateTokenDTO;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
 import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.seller.domain.OAuth2Seller;
@@ -41,13 +41,13 @@ public class OAuth2SellerFacade {
         }
     }
 
-    public GenerateTokenResponse generateToken(String code) {
+    public GenerateTokenDTO generateToken(String code) {
 
         OAuth2InfoRedisDTO sellerInfo = oAuthSellerService.getSellerInfoFromRedis(code);
         String refreshToken = oAuthSellerService.generateRefreshToken(sellerInfo.id(), sellerInfo.role());
         String accessToken = oAuthSellerService.generateAccessToken(sellerInfo.id(), sellerInfo.role());
 
-        return GenerateTokenResponse.of(
+        return GenerateTokenDTO.of(
             refreshToken,
             accessToken,
             sellerInfo.id(),

--- a/src/main/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacade.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacade.java
@@ -1,11 +1,15 @@
 package com.bbangle.bbangle.auth.seller.facade;
 
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2InfoRedisDTO;
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
+import com.bbangle.bbangle.common.role.Role;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.seller.domain.OAuth2Seller;
 import com.bbangle.bbangle.seller.seller.service.OAuth2SellerService;
 import com.bbangle.bbangle.seller.seller.service.command.OAuth2ResponseCreateCommand;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -19,6 +23,8 @@ public class OAuth2SellerFacade {
 
     // OAuth 작업과 관련된 Service 레이어
     private final OAuthSellerService oAuthSellerService;
+
+    private final TokenProvider tokenProvider;
 
     public OAuth2Seller login(OAuth2ResponseCreateCommand response) {
         try {
@@ -48,5 +54,30 @@ public class OAuth2SellerFacade {
             sellerInfo.id(),
             sellerInfo.status()
         );
+    }
+
+    // TODO : Test
+    public TokenResponse reissueToken(String refreshToken) {
+
+        // 1. Refresh Token 분석 -> 만료된 토큰일 경우 예외 던짐
+        Claims claims = tokenProvider.parseRefreshToken(refreshToken);
+
+        // 2. Refresh Token이 DB에 없을 경우 예외
+        oAuthSellerService.refreshTokenValidate(refreshToken);
+
+        Long id = claims.get("id", Long.class);
+        Role role = Role.from(claims.get("role", String.class));
+
+        // 3. 만료되지 않았을 경우 Refresh Token 새로 생성
+        String newRefreshToken = oAuthSellerService.generateRefreshToken(id, role);
+
+        // 4. 만료되지 않았을 경우 Access Token 새로 생성
+        String newAccessToken = oAuthSellerService.generateAccessToken(id, role);
+
+        // 5. DTO 생성 및 반환
+        return TokenResponse.builder()
+            .refreshToken(newRefreshToken)
+            .accessToken(newAccessToken)
+            .build();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacade.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacade.java
@@ -61,6 +61,7 @@ public class OAuth2SellerFacade {
         Claims claims = tokenProvider.parseRefreshToken(refreshToken);
 
         oAuthSellerService.refreshTokenValidate(refreshToken);
+        oAuthSellerService.deleteRefreshToken(refreshToken);
 
         Long id = claims.get("id", Long.class);
         Role role = Role.from(claims.get("role", String.class));

--- a/src/main/java/com/bbangle/bbangle/auth/seller/facade/dto/GenerateTokenDTO.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/facade/dto/GenerateTokenDTO.java
@@ -1,0 +1,27 @@
+package com.bbangle.bbangle.auth.seller.facade.dto;
+
+import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
+
+/**
+ * Token 발급 DTO
+ * @param refreshToken Refresh 토큰
+ * @param accessToken Access 토큰
+ * @param sellerId Seller Id
+ * @param status Seller 계정 상태
+ */
+public record GenerateTokenDTO(
+    String refreshToken,
+    String accessToken,
+    Long sellerId,
+    CertificationStatus status
+) {
+
+    public static GenerateTokenDTO of(
+        String refreshToken,
+        String accessToken,
+        Long sellerId,
+        CertificationStatus status
+    ) {
+        return new GenerateTokenDTO(refreshToken, accessToken, sellerId, status);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerService.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerService.java
@@ -64,7 +64,6 @@ public class OAuthSellerService {
         return tokenProvider.generateToken(sellerId, role, ACCESS_TOKEN_DURATION);
     }
 
-    // TODO : Test
     public void refreshTokenValidate(String refreshToken) {
         refreshTokenRepository.findByRefreshToken(refreshToken)
             .orElseThrow(() -> new BbangleException(BbangleErrorCode._UNAUTHORIZED));

--- a/src/main/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerService.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerService.java
@@ -70,7 +70,7 @@ public class OAuthSellerService {
     }
 
     @Transactional
-    public void logout(String refreshToken) {
+    public void deleteRefreshToken(String refreshToken) {
         refreshTokenRepository.deleteByRefreshToken(refreshToken);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerService.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerService.java
@@ -69,7 +69,6 @@ public class OAuthSellerService {
             .orElseThrow(() -> new BbangleException(BbangleErrorCode._UNAUTHORIZED));
     }
 
-    // TODO : Test
     @Transactional
     public void logout(String refreshToken) {
         refreshTokenRepository.deleteByRefreshToken(refreshToken);

--- a/src/main/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerService.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerService.java
@@ -63,4 +63,10 @@ public class OAuthSellerService {
     public String generateAccessToken(Long sellerId, Role role) {
         return tokenProvider.generateToken(sellerId, role, ACCESS_TOKEN_DURATION);
     }
+
+    // TODO : Test
+    public void refreshTokenValidate(String refreshToken) {
+        refreshTokenRepository.findByRefreshToken(refreshToken)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode._UNAUTHORIZED));
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerService.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerService.java
@@ -68,4 +68,10 @@ public class OAuthSellerService {
         refreshTokenRepository.findByRefreshToken(refreshToken)
             .orElseThrow(() -> new BbangleException(BbangleErrorCode._UNAUTHORIZED));
     }
+
+    // TODO : Test
+    @Transactional
+    public void logout(String refreshToken) {
+        refreshTokenRepository.deleteByRefreshToken(refreshToken);
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/common/redis/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/bbangle/bbangle/common/redis/repository/RefreshTokenRepository.java
@@ -15,4 +15,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
 
     void deleteByUserIdAndUserRole(Long adminId, Role role);
+
+    void deleteByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/bbangle/bbangle/config/security/OAuth2SecurityConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/OAuth2SecurityConfig.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.config.security;
 import com.bbangle.bbangle.config.security.auth.CustomFailureHandler;
 import com.bbangle.bbangle.config.security.auth.CustomSuccessHandler;
 import com.bbangle.bbangle.config.security.auth.OAuth2ClientValidationFilter;
+import com.bbangle.bbangle.config.security.auth.OAuth2HandlerProperties;
 import com.bbangle.bbangle.config.security.auth.OAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -11,6 +12,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -22,7 +24,8 @@ public class OAuth2SecurityConfig {
     private final OAuth2UserService oAuth2UserService;
     private final CustomSuccessHandler successHandler;
     private final CustomFailureHandler failureHandler;
-    private final OAuth2ClientValidationFilter validationFilter;
+    private final ClientRegistrationRepository clientRegistrationRepository;
+    private final OAuth2HandlerProperties oAuth2HandlerProperties;
 
     @Bean
     @Order(1)
@@ -42,9 +45,17 @@ public class OAuth2SecurityConfig {
                 .failureHandler(failureHandler)
             )
             .addFilterBefore(
-                validationFilter,
+                validationFilter(),
                 OAuth2AuthorizationRequestRedirectFilter.class
             );
         return http.build();
+    }
+
+    @Bean
+    public OAuth2ClientValidationFilter validationFilter() {
+        return new OAuth2ClientValidationFilter(
+            clientRegistrationRepository,
+            oAuth2HandlerProperties
+        );
     }
 }

--- a/src/main/java/com/bbangle/bbangle/config/security/PublicApiPath.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/PublicApiPath.java
@@ -13,7 +13,9 @@ public class PublicApiPath {
         "/api/v1/stores/**",
         "/api/v1/health/**",
         "/api/v1/push/**",
-        SellerApiPath.PREFIX + "/oauth2/**",
+        SellerApiPath.PREFIX + "/oauth2/tokens",
+        SellerApiPath.PREFIX + "/oauth2/reissue",
+        SellerApiPath.PREFIX + "/oauth2/logout"
     };
 
     public static final String[] GET_ONLY = {

--- a/src/main/java/com/bbangle/bbangle/config/security/PublicApiPath.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/PublicApiPath.java
@@ -13,7 +13,7 @@ public class PublicApiPath {
         "/api/v1/stores/**",
         "/api/v1/health/**",
         "/api/v1/push/**",
-        SellerApiPath.PREFIX + "/oauth2/tokens",
+        SellerApiPath.PREFIX + "/oauth2/**",
     };
 
     public static final String[] GET_ONLY = {

--- a/src/main/java/com/bbangle/bbangle/config/security/auth/CustomFailureHandler.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/auth/CustomFailureHandler.java
@@ -42,7 +42,12 @@ public class CustomFailureHandler implements AuthenticationFailureHandler {
             return;
         }
 
-        log.error("Unknown authentication error - [{}] {}", exception.getCause(), exception.getMessage());
+        // 간헐적으로 발생하는 에러를 분석하기 위해 추가
+        log.error("Authentication error occurred - FailureHandler");
+        log.error("Exception class: {}", exception.getClass().getName());
+        log.error("Message: {}", exception.getMessage());
+        log.error("Cause: {}", exception.getCause(), exception);
+        
         slackAdaptor.sendAlert(request, exception);
         response.sendRedirect(createRedirectUrl(null));
     }

--- a/src/main/java/com/bbangle/bbangle/config/security/auth/CustomFailureHandler.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/auth/CustomFailureHandler.java
@@ -42,11 +42,13 @@ public class CustomFailureHandler implements AuthenticationFailureHandler {
             return;
         }
 
-        // 간헐적으로 발생하는 에러를 분석하기 위해 추가
-        log.error("Authentication error occurred - FailureHandler");
-        log.error("Exception class: {}", exception.getClass().getName());
-        log.error("Message: {}", exception.getMessage());
-        log.error("Cause: {}", exception.getCause(), exception);
+        // TODO : 간헐적으로 발생하는 에러를 분석하기 위해 추가 - 추후 삭제 예정
+        log.error("Authentication error occurred - FailureHandler | class : {} | message : {} | cause : {}",
+            exception.getClass().getName(),
+            exception.getMessage(),
+            exception.getCause(),
+            exception
+        );
         
         slackAdaptor.sendAlert(request, exception);
         response.sendRedirect(createRedirectUrl(null));

--- a/src/main/java/com/bbangle/bbangle/config/security/auth/OAuth2ClientValidationFilter.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/auth/OAuth2ClientValidationFilter.java
@@ -28,8 +28,7 @@ public class OAuth2ClientValidationFilter extends OncePerRequestFilter {
             HttpServletRequest request,
             HttpServletResponse response,
             FilterChain filterChain
-    )
-            throws ServletException, IOException {
+    ) throws ServletException, IOException {
 
         String uri = request.getRequestURI();
 

--- a/src/main/java/com/bbangle/bbangle/config/security/auth/OAuth2ClientValidationFilter.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/auth/OAuth2ClientValidationFilter.java
@@ -8,15 +8,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Profile("!test")
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class OAuth2ClientValidationFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/bbangle/bbangle/config/security/jwt/TokenProvider.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/jwt/TokenProvider.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.config.security.jwt;
 
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenClaimsDTO;
 import com.bbangle.bbangle.common.role.Role;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
@@ -56,9 +57,14 @@ public class TokenProvider {
         }
     }
 
-    public Claims parseRefreshToken(String token) {
+    public TokenClaimsDTO parseRefreshToken(String token) {
         try {
-            return getClaims(token);
+            Claims claims = getClaims(token);
+
+            return TokenClaimsDTO.builder()
+                .id(claims.get("id", Long.class))
+                .role(Role.from(claims.get("role", String.class)))
+                .build();
         } catch (JwtException | IllegalArgumentException e) {
             throw new BbangleException(BbangleErrorCode._UNAUTHORIZED);
         }

--- a/src/main/java/com/bbangle/bbangle/config/security/jwt/TokenProvider.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/jwt/TokenProvider.java
@@ -60,10 +60,12 @@ public class TokenProvider {
     public TokenClaimsDTO parseRefreshToken(String token) {
         try {
             Claims claims = getClaims(token);
+            Long id = Long.valueOf((Integer) claims.get(USER_KEY));
+            Role role = Role.from((String) claims.get(ROLE_KEY));
 
             return TokenClaimsDTO.builder()
-                .id(claims.get("id", Long.class))
-                .role(Role.from(claims.get("role", String.class)))
+                .id(id)
+                .role(role)
                 .build();
         } catch (JwtException | IllegalArgumentException e) {
             throw new BbangleException(BbangleErrorCode._UNAUTHORIZED);

--- a/src/main/java/com/bbangle/bbangle/config/security/jwt/TokenProvider.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/jwt/TokenProvider.java
@@ -1,8 +1,11 @@
 package com.bbangle.bbangle.config.security.jwt;
 
 import com.bbangle.bbangle.common.role.Role;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.time.Duration;
@@ -53,6 +56,14 @@ public class TokenProvider {
         }
     }
 
+    public Claims parseRefreshToken(String token) {
+        try {
+            return getClaims(token);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new BbangleException(BbangleErrorCode._UNAUTHORIZED);
+        }
+    }
+
     public Authentication getAuthentication(String token) {
         Claims claims = getClaims(token);
         Long memberId = Long.valueOf((Integer) claims.get(USER_KEY));
@@ -68,5 +79,4 @@ public class TokenProvider {
             .parseClaimsJws(token)
             .getBody();
     }
-
 }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
@@ -4,15 +4,17 @@ import static com.bbangle.bbangle.common.service.ResponseService.CommonResponse.
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenRequest;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.facade.OAuth2SellerFacade;
 import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.JsonDataEncoder;
+import com.bbangle.bbangle.config.security.SecurityConfig;
 import com.bbangle.bbangle.config.security.SellerApiPath;
 import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
 import com.bbangle.bbangle.config.security.jwt.TokenProvider;
@@ -26,6 +28,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -35,7 +38,8 @@ import org.springframework.test.web.servlet.MockMvc;
     JsonDataEncoder.class,
     TokenProvider.class,
     TestJwtPropertiesConfig.class,
-    ResponseService.class
+    ResponseService.class,
+    SecurityConfig.class
 })
 @WebMvcTest(controllers = SellerOauthController.class)
 @ActiveProfiles("test")
@@ -43,6 +47,9 @@ class SellerOauthControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private JsonDataEncoder jsonDataEncoder;
 
     @MockBean
     private OAuth2SellerFacade oAuth2SellerFacade;
@@ -67,8 +74,10 @@ class SellerOauthControllerTest {
         given(oAuth2SellerFacade.generateToken(code)).willReturn(dto);
 
         // when & then
-        mockMvc.perform(get(SellerApiPath.PREFIX + "/oauth2/tokens")
-            .param("generateToken", code))
+        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/tokens")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonDataEncoder.encode(new GenerateTokenRequest(code)))
+            )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
@@ -84,7 +93,10 @@ class SellerOauthControllerTest {
     @Test
     @DisplayName("임시 코드가 없으면 400 에러를 반환한다.")
     void failure_sellerToken_400() throws Exception {
-        mockMvc.perform(get(SellerApiPath.PREFIX + "/oauth2/tokens"))
+        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/tokens")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonDataEncoder.encode(new GenerateTokenRequest("")))
+            )
             .andExpect(status().isBadRequest());
     }
 
@@ -99,8 +111,10 @@ class SellerOauthControllerTest {
             .willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED));
 
         // when & then
-        mockMvc.perform(get(SellerApiPath.PREFIX + "/oauth2/tokens")
-            .param("generateToken", code))
+        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/tokens")
+                    .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonDataEncoder.encode(new GenerateTokenRequest(code)))
+            )
             .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
@@ -146,10 +146,9 @@ class SellerOauthControllerTest {
             .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=newRefreshToken")))
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
-            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
-            .andExpect(jsonPath("$.result").value("새로운 토큰 발급"));
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()));
 
-        then(responseService).should(times(1)).getSingleResult("새로운 토큰 발급");
+        then(responseService).should(times(1)).getSuccessResult();
     }
 
     @Test

--- a/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -14,6 +15,7 @@ import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenRequest;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.facade.OAuth2SellerFacade;
+import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
 import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.JsonDataEncoder;
@@ -58,6 +60,9 @@ class SellerOauthControllerTest {
 
     @MockBean
     private OAuth2SellerFacade oAuth2SellerFacade;
+
+    @MockBean
+    private OAuthSellerService oAuthSellerService;
 
     @SpyBean
     private ResponseService responseService;
@@ -178,5 +183,23 @@ class SellerOauthControllerTest {
         mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/reissue")
                 .cookie(cookie))
             .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그아웃 시 항상 만료된 쿠키를 반환한다.")
+    void logout() throws Exception {
+
+        // given
+        Cookie cookie = new Cookie("refreshToken", "refreshToken");
+
+        // when & then
+        mockMvc.perform(delete(SellerApiPath.PREFIX + "/oauth2/logout")
+            .cookie(cookie))
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=")))
+            .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Max-Age=0")))
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()));
     }
 }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
@@ -15,6 +15,7 @@ import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenRequest;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.facade.OAuth2SellerFacade;
+import com.bbangle.bbangle.auth.seller.facade.dto.GenerateTokenDTO;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
 import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
 import com.bbangle.bbangle.common.service.ResponseService;
@@ -74,12 +75,16 @@ class SellerOauthControllerTest {
         // given
         String code = "oAuthCode";
 
-        GenerateTokenResponse dto = GenerateTokenResponse.of(
+        GenerateTokenDTO dto = GenerateTokenDTO.of(
             "refreshToken",
             "accessToken",
             1L,
             CertificationStatus.NEW
         );
+        GenerateTokenResponse response = GenerateTokenResponse.builder()
+            .sellerId(dto.sellerId())
+            .status(dto.status())
+            .build();
 
         given(oAuth2SellerFacade.generateToken(code)).willReturn(dto);
 
@@ -89,15 +94,15 @@ class SellerOauthControllerTest {
                 .content(jsonDataEncoder.encode(new GenerateTokenRequest(code)))
             )
             .andExpect(status().isOk())
+            .andExpect(header().string("Authorization", "Bearer accessToken"))
+            .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=refreshToken")))
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
             .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
-            .andExpect(jsonPath("$.result.refreshToken").value("refreshToken"))
-            .andExpect(jsonPath("$.result.accessToken").value("accessToken"))
             .andExpect(jsonPath("$.result.sellerId").value(1L))
             .andExpect(jsonPath("$.result.status").value("NEW"));
 
-        then(responseService).should(times(1)).getSingleResult(dto);
+        then(responseService).should(times(1)).getSingleResult(response);
     }
 
     @Test

--- a/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
@@ -1,13 +1,16 @@
 package com.bbangle.bbangle.auth.seller.controller;
 
 import static com.bbangle.bbangle.common.service.ResponseService.CommonResponse.SUCCESS;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenRequest;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.facade.OAuth2SellerFacade;
@@ -21,6 +24,7 @@ import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +32,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -115,6 +120,64 @@ class SellerOauthControllerTest {
                     .contentType(MediaType.APPLICATION_JSON)
                 .content(jsonDataEncoder.encode(new GenerateTokenRequest(code)))
             )
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Refresh Token 쿠키가 존재하면 토큰을 재발급한다.")
+    void success_reissueToken() throws Exception {
+
+        // given
+        String refreshToken = "validRefreshToken";
+        Cookie cookie = new Cookie("refreshToken", refreshToken);
+
+        TokenResponse tokenResponse = TokenResponse.builder()
+            .refreshToken("newRefreshToken")
+            .accessToken("newAccessToken")
+            .build();
+
+        given(oAuth2SellerFacade.reissueToken(refreshToken)).willReturn(tokenResponse);
+
+        // when & then
+        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/reissue")
+            .cookie(cookie))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Authorization", "Bearer newAccessToken"))
+            .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=newRefreshToken")))
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
+            .andExpect(jsonPath("$.result").value("새로운 토큰 발급"));
+
+        then(responseService).should(times(1)).getSingleResult("새로운 토큰 발급");
+    }
+
+    @Test
+    @DisplayName("Refresh Token 쿠키가 없으면 401을 반환한다.")
+    void failure_reissueToken_notExistCookie() throws Exception {
+
+        // when & then
+        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/reissue"))
+            .andExpect(status().isUnauthorized());
+
+        // 쿠키가 없을 경우 oAuth2SellerFacade는 호출조차 하지 않음
+        then(oAuth2SellerFacade).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 유효하지 않을 경우 401을 반환한다.")
+    void failure_reissueToken_invalidRefreshToken() throws Exception {
+
+        // given
+        String refreshToken = "invalidRefreshToken";
+        Cookie cookie = new Cookie("refreshToken", refreshToken);
+
+        given(oAuth2SellerFacade.reissueToken(refreshToken))
+            .willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED));
+
+        // when & then
+        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/reissue")
+                .cookie(cookie))
             .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeIntegrationTest.java
@@ -2,13 +2,11 @@ package com.bbangle.bbangle.auth.seller.facade;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
 
 import com.bbangle.bbangle.auth.domain.RefreshToken;
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2InfoRedisDTO;
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
 import com.bbangle.bbangle.common.redis.repository.RedisRepository;
@@ -35,7 +33,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,7 +57,7 @@ class OAuth2SellerFacadeIntegrationTest {
     @Autowired
     EntityManager em;
 
-    @MockBean
+    @Autowired
     TokenProvider tokenProvider;
 
     @Test
@@ -193,16 +190,13 @@ class OAuth2SellerFacadeIntegrationTest {
 
         redisRepository.setFromDTO(OAuthSellerService.OAUTH_CODE_NAMESPACE, code, sellerInfo, Duration.ofMinutes(5));
 
-        given(tokenProvider.generateToken(eq(1L), eq(Role.ROLE_SELLER), any()))
-            .willReturn("mockToken");
-
         // when
         GenerateTokenResponse response = oAuth2SellerFacade.generateToken(code);
 
         // then
         assertThat(response.sellerId()).isEqualTo(1L);
-        assertThat(response.refreshToken()).isEqualTo("mockToken");
-        assertThat(response.accessToken()).isEqualTo("mockToken");
+        assertThat(response.refreshToken()).isNotBlank();
+        assertThat(response.accessToken()).isNotBlank();
         assertThat(response.status()).isEqualTo(CertificationStatus.NEW);
 
         assertThat(redisRepository.getDTOAndDelete(OAuthSellerService.OAUTH_CODE_NAMESPACE, code, OAuth2InfoRedisDTO.class))
@@ -212,7 +206,7 @@ class OAuth2SellerFacadeIntegrationTest {
             .findByUserIdAndUserRole(1L, Role.ROLE_SELLER)
             .orElseThrow();
 
-        assertThat(saved.getRefreshToken()).isEqualTo("mockToken");
+        assertThat(saved.getRefreshToken()).isEqualTo(response.refreshToken());
     }
 
     @Test
@@ -224,6 +218,71 @@ class OAuth2SellerFacadeIntegrationTest {
 
         // when & then
         assertThatThrownBy(() -> oAuth2SellerFacade.generateToken(code))
+            .isInstanceOf(BbangleException.class)
+            .satisfies(e -> {
+                BbangleException ex = (BbangleException) e;
+                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
+            });
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 유효하면 토큰을 재발급한다.")
+    void success_reissueToken() {
+
+        // given
+        Long sellerId = 1L;
+        Role role = Role.ROLE_SELLER;
+        String refreshToken = tokenProvider.generateToken(sellerId, role, Duration.ofDays(14));
+
+        RefreshToken entity = RefreshToken.create(sellerId, role, refreshToken);
+        refreshTokenRepository.save(entity);
+
+        // when
+        TokenResponse result = oAuth2SellerFacade.reissueToken(refreshToken);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.accessToken()).isNotNull();
+        assertThat(result.refreshToken()).isNotNull();
+
+        RefreshToken updated = refreshTokenRepository.findByUserIdAndUserRole(sellerId, role).orElseThrow();
+        assertThat(result.refreshToken()).isEqualTo(updated.getRefreshToken());
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 유효하면 토큰을 재발급한다.")
+    void failure_reissueToken_expired() {
+
+        // given
+        Long sellerId = 1L;
+        Role role = Role.ROLE_SELLER;
+        String refreshToken = tokenProvider.generateToken(sellerId, role, Duration.ofMillis(1));
+
+        RefreshToken entity = RefreshToken.create(sellerId, role, refreshToken);
+        refreshTokenRepository.save(entity);
+
+        try { Thread.sleep(3); } catch (InterruptedException e) {}
+
+        // when & then
+        assertThatThrownBy(() -> oAuth2SellerFacade.reissueToken(refreshToken))
+            .isInstanceOf(BbangleException.class)
+            .satisfies(e -> {
+                BbangleException ex = (BbangleException) e;
+                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
+            });
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 DB에 없으면 예외 발생")
+    void failure_reissueToken_notExist() {
+
+        // given
+        Long sellerId = 1L;
+        Role role = Role.ROLE_SELLER;
+        String refreshToken = tokenProvider.generateToken(sellerId, role, Duration.ofDays(14));
+
+        // when & then
+        assertThatThrownBy(() -> oAuth2SellerFacade.reissueToken(refreshToken))
             .isInstanceOf(BbangleException.class)
             .satisfies(e -> {
                 BbangleException ex = (BbangleException) e;

--- a/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeIntegrationTest.java
@@ -7,7 +7,7 @@ import com.bbangle.bbangle.auth.domain.RefreshToken;
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2InfoRedisDTO;
 import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
-import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
+import com.bbangle.bbangle.auth.seller.facade.dto.GenerateTokenDTO;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
 import com.bbangle.bbangle.common.redis.repository.RedisRepository;
 import com.bbangle.bbangle.common.redis.repository.RefreshTokenRepository;
@@ -191,7 +191,7 @@ class OAuth2SellerFacadeIntegrationTest {
         redisRepository.setFromDTO(OAuthSellerService.OAUTH_CODE_NAMESPACE, code, sellerInfo, Duration.ofMinutes(5));
 
         // when
-        GenerateTokenResponse response = oAuth2SellerFacade.generateToken(code);
+        GenerateTokenDTO response = oAuth2SellerFacade.generateToken(code);
 
         // then
         assertThat(response.sellerId()).isEqualTo(1L);

--- a/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeIntegrationTest.java
@@ -235,7 +235,7 @@ class OAuth2SellerFacadeIntegrationTest {
         String refreshToken = tokenProvider.generateToken(sellerId, role, Duration.ofDays(14));
 
         RefreshToken entity = RefreshToken.create(sellerId, role, refreshToken);
-        refreshTokenRepository.save(entity);
+        RefreshToken oldToken = refreshTokenRepository.save(entity);
 
         // when
         TokenResponse result = oAuth2SellerFacade.reissueToken(refreshToken);
@@ -246,30 +246,7 @@ class OAuth2SellerFacadeIntegrationTest {
         assertThat(result.refreshToken()).isNotNull();
 
         RefreshToken updated = refreshTokenRepository.findByUserIdAndUserRole(sellerId, role).orElseThrow();
-        assertThat(result.refreshToken()).isEqualTo(updated.getRefreshToken());
-    }
-
-    @Test
-    @DisplayName("Refresh Token이 유효하면 토큰을 재발급한다.")
-    void failure_reissueToken_expired() {
-
-        // given
-        Long sellerId = 1L;
-        Role role = Role.ROLE_SELLER;
-        String refreshToken = tokenProvider.generateToken(sellerId, role, Duration.ofMillis(1));
-
-        RefreshToken entity = RefreshToken.create(sellerId, role, refreshToken);
-        refreshTokenRepository.save(entity);
-
-        try { Thread.sleep(3); } catch (InterruptedException e) {}
-
-        // when & then
-        assertThatThrownBy(() -> oAuth2SellerFacade.reissueToken(refreshToken))
-            .isInstanceOf(BbangleException.class)
-            .satisfies(e -> {
-                BbangleException ex = (BbangleException) e;
-                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
-            });
+        assertThat(oldToken.getId()).isNotEqualTo(updated.getId());
     }
 
     @Test

--- a/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeUnitTest.java
@@ -4,21 +4,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2InfoRedisDTO;
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
 import com.bbangle.bbangle.common.role.Role;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.domain.OAuth2Seller;
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import com.bbangle.bbangle.seller.seller.service.OAuth2SellerService;
 import com.bbangle.bbangle.seller.seller.service.command.OAuth2ResponseCreateCommand;
+import io.jsonwebtoken.Claims;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,6 +50,9 @@ class OAuth2SellerFacadeUnitTest {
 
     @Mock
     private OAuthSellerService oAuthSellerService;
+
+    @Mock
+    private TokenProvider tokenProvider;
 
     @Test
     @DisplayName("판매자 계정이 없으면 새로 생성한다.")
@@ -179,5 +188,83 @@ class OAuth2SellerFacadeUnitTest {
         // when & then
         assertThatThrownBy(() -> oAuth2SellerFacade.generateToken("code"))
             .isInstanceOf(BbangleException.class);
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 유효하면 토큰을 재발급한다.")
+    void success_reissueToken() {
+
+        // given
+        String refreshToken = "validRefreshToken";
+
+        Claims claims = mock(Claims.class);
+        given(claims.get("id", Long.class)).willReturn(1L);
+        given(claims.get("role", String.class)).willReturn(Role.ROLE_SELLER.getRole());
+
+        given(tokenProvider.parseRefreshToken(refreshToken)).willReturn(claims);
+
+        willDoNothing().given(oAuthSellerService).refreshTokenValidate(refreshToken);
+
+        given(oAuthSellerService.generateRefreshToken(1L, Role.ROLE_SELLER)).willReturn("newRefreshToken");
+        given(oAuthSellerService.generateAccessToken(1L, Role.ROLE_SELLER)).willReturn("newAccessToken");
+
+        // when
+        TokenResponse response = oAuth2SellerFacade.reissueToken(refreshToken);
+
+        // then
+        assertThat(response.refreshToken()).isEqualTo("newRefreshToken");
+        assertThat(response.accessToken()).isEqualTo("newAccessToken");
+
+        InOrder inOrder = inOrder(tokenProvider, oAuthSellerService);
+        inOrder.verify(tokenProvider).parseRefreshToken(refreshToken);
+        inOrder.verify(oAuthSellerService).refreshTokenValidate(refreshToken);
+        inOrder.verify(oAuthSellerService).generateRefreshToken(1L, Role.ROLE_SELLER);
+        inOrder.verify(oAuthSellerService).generateAccessToken(1L, Role.ROLE_SELLER);
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 만료되면 예외 발생")
+    void failure_reissueToken_expired() {
+
+        // given
+        String refreshToken = "expiredRefreshToken";
+
+        given(tokenProvider.parseRefreshToken(refreshToken)).willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED));
+
+        // when & then
+        assertThatThrownBy(() -> oAuth2SellerFacade.reissueToken(refreshToken))
+            .isInstanceOf(BbangleException.class)
+            .satisfies(e -> {
+                BbangleException ex = (BbangleException) e;
+                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
+            });
+
+        verify(oAuthSellerService, never()).refreshTokenValidate(refreshToken);
+        verify(oAuthSellerService, never()).generateRefreshToken(any(), any());
+        verify(oAuthSellerService, never()).generateAccessToken(any(), any());
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 DB에 없으면 예외 발생")
+    void failure_reissueToken_notExist() {
+
+        // given
+        String refreshToken = "invalidRefreshToken";
+
+        Claims claims = mock(Claims.class);
+        given(tokenProvider.parseRefreshToken(refreshToken)).willReturn(claims);
+
+        willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED)).given(oAuthSellerService).refreshTokenValidate(refreshToken);
+
+        // when & then
+        assertThatThrownBy(() -> oAuth2SellerFacade.reissueToken(refreshToken))
+            .isInstanceOf(BbangleException.class)
+            .satisfies(e -> {
+                BbangleException ex = (BbangleException) e;
+                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
+            });
+
+        verify(oAuthSellerService, never()).generateRefreshToken(any(), any());
+        verify(oAuthSellerService, never()).generateAccessToken(any(), any());
     }
 }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeUnitTest.java
@@ -7,12 +7,12 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2InfoRedisDTO;
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenClaimsDTO;
 import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
@@ -24,7 +24,6 @@ import com.bbangle.bbangle.seller.domain.OAuth2Seller;
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import com.bbangle.bbangle.seller.seller.service.OAuth2SellerService;
 import com.bbangle.bbangle.seller.seller.service.command.OAuth2ResponseCreateCommand;
-import io.jsonwebtoken.Claims;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -196,12 +195,12 @@ class OAuth2SellerFacadeUnitTest {
 
         // given
         String refreshToken = "validRefreshToken";
+        TokenClaimsDTO tokenClaimsDTO = TokenClaimsDTO.builder()
+            .id(1L)
+            .role(Role.ROLE_SELLER)
+            .build();
 
-        Claims claims = mock(Claims.class);
-        given(claims.get("id", Long.class)).willReturn(1L);
-        given(claims.get("role", String.class)).willReturn(Role.ROLE_SELLER.getRole());
-
-        given(tokenProvider.parseRefreshToken(refreshToken)).willReturn(claims);
+        given(tokenProvider.parseRefreshToken(refreshToken)).willReturn(tokenClaimsDTO);
 
         willDoNothing().given(oAuthSellerService).refreshTokenValidate(refreshToken);
         willDoNothing().given(oAuthSellerService).deleteRefreshToken(refreshToken);
@@ -253,10 +252,12 @@ class OAuth2SellerFacadeUnitTest {
 
         // given
         String refreshToken = "invalidRefreshToken";
+        TokenClaimsDTO tokenClaimsDTO = TokenClaimsDTO.builder()
+            .id(1L)
+            .role(Role.ROLE_SELLER)
+            .build();
 
-        Claims claims = mock(Claims.class);
-        given(tokenProvider.parseRefreshToken(refreshToken)).willReturn(claims);
-
+        given(tokenProvider.parseRefreshToken(refreshToken)).willReturn(tokenClaimsDTO);
         willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED)).given(oAuthSellerService).refreshTokenValidate(refreshToken);
 
         // when & then

--- a/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeUnitTest.java
@@ -14,7 +14,7 @@ import com.bbangle.bbangle.auth.oauth.OauthServerType;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2InfoRedisDTO;
 import com.bbangle.bbangle.auth.oauth.client.dto.TokenClaimsDTO;
 import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
-import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
+import com.bbangle.bbangle.auth.seller.facade.dto.GenerateTokenDTO;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
 import com.bbangle.bbangle.common.role.Role;
 import com.bbangle.bbangle.config.security.jwt.TokenProvider;
@@ -163,7 +163,7 @@ class OAuth2SellerFacadeUnitTest {
         given(oAuthSellerService.generateAccessToken(1L, Role.ROLE_SELLER)).willReturn("accessToken");
 
         // when
-        GenerateTokenResponse response = oAuth2SellerFacade.generateToken(code);
+        GenerateTokenDTO response = oAuth2SellerFacade.generateToken(code);
 
         // then
         assertThat(response.refreshToken()).isEqualTo("refreshToken");

--- a/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeUnitTest.java
@@ -204,6 +204,7 @@ class OAuth2SellerFacadeUnitTest {
         given(tokenProvider.parseRefreshToken(refreshToken)).willReturn(claims);
 
         willDoNothing().given(oAuthSellerService).refreshTokenValidate(refreshToken);
+        willDoNothing().given(oAuthSellerService).deleteRefreshToken(refreshToken);
 
         given(oAuthSellerService.generateRefreshToken(1L, Role.ROLE_SELLER)).willReturn("newRefreshToken");
         given(oAuthSellerService.generateAccessToken(1L, Role.ROLE_SELLER)).willReturn("newAccessToken");
@@ -218,6 +219,7 @@ class OAuth2SellerFacadeUnitTest {
         InOrder inOrder = inOrder(tokenProvider, oAuthSellerService);
         inOrder.verify(tokenProvider).parseRefreshToken(refreshToken);
         inOrder.verify(oAuthSellerService).refreshTokenValidate(refreshToken);
+        inOrder.verify(oAuthSellerService).deleteRefreshToken(refreshToken);
         inOrder.verify(oAuthSellerService).generateRefreshToken(1L, Role.ROLE_SELLER);
         inOrder.verify(oAuthSellerService).generateAccessToken(1L, Role.ROLE_SELLER);
     }
@@ -240,6 +242,7 @@ class OAuth2SellerFacadeUnitTest {
             });
 
         verify(oAuthSellerService, never()).refreshTokenValidate(refreshToken);
+        verify(oAuthSellerService, never()).deleteRefreshToken(any());
         verify(oAuthSellerService, never()).generateRefreshToken(any(), any());
         verify(oAuthSellerService, never()).generateAccessToken(any(), any());
     }
@@ -264,6 +267,7 @@ class OAuth2SellerFacadeUnitTest {
                 assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
             });
 
+        verify(oAuthSellerService, never()).deleteRefreshToken(any());
         verify(oAuthSellerService, never()).generateRefreshToken(any(), any());
         verify(oAuthSellerService, never()).generateAccessToken(any(), any());
     }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceIntegrationTest.java
@@ -161,7 +161,7 @@ class OAuthSellerServiceIntegrationTest {
 
     @Test
     @DisplayName("로그아웃 시 DB의 Refresh Token을 삭제한다.")
-    void logout() {
+    void deleteRefreshToken() {
 
         // given
         String refreshToken = "refreshToken";
@@ -173,7 +173,7 @@ class OAuthSellerServiceIntegrationTest {
         refreshTokenRepository.save(exist);
 
         // when
-        service.logout(refreshToken);
+        service.deleteRefreshToken(refreshToken);
 
         // then
         assertThat(refreshTokenRepository.findByUserIdAndUserRole(1L, Role.ROLE_SELLER)).isEmpty();

--- a/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.auth.seller.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -127,5 +128,34 @@ class OAuthSellerServiceIntegrationTest {
             .orElseThrow();
 
         assertThat(updated.getRefreshToken()).isEqualTo("newToken");
+    }
+
+    @Test
+    @DisplayName("DB에 Refresh Token이 존재하면 통과한다.")
+    void refreshTokenValidate_existToken() {
+
+        // given
+        String refreshToken = "validRefreshToken";
+        RefreshToken existing = RefreshToken.create(1L, Role.ROLE_SELLER, refreshToken);
+        refreshTokenRepository.save(existing);
+
+        // when & then
+        assertDoesNotThrow(() -> service.refreshTokenValidate(refreshToken));
+    }
+
+    @Test
+    @DisplayName("DB에 Refresh Token이 없으면 UNAUTHORIZED 예외")
+    void refreshTokenValidate_notExistToken() {
+
+        // given
+        String refreshToken = "invalidRefreshToken";
+
+        // when & then
+        assertThatThrownBy(() -> service.refreshTokenValidate(refreshToken))
+            .isInstanceOf(BbangleException.class)
+            .satisfies(e -> {
+                BbangleException ex = (BbangleException) e;
+                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
+            });
     }
 }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceIntegrationTest.java
@@ -158,4 +158,25 @@ class OAuthSellerServiceIntegrationTest {
                 assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
             });
     }
+
+    @Test
+    @DisplayName("로그아웃 시 DB의 Refresh Token을 삭제한다.")
+    void logout() {
+
+        // given
+        String refreshToken = "refreshToken";
+        RefreshToken exist = RefreshToken.create(
+            1L,
+            Role.ROLE_SELLER,
+            refreshToken
+        );
+        refreshTokenRepository.save(exist);
+
+        // when
+        service.logout(refreshToken);
+
+        // then
+        assertThat(refreshTokenRepository.findByUserIdAndUserRole(1L, Role.ROLE_SELLER)).isEmpty();
+        assertThat(refreshTokenRepository.findByRefreshToken(refreshToken)).isEmpty();
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceUnitTest.java
@@ -179,4 +179,18 @@ class OAuthSellerServiceUnitTest {
                 assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
             });
     }
+
+    @Test
+    @DisplayName("DB에 존재하는 Refresh Token을 삭제한다.")
+    void logout() {
+
+        // given
+        String refreshToken = "refreshToken";
+
+        // when
+        service.logout(refreshToken);
+
+        // then
+        verify(refreshTokenRepository).deleteByRefreshToken(refreshToken);
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceUnitTest.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.auth.seller.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -12,6 +13,7 @@ import com.bbangle.bbangle.common.redis.repository.RedisRepository;
 import com.bbangle.bbangle.common.redis.repository.RefreshTokenRepository;
 import com.bbangle.bbangle.common.role.Role;
 import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import java.util.Optional;
@@ -143,5 +145,38 @@ class OAuthSellerServiceUnitTest {
 
         // then
         assertThat(token).isEqualTo("accessToken");
+    }
+
+    // --------------------
+    // refreshTokenValidate Test
+    // --------------------
+    @Test
+    @DisplayName("DB에 Refresh Token이 존재하면 통과한다.")
+    void refreshTokenValidate_existToken() {
+
+        // given
+        String refreshToken = "validRefreshToken";
+        RefreshToken existing = RefreshToken.create(1L, Role.ROLE_SELLER, "refreshToken");
+        given(refreshTokenRepository.findByRefreshToken(any())).willReturn(Optional.of(existing));
+
+        // when & then
+        assertDoesNotThrow(() -> service.refreshTokenValidate(refreshToken));
+    }
+
+    @Test
+    @DisplayName("DB에 Refresh Token이 없을 경우 UNAUTHORIZED 예외")
+    void refreshTokenValidate_notExistToken() {
+
+        // given
+        String refreshToken = "invalidRefreshToken";
+        given(refreshTokenRepository.findByRefreshToken(refreshToken)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> service.refreshTokenValidate(refreshToken))
+            .isInstanceOf(BbangleException.class)
+            .satisfies(e -> {
+                BbangleException ex = (BbangleException) e;
+                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
+            });
     }
 }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceUnitTest.java
@@ -182,13 +182,13 @@ class OAuthSellerServiceUnitTest {
 
     @Test
     @DisplayName("DB에 존재하는 Refresh Token을 삭제한다.")
-    void logout() {
+    void deleteRefreshToken() {
 
         // given
         String refreshToken = "refreshToken";
 
         // when
-        service.logout(refreshToken);
+        service.deleteRefreshToken(refreshToken);
 
         // then
         verify(refreshTokenRepository).deleteByRefreshToken(refreshToken);


### PR DESCRIPTION
## Reviewer
1팀
- @kmindev 경민님
- @MSBANG 민수님

## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
- 연관된 이슈 
  - #567 
  - #570 
- Notion 개발 일정
  - [(판매자) 토큰 재발급 개발 일정](https://www.notion.so/sideproject-unione/1-_-_-2ed622e86d3d80cea572e7c7f4ed3c6d?source=copy_link)
  - [(판매자) 로그아웃 개발 일정](https://www.notion.so/sideproject-unione/1-_-_-2f2622e86d3d80dcb66ac2059daba4b4?source=copy_link)
- API 명세서
  - [(판매자) 토큰 재발급 API 명세서](https://www.notion.so/sideproject-unione/2ee622e86d3d8077b3c3df69610fb22c?source=copy_link)
  - [(판매자) 로그아웃 API 명세서](https://www.notion.so/sideproject-unione/2f2622e86d3d806fbd0ce4919396d735?v=2c6622e86d3d8157890d000cc857bdd2&source=copy_link)

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
- (판매자)  Access Token 재발급
- (판매자) Refresh Token 갱신
- 이전에 추가한 (판매자) 토큰 발급 API를 보안상의 문제로 GET에서 POST로 변경하였습니다.
  - #553 

1. Cookie에서 Refresh Token 추출
2. Refresh Token 검증
  i. Refresh Token이 유효할 경우 새로운 Access Token 생성 및 Refresh Token 갱신
  ii. 만약 Refresh Token이 유효하지 않다면 401 응답
4. Access Token은 헤더에, Refresh Token은 쿠키에 담아서 프론트로 전송

### Token
- Refresh Token은 Cookie를 통해 주고받도록 구현하였습니다.
- Access Token은 Header를 통해 주고받도록 구현하였습니다.

이에 따라 이전에 구현하였던 (판매자) 토큰 발급 API도 리팩토링 하였습니다.

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->
- 토큰 재발급 전
<img width="755" height="71" alt="image" src="https://github.com/user-attachments/assets/65e57dcf-b192-4a21-9c77-ee81d5b9d75f" />

- 토큰 재발급 후
<img width="805" height="155" alt="스크린샷 2026-01-26 220208" src="https://github.com/user-attachments/assets/bd8bbc0a-fed1-46f3-a7f2-53684539cc7a" />

- 로그아웃 후
<img width="741" height="52" alt="스크린샷 2026-01-26 220227" src="https://github.com/user-attachments/assets/575f615d-a6a2-4942-97b2-e2c337e53b48" />

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
- 현재 서버에서 OAuth2 로그인 시 간헐적으로 에러가 발생하는데, 현재 로그는 자세하게 정보를 출력하지 않아 일부 수정을 했습니다.
  - 에러를 해결하고 나면 해당 코드를 다시 수정할 계획입니다.
- Cookie로 전송하면 모바일 앱에서는 받을 방법이 없으므로 이 부분은 추후에 담당 프론트분과 의논을 해야 될 것 같습니다.
  - 의논 결과 Refresh Token은 쿠키를 통해 주고받으며 모바일 앱은 헤더를 통해 주고 받도록 결정하였습니다.
  - 모바일 앱 전용 인증 API는 추후에 개발해야 될 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리프레시 토큰으로 액세스 토큰 재발급(reissue) 엔드포인트 추가
  * 로그아웃(리프레시 토큰 삭제 및 쿠키 만료) 엔드포인트 추가
  * 토큰 생성 API 요청 방식 쿼리→JSON 본문 변경

* **개선 사항**
  * 리프레시 토큰 유효성 검증 및 삭제 로직 추가
  * 보안 쿠키(HTTPOnly, Secure, SameSite, 만료) 적용 및 응답 헤더 처리 개선
  * 인증 예외 로깅 보강 및 보안 설정 일부 개선
  * 토큰 응답/클레임 관련 DTO 추가

* **테스트**
  * 발급·재발급·로그아웃 관련 단위·통합 테스트 대폭 보강

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->