### PR TITLE
[Feat] 관리자 공지사항 삭제 기능 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationApi.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationApi.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.notification.admin.controller;
 
+import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
@@ -34,4 +35,10 @@ public interface AdminNotificationApi {
     @Operation(summary = "(관리자) 공지사항 조회")
     SingleResult<BbanglePageResponse<AdminNotificationSearchResponse>> searchNotification(
         Pageable pageable);
+
+    @Operation(summary = "(관리자) 공지사항 삭제")
+    CommonResult deleteNotification(
+        Long adminId,
+        List<Long> noticeId);
+
 }

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationApi.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationApi.java
@@ -1,11 +1,11 @@
 package com.bbangle.bbangle.notification.admin.controller;
 
-import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationUpdateRequest;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationCreateResponse;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationDeleteResponse;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationSearchResponse;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,7 +37,7 @@ public interface AdminNotificationApi {
         Pageable pageable);
 
     @Operation(summary = "(관리자) 공지사항 삭제")
-    CommonResult deleteNotification(
+    SingleResult<AdminNotificationDeleteResponse> deleteNotification(
         Long adminId,
         List<Long> noticeId);
 

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
@@ -1,6 +1,5 @@
 package com.bbangle.bbangle.notification.admin.controller;
 
-import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.common.service.ResponseService;
@@ -8,6 +7,7 @@ import com.bbangle.bbangle.config.security.AdminApiPath;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationCreateRequest;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationRequest.AdminNotificationUpdateRequest;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationCreateResponse;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationDeleteResponse;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationSearchResponse;
 import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationUpdateResponse;
 import com.bbangle.bbangle.notification.admin.facade.AdminNotificationFacade;
@@ -77,11 +77,11 @@ public class AdminNotificationController implements AdminNotificationApi {
 
     @DeleteMapping
     @Override
-    public CommonResult deleteNotification(
+    public SingleResult<AdminNotificationDeleteResponse> deleteNotification(
         @AuthenticationPrincipal Long adminId,
         @RequestBody List<Long> noticeId) {
 
-        adminNotificationService.deleteNotification(adminId, noticeId);
-        return responseService.getSuccessResult();
+        AdminNotificationDeleteResponse response = adminNotificationService.deleteNotification(adminId, noticeId);
+        return responseService.getSingleResult(response);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
@@ -82,6 +82,6 @@ public class AdminNotificationController implements AdminNotificationApi {
         @RequestBody List<Long> noticeId) {
 
         adminNotificationService.deleteNotification(adminId, noticeId);
-        return null;
+        return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/AdminNotificationController.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.notification.admin.controller;
 
+import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.common.service.ResponseService;
@@ -20,10 +21,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -70,5 +73,15 @@ public class AdminNotificationController implements AdminNotificationApi {
 
         Page<NoticeInfo> result = adminNotificationService.searchNotice(pageable);
         return responseService.getSingleResult(BbanglePageResponse.of(result.map(AdminNotificationSearchResponse::from)));
+    }
+
+    @DeleteMapping
+    @Override
+    public CommonResult deleteNotification(
+        @AuthenticationPrincipal Long adminId,
+        @RequestBody List<Long> noticeId) {
+
+        adminNotificationService.deleteNotification(adminId, noticeId);
+        return null;
     }
 }

--- a/src/main/java/com/bbangle/bbangle/notification/admin/controller/dto/AdminNotificationResponse.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/controller/dto/AdminNotificationResponse.java
@@ -84,4 +84,31 @@ public class AdminNotificationResponse {
                 .build();
         }
     }
+
+    @Schema(description = "관리자 공지사항 삭제 응답 DTO")
+    @Builder
+    public record AdminNotificationDeleteResponse(
+        @Schema(description = "삭제 성공한 공지사항 개수")
+        int successCount,
+        @Schema(description = "삭제 실패한 공지사항 개수")
+        int failureCount,
+        @Schema(description = "삭제 실패한 공지사항 정보 목록")
+        List<FailedNotice> failedNotices
+    ){
+        @Builder
+        public record FailedNotice(
+            @Schema(description = "공지사항 ID")
+            Long id,
+            @Schema(description = "공지사항 제목")
+            String title
+        ) {}
+
+        public static AdminNotificationDeleteResponse of(int successCount, List<FailedNotice> failedNotices) {
+            return AdminNotificationDeleteResponse.builder()
+                .successCount(successCount)
+                .failureCount(failedNotices.size())
+                .failedNotices(failedNotices)
+                .build();
+        }
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationService.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationService.java
@@ -112,13 +112,12 @@ public class AdminNotificationService {
 
         adminRepository.findById(adminId)
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.ADMIN_NOT_FOUND));
+
         List<Long> distinctIds = noticeIds.stream().distinct().toList();
-        List<Notice> notices = notificationRepository.findAllById(distinctIds);
 
-        boolean hasOtherAdmin = notices.stream()
-            .anyMatch(n -> !n.getAdmin().getId().equals(adminId));
+        List<Notice> notices = notificationRepository.findAllByIdInAndAdminId(distinctIds, adminId);
 
-        if (notices.size() != distinctIds.size() || hasOtherAdmin) {
+        if (notices.size() != distinctIds.size()) {
             throw new BbangleException(BbangleErrorCode.NOT_FIND_NOTICE);
         }
         // soft delete 적용

--- a/src/main/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationService.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationService.java
@@ -17,11 +17,13 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AdminNotificationService {
 
     private final NotificationRepository notificationRepository;
@@ -104,4 +106,19 @@ public class AdminNotificationService {
         Page<Notice> notice = notificationRepository.searchNoticeAll(pageable);
         return notice.map(NoticeInfo::from);
     }
+
+    @Transactional
+    public void deleteNotification(Long adminId, List<Long> noticeIds) {
+
+        List<Notice> notice = notificationRepository.findAllById(noticeIds);
+
+        if (notice.size() != noticeIds.size()) {
+            throw new BbangleException(BbangleErrorCode.NOT_FIND_NOTICE);
+        }
+        // soft delete 적용
+        notice.forEach(Notice::delete);
+        notificationRepository.saveAll(notice);
+    }
+
+
 }

--- a/src/main/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationService.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationService.java
@@ -110,14 +110,20 @@ public class AdminNotificationService {
     @Transactional
     public void deleteNotification(Long adminId, List<Long> noticeIds) {
 
-        List<Notice> notice = notificationRepository.findAllById(noticeIds);
+        adminRepository.findById(adminId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.ADMIN_NOT_FOUND));
+        List<Long> distinctIds = noticeIds.stream().distinct().toList();
+        List<Notice> notices = notificationRepository.findAllById(distinctIds);
 
-        if (notice.size() != noticeIds.size()) {
+        boolean hasOtherAdmin = notices.stream()
+            .anyMatch(n -> !n.getAdmin().getId().equals(adminId));
+
+        if (notices.size() != distinctIds.size() || hasOtherAdmin) {
             throw new BbangleException(BbangleErrorCode.NOT_FIND_NOTICE);
         }
         // soft delete 적용
-        notice.forEach(Notice::delete);
-        notificationRepository.saveAll(notice);
+        notices.forEach(Notice::delete);
+        notificationRepository.saveAll(notices);
     }
 
 

--- a/src/main/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationService.java
+++ b/src/main/java/com/bbangle/bbangle/notification/admin/service/AdminNotificationService.java
@@ -7,6 +7,8 @@ import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeCreateCommand;
 import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeCommand.AdminNoticeUpdateCommand;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationDeleteResponse;
+import com.bbangle.bbangle.notification.admin.controller.dto.AdminNotificationResponse.AdminNotificationDeleteResponse.FailedNotice;
 import com.bbangle.bbangle.notification.admin.service.model.AdminNoticeInfo.NoticeInfo;
 import com.bbangle.bbangle.notification.domain.Notice;
 import com.bbangle.bbangle.notification.repository.NotificationRepository;
@@ -108,22 +110,30 @@ public class AdminNotificationService {
     }
 
     @Transactional
-    public void deleteNotification(Long adminId, List<Long> noticeIds) {
-
-        adminRepository.findById(adminId)
-            .orElseThrow(() -> new BbangleException(BbangleErrorCode.ADMIN_NOT_FOUND));
+    public AdminNotificationDeleteResponse deleteNotification(Long adminId, List<Long> noticeIds) {
+        if (noticeIds == null || noticeIds.isEmpty()) {
+             throw new BbangleException(BbangleErrorCode._BAD_REQUEST);
+        }
 
         List<Long> distinctIds = noticeIds.stream().distinct().toList();
-
         List<Notice> notices = notificationRepository.findAllByIdInAndAdminId(distinctIds, adminId);
 
-        if (notices.size() != distinctIds.size()) {
-            throw new BbangleException(BbangleErrorCode.NOT_FIND_NOTICE);
-        }
-        // soft delete 적용
+        // 삭제 성공 처리
         notices.forEach(Notice::delete);
         notificationRepository.saveAll(notices);
-    }
 
+        // 실패한 공지사항 목록 생성
+        List<Long> foundIds = notices.stream().map(Notice::getId).toList();
+        List<FailedNotice> failedNotices = distinctIds.stream()
+            .filter(id -> !foundIds.contains(id))
+            .map(id -> FailedNotice.builder()
+                .id(id)
+                .title("[존재하지 않는 공지사항]")
+                .build())
+            .toList();
+
+        int successCount = notices.size();
+        return AdminNotificationDeleteResponse.of(successCount, failedNotices);
+    }
 
 }

--- a/src/main/java/com/bbangle/bbangle/notification/domain/Notice.java
+++ b/src/main/java/com/bbangle/bbangle/notification/domain/Notice.java
@@ -1,7 +1,7 @@
 package com.bbangle.bbangle.notification.domain;
 
 import com.bbangle.bbangle.admin.domain.Admin;
-import com.bbangle.bbangle.common.domain.BaseEntity;
+import com.bbangle.bbangle.common.domain.SoftDeleteBaseEntity;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.notification.customer.dto.NotificationResponse;
@@ -30,7 +30,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Notice extends BaseEntity {
+public class Notice extends SoftDeleteBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/bbangle/bbangle/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/bbangle/bbangle/notification/repository/NotificationRepository.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.notification.repository;
 
 import com.bbangle.bbangle.notification.domain.Notice;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,5 @@ public interface NotificationRepository extends JpaRepository<Notice, Long>, Not
     @Query("SELECT n FROM Notice n ORDER BY n.createdAt DESC")
     Page<Notice> searchNoticeAll(Pageable pageable);
 
+    void deleteAllByAdminIdAndIdIn(Long adminId, List<Long> noticeId);
 }

--- a/src/main/java/com/bbangle/bbangle/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/bbangle/bbangle/notification/repository/NotificationRepository.java
@@ -5,12 +5,20 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notice, Long>, NotificationQueryDSLRepository {
 
     @Query("SELECT n FROM Notice n ORDER BY n.createdAt DESC")
     Page<Notice> searchNoticeAll(Pageable pageable);
 
-    void deleteAllByAdminIdAndIdIn(Long adminId, List<Long> noticeId);
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        UPDATE Notice n
+        SET n.isDeleted = true
+        WHERE n.admin.id = :adminId AND n.id IN :noticeIds
+        """)
+    void deleteAllByAdminIdAndIdIn(@Param("adminId") Long adminId, @Param("noticeIds") List<Long> noticeIds);
 }

--- a/src/main/java/com/bbangle/bbangle/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/bbangle/bbangle/notification/repository/NotificationRepository.java
@@ -21,4 +21,6 @@ public interface NotificationRepository extends JpaRepository<Notice, Long>, Not
         WHERE n.admin.id = :adminId AND n.id IN :noticeIds
         """)
     void deleteAllByAdminIdAndIdIn(@Param("adminId") Long adminId, @Param("noticeIds") List<Long> noticeIds);
+
+    List<Notice> findAllByIdInAndAdminId(List<Long> distinctIds, Long adminId);
 }

--- a/src/main/java/com/bbangle/bbangle/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/bbangle/bbangle/notification/repository/NotificationRepository.java
@@ -22,5 +22,6 @@ public interface NotificationRepository extends JpaRepository<Notice, Long>, Not
         """)
     void deleteAllByAdminIdAndIdIn(@Param("adminId") Long adminId, @Param("noticeIds") List<Long> noticeIds);
 
-    List<Notice> findAllByIdInAndAdminId(List<Long> distinctIds, Long adminId);
+    @Query("SELECT n FROM Notice n WHERE n.id IN :distinctIds AND n.admin.id = :adminId AND n.isDeleted = false")
+    List<Notice> findAllByIdInAndAdminId(@Param("distinctIds") List<Long> distinctIds, @Param("adminId") Long adminId);
 }

--- a/src/main/resources/flyway/V30__app.sql
+++ b/src/main/resources/flyway/V30__app.sql
@@ -1,0 +1,3 @@
+ALTER TABLE notice
+DROP COLUMN links,
+    ADD COLUMN is_delete TINYINT(1) DEFAULT 0 NOT NULL COMMENT '삭제 여부 (0: 미삭제, 1: 삭제)';

--- a/src/main/resources/flyway/V30__app.sql
+++ b/src/main/resources/flyway/V30__app.sql
@@ -1,3 +1,3 @@
 ALTER TABLE notice
-DROP COLUMN links,
-    ADD COLUMN is_delete TINYINT(1) DEFAULT 0 NOT NULL COMMENT '삭제 여부 (0: 미삭제, 1: 삭제)';
+DROP COLUMN IF EXISTS links,
+    ADD COLUMN is_deleted TINYINT(1) DEFAULT 0 NOT NULL;

--- a/src/test/java/com/bbangle/bbangle/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/bbangle/bbangle/notification/repository/NotificationRepositoryTest.java
@@ -53,6 +53,8 @@ class NotificationRepositoryTest {
     private EntityManager em;
 
     private static final Long PAGE_SIZE = 20L;
+    @Autowired
+    private NotificationRepository notificationRepository;
 
     /**
      * 테스트 전 auto increment 초기화
@@ -198,5 +200,29 @@ class NotificationRepositoryTest {
         assertThat(result.getNextCursor()).isNotNull();
     }
 
+    @DisplayName("작성자가 모든 공지사항을 삭제한다.")
+    @Test
+    void deleteNotification_success(){
+        // given
+        Admin admin = adminRepository.save(NoticeFixture.createTestAdmin());
+        List<Notice> notices = IntStream.rangeClosed(1, 25)
+            .mapToObj(i -> NoticeFixture.notice("공지사항 등록", "<div> 본문내용 <div>", admin))
+            .toList();
+        //when
+        notificationRepository.saveAll(notices);
+        em.flush();
+        em.clear();
+
+        // 저장 후 ID 수집
+        List<Long> noticeIds = notificationRepository.findAll().stream()
+            .map(Notice::getId)
+            .toList();
+
+        // then
+        notificationRepository.deleteAllByAdminIdAndIdIn(admin.getId(), noticeIds);
+
+        assertThat(notificationRepository.findAll()).isEmpty();
+
+    }
 }
 


### PR DESCRIPTION
## History
연관된 이슈: * Resolves #494

## 🚀 Major Changes & Explanations

관리자 공지사항 삭제 기능을 추가하였습니다.
- 간단한 기능 추가라 별다른 설명사항이 없습니다
- 코드래빗이 현재 저희 repo에 적용되는지 테스트 겸으로 하여 업로드하였습니다.

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자가 여러 공지사항을 한 번에 소프트 삭제(일괄 삭제)할 수 있는 삭제 API와 응답 구조(성공/실패 건수 및 실패 항목 목록)가 추가되었습니다.

* **기타**
  * 공지사항에 소프트 삭제(is_deleted) 컬럼 도입 및 관련 DB 마이그레이션이 적용되었습니다.
  * 도메인에 소프트 삭제 동작이 반영되었습니다.

* **테스트**
  * 공지사항 일괄 삭제 동작을 검증하는 통합 테스트가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->