### PR TITLE
[Feature] 스토어 정보 등록 시 사용하는 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/store/domain/StoreStatus.java
+++ b/src/main/java/com/bbangle/bbangle/store/domain/StoreStatus.java
@@ -7,10 +7,15 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum StoreStatus {
+    
+    // 크롤링 하여 수집한 가게는 아직 판매자가 등록되어있지 않으니 비선점
+    // 판매자가 만약 가게를 등록하면 해당 가게는 선점
+    // 관리자가 승인하면 해당 가게는 등록
+    // 관리자가 거절하면 해당 가게는 다시 비선점
 
-    RESERVED("선점"),
-    ACTIVE("등록"),
-    NONE("비선점");
+    RESERVED("선점"), // 판매자가 해당 가게를 등록했지만 관리자가 승인하지 않은 상태
+    ACTIVE("등록"),   // 관리자가 승인하여 최종적으로 해당 가게의 판매자가 된 상태
+    NONE("비선점");    // 아직 판매자가 등록하지 않은 상태 
 
 
     private final String description;

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreQueryDSLRepository.java
@@ -24,12 +24,5 @@ public interface StoreQueryDSLRepository {
 
     boolean existsByStoreName(String name);
 
-    /**
-     * Seller 정보 등록 시 Store 목록 찾을 때 사용하는 메서드
-     * @param storeName 빈칸을 제거한 StoreName
-     * @return List<Store>
-     */
-    List<Store> getStoreByStoreName(String storeName);
-
-    CursorPagination<StoreInfo> findNextCursorPage(List<Long> storeIds);
+    CursorPagination<StoreInfo> findByStoreNameWithCursor(String storeName, Long cursorId);
 }

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreQueryDSLRepository.java
@@ -20,16 +20,16 @@ public interface StoreQueryDSLRepository {
 
     Optional<Store> findByStoreName(String storeName);
 
+    Optional<Store> findByStoreNameAndIsNotDeleted(String storeName);
+
     boolean existsByStoreName(String name);
-
-    List<Store> getStoreByStoreName(String storeName);
-
-    CursorPagination<StoreInfo> findNextCursorPage(List<Long> storeIds);
 
     /**
      * Seller 정보 등록 시 Store 목록 찾을 때 사용하는 메서드
      * @param storeName 빈칸을 제거한 StoreName
      * @return List<Store>
      */
-    List<Store> getStoreListByStoreName(String storeName);
+    List<Store> getStoreByStoreName(String storeName);
+
+    CursorPagination<StoreInfo> findNextCursorPage(List<Long> storeIds);
 }

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreQueryDSLRepository.java
@@ -25,4 +25,11 @@ public interface StoreQueryDSLRepository {
     List<Store> getStoreByStoreName(String storeName);
 
     CursorPagination<StoreInfo> findNextCursorPage(List<Long> storeIds);
+
+    /**
+     * Seller 정보 등록 시 Store 목록 찾을 때 사용하는 메서드
+     * @param storeName 빈칸을 제거한 StoreName
+     * @return List<Store>
+     */
+    List<Store> getStoreListByStoreName(String storeName);
 }

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.bbangle.bbangle.store.domain.StoreStatus;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo.StoreInfo;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Collections;
 import java.util.List;
@@ -125,6 +126,19 @@ public class StoreRepositoryImpl implements StoreQueryDSLRepository {
         return CursorPagination.of(response, PAGE_SIZE, null, SellerStoreInfo.StoreInfo::id);
     }
 
+    // TODO : Test
+    @Override
+    public List<Store> getStoreListByStoreName(String storeName) {
+
+        return queryFactory.selectFrom(store)
+            .where(
+                Expressions.stringTemplate(
+                    "REPLACE({0}, ' ', '')", store.name
+                ).contains(storeName)
+            )
+            .orderBy(store.name.desc())
+            .fetch();
+    }
 
     ///  페이징 처리를 위한 스토어 이름 검색 메서드
     @Override

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
@@ -11,7 +11,6 @@ import com.bbangle.bbangle.board.customer.dto.QAiLearningStoreDto;
 import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.common.page.CursorPagination;
 import com.bbangle.bbangle.store.domain.Store;
-import com.bbangle.bbangle.store.domain.StoreStatus;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo.StoreInfo;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -103,7 +102,16 @@ public class StoreRepositoryImpl implements StoreQueryDSLRepository {
             .fetchOne());
     }
 
+    // TODO : Test
+    @Override
+    public Optional<Store> findByStoreNameAndIsNotDeleted(String storeName) {
+        return Optional.ofNullable(queryFactory.selectFrom(store)
+            .where(store.name.eq(storeName)
+                .and(store.isDeleted.eq(false)))
+            .fetchOne());
+    }
 
+    // TODO : Test
     @Override
     public CursorPagination<StoreInfo> findNextCursorPage(List<Long> storeIds) {
 
@@ -115,41 +123,31 @@ public class StoreRepositoryImpl implements StoreQueryDSLRepository {
             .selectFrom(store)
             .where(store.id.in(storeIds))
             .limit(PAGE_SIZE + 1) // PAGE_SIZE는 상수값 20 고정
-            .orderBy(store.createdAt.desc(), store.id.desc())
+            .orderBy(store.name.asc())
+            //.orderBy(store.createdAt.desc(), store.id.desc())
             .fetch();
 
         List<SellerStoreInfo.StoreInfo> response = stores.stream()
             .map(StoreInfo::from)
             .toList();
 
-
         return CursorPagination.of(response, PAGE_SIZE, null, SellerStoreInfo.StoreInfo::id);
     }
 
     // TODO : Test
-    @Override
-    public List<Store> getStoreListByStoreName(String storeName) {
-
-        return queryFactory.selectFrom(store)
-            .where(
-                Expressions.stringTemplate(
-                    "REPLACE({0}, ' ', '')", store.name
-                ).contains(storeName)
-            )
-            .orderBy(store.name.desc())
-            .fetch();
-    }
-
     ///  페이징 처리를 위한 스토어 이름 검색 메서드
     @Override
     public List<Store> getStoreByStoreName(String storeName) {
 
         return queryFactory.selectFrom(store)
-            .where(store.name.contains(storeName)
-                .and(store.isDeleted.eq(false))
-                .and(store.status.eq(StoreStatus.NONE)))
+            .where(
+                Expressions.stringTemplate("REPLACE({0}, ' ', '')", store.name)
+                    .contains(storeName)
+                    .and(store.isDeleted.eq(false))
+            )
             .limit(PAGE_SIZE + 1)
-            .orderBy(store.createdAt.desc(), store.id.desc())
-            .stream().toList();
+            .orderBy(store.name.asc())
+            //.orderBy(store.createdAt.desc(), store.id.desc())
+            .fetch();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
@@ -100,7 +100,6 @@ public class StoreRepositoryImpl implements StoreQueryDSLRepository {
             .fetchOne());
     }
 
-    // TODO : Test
     @Override
     public Optional<Store> findByStoreNameAndIsNotDeleted(String storeName) {
         return Optional.ofNullable(queryFactory.selectFrom(store)
@@ -109,7 +108,6 @@ public class StoreRepositoryImpl implements StoreQueryDSLRepository {
             .fetchOne());
     }
 
-    // TODO : Test
     @Override
     public CursorPagination<StoreInfo> findByStoreNameWithCursor(String storeName, Long cursorId) {
 
@@ -119,7 +117,7 @@ public class StoreRepositoryImpl implements StoreQueryDSLRepository {
                 Expressions.stringTemplate("REPLACE({0}, ' ', '')", store.name)
                     .contains(storeName),
                 store.isDeleted.eq(false),
-                cursorId != null ? store.id.gt(cursorId) : null
+                cursorId != null ? store.id.goe(cursorId) : null
             )
             .orderBy(store.id.asc())
             .limit(PAGE_SIZE + 1)

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
@@ -11,12 +11,10 @@ import com.bbangle.bbangle.board.customer.dto.QAiLearningStoreDto;
 import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.common.page.CursorPagination;
 import com.bbangle.bbangle.store.domain.Store;
-import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo.StoreInfo;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -113,41 +111,27 @@ public class StoreRepositoryImpl implements StoreQueryDSLRepository {
 
     // TODO : Test
     @Override
-    public CursorPagination<StoreInfo> findNextCursorPage(List<Long> storeIds) {
+    public CursorPagination<StoreInfo> findByStoreNameWithCursor(String storeName, Long cursorId) {
 
-        if (storeIds == null || storeIds.isEmpty()) {
-            return CursorPagination.of(Collections.emptyList(), PAGE_SIZE, 0L, SellerStoreInfo.StoreInfo::id);
-        }
-        ///  추출한 아이디를 통해 조회
         List<Store> stores = queryFactory
             .selectFrom(store)
-            .where(store.id.in(storeIds))
-            .limit(PAGE_SIZE + 1) // PAGE_SIZE는 상수값 20 고정
-            .orderBy(store.name.asc())
-            //.orderBy(store.createdAt.desc(), store.id.desc())
-            .fetch();
-
-        List<SellerStoreInfo.StoreInfo> response = stores.stream()
-            .map(StoreInfo::from)
-            .toList();
-
-        return CursorPagination.of(response, PAGE_SIZE, null, SellerStoreInfo.StoreInfo::id);
-    }
-
-    // TODO : Test
-    ///  페이징 처리를 위한 스토어 이름 검색 메서드
-    @Override
-    public List<Store> getStoreByStoreName(String storeName) {
-
-        return queryFactory.selectFrom(store)
             .where(
                 Expressions.stringTemplate("REPLACE({0}, ' ', '')", store.name)
-                    .contains(storeName)
-                    .and(store.isDeleted.eq(false))
+                    .contains(storeName),
+                store.isDeleted.eq(false),
+                cursorId != null ? store.id.gt(cursorId) : null
             )
+            .orderBy(store.id.asc())
             .limit(PAGE_SIZE + 1)
-            .orderBy(store.name.asc())
-            //.orderBy(store.createdAt.desc(), store.id.desc())
             .fetch();
+
+        List<StoreInfo> response = stores.stream().map(StoreInfo::from).toList();
+
+        return CursorPagination.of(
+            response,
+            PAGE_SIZE,
+            null,
+            StoreInfo::id
+        );
     }
 }

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
@@ -1,11 +1,10 @@
 package com.bbangle.bbangle.store.seller.controller;
 
-import com.bbangle.bbangle.common.dto.ListResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.page.CursorPagination;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.SellerApiPath;
-import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SearchResponse;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
 import com.bbangle.bbangle.store.seller.controller.swagger.SellerStoreApi;
 import com.bbangle.bbangle.store.seller.service.SellerStoreService;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo;
@@ -15,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+// TODO : Test
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(SellerApiPath.PREFIX + "/stores")
@@ -23,24 +23,22 @@ public class SellerStoreController implements SellerStoreApi {
     private final ResponseService responseService;
     private final SellerStoreService sellerStoreService;
 
-    // TODO : Test
     @Override
     @GetMapping("/search")
-    public ListResult<SearchResponse> search(
+    public SingleResult<CursorPagination<SellerStoreInfo.StoreInfo>> search(
         @RequestParam String storeName
     ) {
-        return responseService.getListResult(sellerStoreService.searchStore(storeName));
+        return responseService.getSingleResult(
+            sellerStoreService.selectStoreNameForSeller(storeName)
+        );
     }
 
 
     @Override
-    @GetMapping("/check-name-duplicate")
-    public SingleResult<CursorPagination<SellerStoreInfo.StoreInfo>> checkStoreNameDuplicate(
-        @RequestParam String storeName) {
-
-        CursorPagination<SellerStoreInfo.StoreInfo> result = sellerStoreService.selectStoreNameForSeller(
-            storeName);
-
-        return responseService.getSingleResult(result);
+    @GetMapping("/check-name")
+    public SingleResult<StoreResponse.StoreNameCheck> checkStoreNameDuplicate(
+        @RequestParam String storeName
+    ) {
+        return responseService.getSingleResult(sellerStoreService.checkStoreName(storeName));
     }
 }

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-// TODO : Test
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(SellerApiPath.PREFIX + "/stores")

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
@@ -9,8 +9,6 @@ import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SearchRespo
 import com.bbangle.bbangle.store.seller.controller.swagger.SellerStoreApi;
 import com.bbangle.bbangle.store.seller.service.SellerStoreService;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,14 +23,13 @@ public class SellerStoreController implements SellerStoreApi {
     private final ResponseService responseService;
     private final SellerStoreService sellerStoreService;
 
+    // TODO : Test
     @Override
     @GetMapping("/search")
-    public ListResult<SearchResponse> search(@RequestParam String searchValue) {
-        // TODO: 구현 필요
-        List<SearchResponse> response = new ArrayList<>();
-        response.add(new SearchResponse(1L, "빵그리의 오븐 즉석빵 상점"));
-        response.add(new SearchResponse(2L, "빵그리의 오븐 공장빵 상점"));
-        return responseService.getListResult(response);
+    public ListResult<SearchResponse> search(
+        @RequestParam String storeName
+    ) {
+        return responseService.getListResult(sellerStoreService.searchStore(storeName));
     }
 
 

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
@@ -8,7 +8,9 @@ import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
 import com.bbangle.bbangle.store.seller.controller.swagger.SellerStoreApi;
 import com.bbangle.bbangle.store.seller.service.SellerStoreService;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(SellerApiPath.PREFIX + "/stores")
+@Validated
 public class SellerStoreController implements SellerStoreApi {
 
     private final ResponseService responseService;
@@ -26,18 +29,18 @@ public class SellerStoreController implements SellerStoreApi {
     @Override
     @GetMapping("/search")
     public SingleResult<CursorPagination<SellerStoreInfo.StoreInfo>> search(
-        @RequestParam String storeName
+        @RequestParam @NotBlank(message = "스토어 이름은 필수입니다.") String storeName,
+        @RequestParam(required = false) Long cursorId
     ) {
         return responseService.getSingleResult(
-            sellerStoreService.selectStoreNameForSeller(storeName)
+            sellerStoreService.selectStoreNameForSeller(storeName, cursorId)
         );
     }
-
 
     @Override
     @GetMapping("/check-name")
     public SingleResult<StoreResponse.StoreNameCheck> checkStoreNameDuplicate(
-        @RequestParam String storeName
+        @RequestParam @NotBlank(message = "스토어 이름은 필수입니다.") String storeName
     ) {
         return responseService.getSingleResult(sellerStoreService.checkStoreName(storeName));
     }

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/dto/StoreResponse.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/dto/StoreResponse.java
@@ -1,9 +1,7 @@
 package com.bbangle.bbangle.store.seller.controller.dto;
 
 import com.bbangle.bbangle.store.domain.StoreStatus;
-import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo.StoreInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
 import lombok.Builder;
 
 public class StoreResponse {
@@ -26,5 +24,21 @@ public class StoreResponse {
     ) {
 
     }
+
+    @Schema(description = "판매자 스토어 중복 검사 응답 DTO")
+    @Builder
+    public record StoreNameCheck(
+        @Schema(description = "스토어 이름 중복 여부 (true = 중복, false = 사용 가능)", example = "false") boolean duplicated,
+        SellerStoreDetail store
+    ) {}
+
+    @Schema(description = "판매자 스토어 상세 응답 DTO")
+    public record SellerStoreDetail(
+        @Schema(description = "스토어 ID", example = "1") Long storeId,
+        @Schema(description = "스토어명", example = "빵그리의 오븐") String name,
+        @Schema(description = "스토어 소개", example = "건강한 디저트를 만드는 베이커리") String introduce,
+        @Schema(description = "스토어 프로필 이미지 URL", example = "https://d37g3q9mfan3cw.cloudfront.net/store/000000/logo.png") String profile,
+        @Schema(description = "스토어 등록 상태", example = "NONE") StoreStatus status
+    ) {}
 
 }

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/dto/StoreResponse.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/dto/StoreResponse.java
@@ -28,8 +28,8 @@ public class StoreResponse {
     @Schema(description = "판매자 스토어 중복 검사 응답 DTO")
     @Builder
     public record StoreNameCheck(
-        @Schema(description = "스토어 이름 중복 여부 (true = 중복, false = 사용 가능)", example = "false") boolean duplicated,
-        SellerStoreDetail store
+        @Schema(description = "스토어 이름 중복 여부 (false = 중복, true = 사용 가능)", example = "false") boolean available,
+        @Schema(description = "스토어 상세 정보 (스토어가 존재할 경우)", nullable = true) SellerStoreDetail store
     ) {}
 
     @Schema(description = "판매자 스토어 상세 응답 DTO")

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/mapper/SellerStoreMapper.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/mapper/SellerStoreMapper.java
@@ -1,0 +1,23 @@
+package com.bbangle.bbangle.store.seller.controller.mapper;
+
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SearchResponse;
+import java.util.List;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+    componentModel = "spring",
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+    unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface SellerStoreMapper {
+
+    @Mapping(source = "id", target = "storeId")
+    @Mapping(source = "name", target = "storeName")
+    SearchResponse toSearchResponse(Store store);
+
+    List<SearchResponse> toSearchResponseList(List<Store> stores);
+}

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/mapper/SellerStoreMapper.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/mapper/SellerStoreMapper.java
@@ -1,8 +1,7 @@
 package com.bbangle.bbangle.store.seller.controller.mapper;
 
 import com.bbangle.bbangle.store.domain.Store;
-import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SearchResponse;
-import java.util.List;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -16,8 +15,5 @@ import org.mapstruct.ReportingPolicy;
 public interface SellerStoreMapper {
 
     @Mapping(source = "id", target = "storeId")
-    @Mapping(source = "name", target = "storeName")
-    SearchResponse toSearchResponse(Store store);
-
-    List<SearchResponse> toSearchResponseList(List<Store> stores);
+    StoreResponse.SellerStoreDetail toSellerStoreDetail(Store store);
 }

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
@@ -17,9 +17,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Seller Store", description = "(판매자) 스토어 API")
 public interface SellerStoreApi {
 
-    @Operation(summary = "(판매자) 스토어 검색")
+    @Operation(
+        summary = "(판매자) 스토어 검색",
+        description = """
+            ### 스토어 이름을 통해 스토어 목록을 조회
+            - storeName에 스토어 이름을 입력하실 때 **빈칸을 제거**하고 입력하셔야합니다.
+            - EX) `storeName.replaceAll(" " , "")`
+            """
+    )
     ListResult<SearchResponse> search(
-        @Parameter(description = "검색어", example = "빵그리의 오븐") String searchValue
+        @Parameter(description = "검색어", example = "빵그리의오븐") String storeName
     );
 
     @Operation(summary = "스토어명 중복 확인")

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
@@ -1,10 +1,9 @@
 package com.bbangle.bbangle.store.seller.controller.swagger;
 
-import com.bbangle.bbangle.common.dto.ListResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.page.CursorPagination;
 import com.bbangle.bbangle.exception.GlobalControllerAdvice;
-import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SearchResponse;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -25,7 +24,7 @@ public interface SellerStoreApi {
             - EX) `storeName.replaceAll(" " , "")`
             """
     )
-    ListResult<SearchResponse> search(
+    SingleResult<CursorPagination<SellerStoreInfo.StoreInfo>> search(
         @Parameter(description = "검색어", example = "빵그리의오븐") String storeName
     );
 
@@ -39,7 +38,7 @@ public interface SellerStoreApi {
             )
         )
     })
-    SingleResult<CursorPagination<SellerStoreInfo.StoreInfo>> checkStoreNameDuplicate(
+    SingleResult<StoreResponse.StoreNameCheck> checkStoreNameDuplicate(
         @Parameter(description = "스토어명", example = "빵그리의 오븐") String storeName
     );
 

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
 
 @Tag(name = "Seller Store", description = "(판매자) 스토어 API")
 public interface SellerStoreApi {
@@ -25,7 +26,11 @@ public interface SellerStoreApi {
             """
     )
     SingleResult<CursorPagination<SellerStoreInfo.StoreInfo>> search(
-        @Parameter(description = "검색어", example = "빵그리의오븐") String storeName
+        @Parameter(description = "검색어", example = "빵그리의오븐")
+        @NotBlank(message = "스토어 이름은 필수입니다.")
+        String storeName,
+        @Parameter(description = "조회한 목록의 마지막 스토어의 id", example = "1")
+        Long cursorId
     );
 
     @Operation(summary = "스토어명 중복 확인")
@@ -39,7 +44,9 @@ public interface SellerStoreApi {
         )
     })
     SingleResult<StoreResponse.StoreNameCheck> checkStoreNameDuplicate(
-        @Parameter(description = "스토어명", example = "빵그리의 오븐") String storeName
+        @Parameter(description = "스토어명", example = "빵그리의 오븐")
+        @NotBlank(message = "스토어 이름은 필수입니다.")
+        String storeName
     );
 
 }

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
@@ -36,7 +36,7 @@ public interface SellerStoreApi {
     @Operation(
         summary = "스토어명 중복 확인",
         description = """
-        ### 판매자의 JWT 토큰을 발급 받고 계정 상태를 조회
+        ### 입력한 스토어 이름이 사용가능한지 체크하고 스토어 상세 정보를 조회
 
         ---
         ### 스토어 상태 설명 표

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
@@ -33,7 +33,20 @@ public interface SellerStoreApi {
         Long cursorId
     );
 
-    @Operation(summary = "스토어명 중복 확인")
+    @Operation(
+        summary = "스토어명 중복 확인",
+        description = """
+        ### 판매자의 JWT 토큰을 발급 받고 계정 상태를 조회
+
+        ---
+        ### 스토어 상태 설명 표
+        |Status Code|의미|설명|
+        |-----------|----|----|
+        |RESERVED|선점|판매자가 해당 가게를 등록했지만 관리자가 승인하지 않은 상태|
+        |ACTIVE|등록|관리자가 승인하여 최종적으로 해당 가게 등록자가 된 상태|
+        |NONE|비선점|해당 스토어를 등록한 판매자가 아직 없는 상태|
+        """
+    )
     @ApiResponses(value = {
               @ApiResponse(
             responseCode = "400",

--- a/src/main/java/com/bbangle/bbangle/store/seller/service/SellerStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/service/SellerStoreService.java
@@ -36,7 +36,6 @@ public class SellerStoreService {
         return storeRepository.save(Store.createForSeller(storeName));
     }
 
-    // TODO : Test
     @Transactional(readOnly = true)
     public CursorPagination<StoreInfo> selectStoreNameForSeller(String storeName, Long cursorId) {
         String normalizedStoreName = storeName.replaceAll("\\s+", "");
@@ -44,7 +43,6 @@ public class SellerStoreService {
         return storeRepository.findByStoreNameWithCursor(normalizedStoreName, cursorId);
     }
 
-    // TODO : Test
     public StoreResponse.StoreNameCheck checkStoreName(String storeName) {
         String normalizedStoreName = storeName.strip();
 

--- a/src/main/java/com/bbangle/bbangle/store/seller/service/SellerStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/service/SellerStoreService.java
@@ -5,6 +5,8 @@ import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.repository.StoreRepository;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SearchResponse;
+import com.bbangle.bbangle.store.seller.controller.mapper.SellerStoreMapper;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo.StoreInfo;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class SellerStoreService {
 
     private final StoreRepository storeRepository;
+    private final SellerStoreMapper storeMapper;
+
+    // TODO : Test
+    public List<SearchResponse> searchStore(String storeName) {
+        String noSpaceStoreName = storeName.replaceAll("\\s+", "");
+
+        List<Store> stores = storeRepository.getStoreListByStoreName(noSpaceStoreName);
+        return storeMapper.toSearchResponseList(stores);
+    }
 
     @Transactional
     public Store registerStoreForSeller(Long storeId, String storeName) {

--- a/src/main/java/com/bbangle/bbangle/store/seller/service/SellerStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/service/SellerStoreService.java
@@ -9,7 +9,6 @@ import com.bbangle.bbangle.store.repository.StoreRepository;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
 import com.bbangle.bbangle.store.seller.controller.mapper.SellerStoreMapper;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo.StoreInfo;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,32 +38,26 @@ public class SellerStoreService {
 
     // TODO : Test
     @Transactional(readOnly = true)
-    public CursorPagination<StoreInfo> selectStoreNameForSeller(String storeName){
-        if (storeName.isBlank()) {
-            throw new BbangleException(BbangleErrorCode.INVALID_STORE_NAME);
-        }
+    public CursorPagination<StoreInfo> selectStoreNameForSeller(String storeName, Long cursorId) {
         String normalizedStoreName = storeName.replaceAll("\\s+", "");
 
-        /// 페이징 처리를 위한 +1 조회 진행
-        ///중복되지 않은 스토어명들을 조회하고 id 값을 List로 모아 페이징 처리 로직으로 전달
-        List<Long> storeIds = storeRepository.getStoreByStoreName(normalizedStoreName).stream().map(Store::getId).toList();
-
-        // 2. 스토어 명이 중복이 아니라면 사용 가능하다
-         return storeRepository.findNextCursorPage(storeIds);
+        return storeRepository.findByStoreNameWithCursor(normalizedStoreName, cursorId);
     }
 
     // TODO : Test
     public StoreResponse.StoreNameCheck checkStoreName(String storeName) {
-        return storeRepository.findByStoreNameAndIsNotDeleted(storeName)
+        String normalizedStoreName = storeName.strip();
+
+        return storeRepository.findByStoreNameAndIsNotDeleted(normalizedStoreName)
             .map(store ->
                 StoreResponse.StoreNameCheck.builder()
-                    .duplicated(!StoreStatus.NONE.equals(store.getStatus()))
+                    .available(StoreStatus.NONE.equals(store.getStatus()))
                     .store(sellerStoreMapper.toSellerStoreDetail(store))
                     .build()
             )
             .orElseGet(() ->
                 StoreResponse.StoreNameCheck.builder()
-                    .duplicated(false)
+                    .available(true)
                     .store(null)
                     .build()
             );

--- a/src/main/java/com/bbangle/bbangle/store/seller/service/SellerStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/service/SellerStoreService.java
@@ -4,8 +4,9 @@ import com.bbangle.bbangle.common.page.CursorPagination;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.domain.StoreStatus;
 import com.bbangle.bbangle.store.repository.StoreRepository;
-import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SearchResponse;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
 import com.bbangle.bbangle.store.seller.controller.mapper.SellerStoreMapper;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo.StoreInfo;
 import java.util.List;
@@ -18,15 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SellerStoreService {
 
     private final StoreRepository storeRepository;
-    private final SellerStoreMapper storeMapper;
-
-    // TODO : Test
-    public List<SearchResponse> searchStore(String storeName) {
-        String noSpaceStoreName = storeName.replaceAll("\\s+", "");
-
-        List<Store> stores = storeRepository.getStoreListByStoreName(noSpaceStoreName);
-        return storeMapper.toSearchResponseList(stores);
-    }
+    private final SellerStoreMapper sellerStoreMapper;
 
     @Transactional
     public Store registerStoreForSeller(Long storeId, String storeName) {
@@ -44,16 +37,13 @@ public class SellerStoreService {
         return storeRepository.save(Store.createForSeller(storeName));
     }
 
+    // TODO : Test
     @Transactional(readOnly = true)
     public CursorPagination<StoreInfo> selectStoreNameForSeller(String storeName){
-        String normalizedStoreName = normalize(storeName);
-        if (normalizedStoreName == null) {
+        if (storeName.isBlank()) {
             throw new BbangleException(BbangleErrorCode.INVALID_STORE_NAME);
         }
-        // 1. 스토어명이 중복이라면 사용할 수없다.
-        if (storeRepository.existsByStoreName((normalizedStoreName))){
-            throw new BbangleException(BbangleErrorCode.INVALID_STORE_NAME);
-        }
+        String normalizedStoreName = storeName.replaceAll("\\s+", "");
 
         /// 페이징 처리를 위한 +1 조회 진행
         ///중복되지 않은 스토어명들을 조회하고 id 값을 List로 모아 페이징 처리 로직으로 전달
@@ -63,11 +53,20 @@ public class SellerStoreService {
          return storeRepository.findNextCursorPage(storeIds);
     }
 
-    private String normalize(String value) {
-        if (value == null) return null;
-        String trimmed = value.trim();
-        // → "   " 같은 공백-only 문자열이면 null로 간주
-        return trimmed.isEmpty() ? null : trimmed;
+    // TODO : Test
+    public StoreResponse.StoreNameCheck checkStoreName(String storeName) {
+        return storeRepository.findByStoreNameAndIsNotDeleted(storeName)
+            .map(store ->
+                StoreResponse.StoreNameCheck.builder()
+                    .duplicated(!StoreStatus.NONE.equals(store.getStatus()))
+                    .store(sellerStoreMapper.toSellerStoreDetail(store))
+                    .build()
+            )
+            .orElseGet(() ->
+                StoreResponse.StoreNameCheck.builder()
+                    .duplicated(false)
+                    .store(null)
+                    .build()
+            );
     }
-
 }

--- a/src/main/java/com/bbangle/bbangle/store/seller/service/model/SellerStoreInfo.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/service/model/SellerStoreInfo.java
@@ -1,7 +1,6 @@
 package com.bbangle.bbangle.store.seller.service.model;
 
 import com.bbangle.bbangle.store.domain.Store;
-import com.bbangle.bbangle.store.domain.StoreStatus;
 import lombok.Builder;
 
 
@@ -9,26 +8,22 @@ public class SellerStoreInfo {
 
     public record StoreInfo(
         Long id,
-        String name,
-        StoreStatus status
+        String name
     ) {
 
         @Builder
         public StoreInfo(
             Long id,
-            String name,
-            StoreStatus status
+            String name
         ) {
             this.id = id;
             this.name = name;
-            this.status = status;
         }
 
         public static StoreInfo from(Store store) {
             return StoreInfo.builder()
                 .id(store.getId())
                 .name(store.getName())
-                .status(store.getStatus())
                 .build();
         }
     }

--- a/src/main/java/com/bbangle/bbangle/store/seller/service/model/SellerStoreInfo.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/service/model/SellerStoreInfo.java
@@ -2,22 +2,25 @@ package com.bbangle.bbangle.store.seller.service.model;
 
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.domain.StoreStatus;
-import java.util.Collection;
 import lombok.Builder;
-import lombok.Getter;
 
 
 public class SellerStoreInfo {
 
-    public record StoreInfo(Long id, String name, boolean isDeleted,
-                            StoreStatus status) {
+    public record StoreInfo(
+        Long id,
+        String name,
+        StoreStatus status
+    ) {
 
         @Builder
-        public StoreInfo(Long id, String name,
-            boolean isDeleted, StoreStatus status) {
+        public StoreInfo(
+            Long id,
+            String name,
+            StoreStatus status
+        ) {
             this.id = id;
             this.name = name;
-            this.isDeleted = isDeleted;
             this.status = status;
         }
 
@@ -25,11 +28,8 @@ public class SellerStoreInfo {
             return StoreInfo.builder()
                 .id(store.getId())
                 .name(store.getName())
-                .isDeleted(store.isDeleted())
                 .status(store.getStatus())
                 .build();
         }
-
     }
-
 }

--- a/src/test/java/com/bbangle/bbangle/store/repository/StoreRepositoryPagingTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/repository/StoreRepositoryPagingTest.java
@@ -12,7 +12,6 @@ import com.bbangle.bbangle.store.domain.StoreStatus;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo.StoreInfo;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
@@ -43,26 +42,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class StoreRepositoryPagingTest {
 
+    private static final int TOTAL_STORES = 25;
+    private static final long PAGE_SIZE = 20L;
+    // 시간을 조작할 변수 (static으로 공유)
+    static LocalDateTime mockTime = LocalDateTime.now().minusDays(1);
+
     @Autowired
     private StoreRepository storeRepository;
 
     @Autowired
     private EntityManager em;
-
-    // 시간을 조작할 변수 (static으로 공유)
-    static LocalDateTime mockTime = LocalDateTime.now().minusDays(1);
-
-    @TestConfiguration
-    static class TestConfig {
-        @Bean
-        public DateTimeProvider dateTimeProvider() {
-            // 항상 mockTime 변수의 값을 현재 시간으로 반환
-            return () -> Optional.of(mockTime);
-        }
-    }
-
-    private static final int TOTAL_STORES = 25;
-    private static final long PAGE_SIZE = 20L;
 
     @BeforeEach
     void setUp() {
@@ -86,22 +75,57 @@ public class StoreRepositoryPagingTest {
         em.clear();
     }
 
-
     @Test
-    @DisplayName("첫 페이지를 정상적으로 조회한다")
-    void findNextCursorPage_firstPage_success() {
-        List<Long> storeIds = storeRepository.findAll().stream()
-            .map(Store::getId)
-            .toList();
+    @DisplayName("스토어 이름 검색 - 첫 페이지를 조회한다")
+    void findByStoreNameWithCursor_firstPage_success() {
+
+        // given
+        String storeName = "Store";
+
         // when
-        CursorPagination<StoreInfo> result = storeRepository.findNextCursorPage(storeIds);
+        CursorPagination<StoreInfo> result = storeRepository.findByStoreNameWithCursor(storeName, null);
 
         // then
         assertThat(result.getContent()).hasSize((int) PAGE_SIZE);
         assertThat(result.getHasNext()).isTrue();
-        // createdAt DESC, id DESC 이므로 가장 마지막에 생성된 Store 25가 첫번째로 와야 함
-        assertThat(result.getContent().get(0).name()).isEqualTo("Store 25");
-        assertThat(result.getContent().get(19).name()).isEqualTo("Store 6");
+
+        // id ASC이므로 가장 먼저 생성된 Store 1 부터
+        assertThat(result.getContent().get(0).name()).isEqualTo("Store 1");
+        assertThat(result.getContent().get(19).name()).isEqualTo("Store 20");
+
+        // nextCursor는 21번째 Store의 id
+        assertThat(result.getNextCursor()).isEqualTo(
+            result.getContent().get(19).id() + 1
+        );
     }
 
+    @Test
+    @DisplayName("스토어 이름 검색 - 두 번째 페이지를 cursorId 기준으로 조회한다.")
+    void findByStoreNameWithCursor_secondPage_success() {
+
+        // given
+        String storeName = "Store";
+
+        CursorPagination<StoreInfo> firstPage = storeRepository.findByStoreNameWithCursor(storeName, null);
+        Long cursorId = firstPage.getNextCursor();
+
+        // when
+        CursorPagination<StoreInfo> secondPage = storeRepository.findByStoreNameWithCursor(storeName, cursorId);
+
+        // then
+        assertThat(secondPage.getContent()).hasSize(5);
+        assertThat(secondPage.getHasNext()).isFalse();
+
+        assertThat(secondPage.getContent().get(0).name()).isEqualTo("Store 21");
+        assertThat(secondPage.getContent().get(4).name()).isEqualTo("Store 25");
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public DateTimeProvider dateTimeProvider() {
+            // 항상 mockTime 변수의 값을 현재 시간으로 반환
+            return () -> Optional.of(mockTime);
+        }
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/store/seller/controller/SellerStoreControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/seller/controller/SellerStoreControllerTest.java
@@ -1,0 +1,234 @@
+package com.bbangle.bbangle.store.seller.controller;
+
+import static com.bbangle.bbangle.common.service.ResponseService.CommonResponse.SUCCESS;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
+import com.bbangle.bbangle.common.page.CursorPagination;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.JsonDataEncoder;
+import com.bbangle.bbangle.config.security.SecurityConfig;
+import com.bbangle.bbangle.config.security.SellerApiPath;
+import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.store.domain.StoreStatus;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDetail;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.StoreNameCheck;
+import com.bbangle.bbangle.store.seller.service.SellerStoreService;
+import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo;
+import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo.StoreInfo;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("[컨트롤러 테스트] SellerStoreController")
+@WebMvcTest(controllers = SellerStoreController.class)
+@Import({
+    TestSlackAdaptorConfig.class,
+    JsonDataEncoder.class,
+    TokenProvider.class,
+    TestJwtPropertiesConfig.class,
+    ResponseService.class,
+    SecurityConfig.class
+})
+@ActiveProfiles("test")
+class SellerStoreControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SellerStoreService sellerStoreService;
+
+    @SpyBean
+    private ResponseService responseService;
+
+    @Test
+    @WithMockUser(roles = "SELLER")
+    @DisplayName("스토어 이름으로 스토어 목록을 반환한다.")
+    void success_search() throws Exception {
+
+        // given
+        String storeName = "빵";
+        StoreInfo storeInfo = StoreInfo.builder()
+            .id(1L)
+            .name("빵굽는하루")
+            .isDeleted(false)
+            .status(StoreStatus.NONE)
+            .build();
+
+        CursorPagination<SellerStoreInfo.StoreInfo> pagination = CursorPagination.of(List.of(storeInfo),20, null, StoreInfo::id);
+        given(sellerStoreService.selectStoreNameForSeller(storeName, null)).willReturn(pagination);
+
+        // when & then
+        mockMvc.perform(get(SellerApiPath.PREFIX  + "/stores" + "/search")
+            .param("storeName", storeName))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
+            .andExpect(jsonPath("$.result.content[0].id").value(1L))
+            .andExpect(jsonPath("$.result.content[0].name").value("빵굽는하루"))
+            .andExpect(jsonPath("$.result.content[0].isDeleted").value(false))
+            .andExpect(jsonPath("$.result.content[0].status").value("NONE"))
+            .andExpect(jsonPath("$.result.nextCursor").value(-1L))
+            .andExpect(jsonPath("$.result.hasNext").value(false));
+    }
+
+    @Test
+    @WithMockUser(roles = "SELLER")
+    @DisplayName("스토어 이름과 cursorId로 스토어 목록을 반환한다.")
+    void success_search_cursorId() throws Exception {
+
+        // given
+        String storeName = "빵";
+        Long cursorId = 21L;
+        StoreInfo storeInfo = StoreInfo.builder()
+            .id(21L)
+            .name("빵굽는하루")
+            .isDeleted(false)
+            .status(StoreStatus.NONE)
+            .build();
+
+        CursorPagination<SellerStoreInfo.StoreInfo> pagination =
+            new CursorPagination<>(List.of(storeInfo), -1L, false, null);
+        given(sellerStoreService.selectStoreNameForSeller(storeName, cursorId)).willReturn(pagination);
+
+        // when & then
+        mockMvc.perform(get(SellerApiPath.PREFIX + "/stores" + "/search")
+                .param("storeName", storeName)
+                .param("cursorId", "21"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
+            .andExpect(jsonPath("$.result.content[0].id").value(21L))
+            .andExpect(jsonPath("$.result.content[0].name").value("빵굽는하루"))
+            .andExpect(jsonPath("$.result.content[0].isDeleted").value(false))
+            .andExpect(jsonPath("$.result.content[0].status").value("NONE"))
+            .andExpect(jsonPath("$.result.nextCursor").value(-1L))
+            .andExpect(jsonPath("$.result.hasNext").value(false));
+    }
+
+    @Test
+    @WithMockUser(roles = "SELLER")
+    @DisplayName("storeName이 공백일 경우 400에러를 반환한다.")
+    void failure_search_400() throws Exception {
+
+        mockMvc.perform(get(SellerApiPath.PREFIX + "/stores" + "/search")
+            .param("storeName", "  "))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "SELLER")
+    @DisplayName("조회한 스토어가 존재하지 않을 경우 사용 가능하다.")
+    void success_checkStoreNameDuplicate_notExist_available() throws Exception {
+
+        // given
+        String storeName = "빵";
+        StoreResponse.StoreNameCheck response = StoreNameCheck.builder()
+            .available(true)
+            .store(null)
+            .build();
+
+        // when
+        given(sellerStoreService.checkStoreName(storeName)).willReturn(response);
+
+        // then
+        mockMvc.perform(get(SellerApiPath.PREFIX + "/stores" + "/check-name")
+            .param("storeName", storeName))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
+            .andExpect(jsonPath("$.result.available").value(true))
+            .andExpect(jsonPath("$.result.store").isEmpty());
+    }
+
+    @Test
+    @WithMockUser(roles = "SELLER")
+    @DisplayName("조회한 스토어의 상태가 None일 경우 사용 가능하다.")
+    void success_checkStoreNameDuplicate_statusNone_available() throws Exception {
+
+        // given
+        String storeName = "빵";
+        StoreResponse.SellerStoreDetail sellerStoreDetail =
+            new SellerStoreDetail(1L, "빵긋", "테스트", "test.png", StoreStatus.NONE);
+        StoreResponse.StoreNameCheck response = StoreNameCheck.builder()
+            .available(true)
+            .store(sellerStoreDetail)
+            .build();
+
+        // when
+        given(sellerStoreService.checkStoreName(storeName)).willReturn(response);
+
+        // then
+        mockMvc.perform(get(SellerApiPath.PREFIX + "/stores" + "/check-name")
+                .param("storeName", storeName))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
+            .andExpect(jsonPath("$.result.available").value(true))
+            .andExpect(jsonPath("$.result.store.storeId").value(1L))
+            .andExpect(jsonPath("$.result.store.name").value("빵긋"))
+            .andExpect(jsonPath("$.result.store.introduce").value("테스트"))
+            .andExpect(jsonPath("$.result.store.profile").value("test.png"))
+            .andExpect(jsonPath("$.result.store.status").value("NONE"));
+    }
+
+    @Test
+    @WithMockUser(roles = "SELLER")
+    @DisplayName("조회한 스토어의 상태가 None이 아닐 경우 사용할 수 없다.")
+    void success_checkStoreNameDuplicate_statusNotNone_unavailable() throws Exception {
+
+        // given
+        String storeName = "빵";
+        StoreResponse.SellerStoreDetail sellerStoreDetail =
+            new SellerStoreDetail(1L, "빵긋", "테스트", "test.png", StoreStatus.ACTIVE);
+        StoreResponse.StoreNameCheck response = StoreNameCheck.builder()
+            .available(false)
+            .store(sellerStoreDetail)
+            .build();
+
+        // when
+        given(sellerStoreService.checkStoreName(storeName)).willReturn(response);
+
+        // then
+        mockMvc.perform(get(SellerApiPath.PREFIX + "/stores" + "/check-name")
+                .param("storeName", storeName))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
+            .andExpect(jsonPath("$.result.available").value(false))
+            .andExpect(jsonPath("$.result.store.storeId").value(1L))
+            .andExpect(jsonPath("$.result.store.name").value("빵긋"))
+            .andExpect(jsonPath("$.result.store.introduce").value("테스트"))
+            .andExpect(jsonPath("$.result.store.profile").value("test.png"))
+            .andExpect(jsonPath("$.result.store.status").value("ACTIVE"));
+    }
+
+    @Test
+    @WithMockUser(roles = "SELLER")
+    @DisplayName("storeName이 공백일 경우 400에러를 반환한다.")
+    void failure_checkStoreNameDuplicate_400() throws Exception {
+
+        mockMvc.perform(get(SellerApiPath.PREFIX + "/stores" + "/check-name")
+                .param("storeName", "  "))
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/store/seller/controller/SellerStoreControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/seller/controller/SellerStoreControllerTest.java
@@ -65,7 +65,6 @@ class SellerStoreControllerTest {
         StoreInfo storeInfo = StoreInfo.builder()
             .id(1L)
             .name("빵굽는하루")
-            .status(StoreStatus.NONE)
             .build();
 
         CursorPagination<SellerStoreInfo.StoreInfo> pagination = CursorPagination.of(List.of(storeInfo),20, null, StoreInfo::id);
@@ -80,7 +79,6 @@ class SellerStoreControllerTest {
             .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
             .andExpect(jsonPath("$.result.content[0].id").value(1L))
             .andExpect(jsonPath("$.result.content[0].name").value("빵굽는하루"))
-            .andExpect(jsonPath("$.result.content[0].status").value("NONE"))
             .andExpect(jsonPath("$.result.nextCursor").value(-1L))
             .andExpect(jsonPath("$.result.hasNext").value(false));
     }
@@ -96,7 +94,6 @@ class SellerStoreControllerTest {
         StoreInfo storeInfo = StoreInfo.builder()
             .id(21L)
             .name("빵굽는하루")
-            .status(StoreStatus.NONE)
             .build();
 
         CursorPagination<SellerStoreInfo.StoreInfo> pagination =
@@ -113,7 +110,6 @@ class SellerStoreControllerTest {
             .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
             .andExpect(jsonPath("$.result.content[0].id").value(21L))
             .andExpect(jsonPath("$.result.content[0].name").value("빵굽는하루"))
-            .andExpect(jsonPath("$.result.content[0].status").value("NONE"))
             .andExpect(jsonPath("$.result.nextCursor").value(-1L))
             .andExpect(jsonPath("$.result.hasNext").value(false));
     }

--- a/src/test/java/com/bbangle/bbangle/store/seller/controller/SellerStoreControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/seller/controller/SellerStoreControllerTest.java
@@ -65,7 +65,6 @@ class SellerStoreControllerTest {
         StoreInfo storeInfo = StoreInfo.builder()
             .id(1L)
             .name("빵굽는하루")
-            .isDeleted(false)
             .status(StoreStatus.NONE)
             .build();
 
@@ -81,7 +80,6 @@ class SellerStoreControllerTest {
             .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
             .andExpect(jsonPath("$.result.content[0].id").value(1L))
             .andExpect(jsonPath("$.result.content[0].name").value("빵굽는하루"))
-            .andExpect(jsonPath("$.result.content[0].isDeleted").value(false))
             .andExpect(jsonPath("$.result.content[0].status").value("NONE"))
             .andExpect(jsonPath("$.result.nextCursor").value(-1L))
             .andExpect(jsonPath("$.result.hasNext").value(false));
@@ -98,7 +96,6 @@ class SellerStoreControllerTest {
         StoreInfo storeInfo = StoreInfo.builder()
             .id(21L)
             .name("빵굽는하루")
-            .isDeleted(false)
             .status(StoreStatus.NONE)
             .build();
 
@@ -116,7 +113,6 @@ class SellerStoreControllerTest {
             .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
             .andExpect(jsonPath("$.result.content[0].id").value(21L))
             .andExpect(jsonPath("$.result.content[0].name").value("빵굽는하루"))
-            .andExpect(jsonPath("$.result.content[0].isDeleted").value(false))
             .andExpect(jsonPath("$.result.content[0].status").value("NONE"))
             .andExpect(jsonPath("$.result.nextCursor").value(-1L))
             .andExpect(jsonPath("$.result.hasNext").value(false));

--- a/src/test/java/com/bbangle/bbangle/store/seller/service/SellerStoreServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/seller/service/SellerStoreServiceIntegrationTest.java
@@ -19,12 +19,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-@DisplayName("[통합테스트] StoreIntegrationTest")
+@DisplayName("[통합테스트] SellerStoreService")
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
 public class SellerStoreServiceIntegrationTest {
-
 
     @Autowired
     private SellerStoreService sellerStoreService;
@@ -35,7 +34,6 @@ public class SellerStoreServiceIntegrationTest {
     @Autowired
     private EntityManager em;
 
-
     @BeforeEach
     void setUp() {
         em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
@@ -43,7 +41,7 @@ public class SellerStoreServiceIntegrationTest {
         em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
         em.clear();
 
-        // 검색에 걸리는 스토어명 (LIKE '%빵%')
+        // 검색에 걸리는 스토어명 (LIKE '%빵%') - 21개
         List<String> matchingNames = List.of(
             "빵굽는하루",
             "오늘의빵집",
@@ -54,7 +52,18 @@ public class SellerStoreServiceIntegrationTest {
             "서울빵공작소",
             "빵작업실",
             "엄마의빵집",
-            "따끈한빵하우스"
+            "따끈한빵하우스",
+            "시골빵집",
+            "동네빵집",
+            "프랑스빵집",
+            "착한빵집",
+            "장인빵집",
+            "우리빵집",
+            "맛있는빵집",
+            "수제빵집",
+            "행복한빵집",
+            "아침빵집",
+            "야간빵집"
         );
 
         // 검색에 걸리지 않는 스토어명
@@ -89,48 +98,86 @@ public class SellerStoreServiceIntegrationTest {
         em.clear();
     }
 
-
     @Test
-    @DisplayName("가게 이름 일부를 입력하면 해당하는 가게 이름 목록을 10개 반환한다")
+    @DisplayName("가게 이름 일부를 입력하면 해당하는 가게 이름 목록을 20개 반환한다")
     void selectStoreNameForSeller() {
+
         // given
         String keyword = "빵";
+
         // when
         CursorPagination<StoreInfo> result =
-            sellerStoreService.selectStoreNameForSeller(keyword);
+            sellerStoreService.selectStoreNameForSeller(keyword, null);
+
         // then
-        assertThat(result.getContent().size()).isLessThanOrEqualTo(10);
+        assertThat(result.getContent().size()).isLessThanOrEqualTo(20);
 
         assertThat(result.getContent())
-            .allMatch(info -> info.name().contains(keyword));
+            .allMatch(info ->
+                info.name().replace(" ", "")
+                    .contains(keyword.replace(" ", ""))
+            );
     }
 
     @Test
     @DisplayName("일치하는 가게 이름이 없으면 빈 목록을 반환한다")
     void selectStoreNameForSellerWithNoMatch() {
+
         // given
         String keyword = "NonExistent";
 
         // when
-        var result = sellerStoreService.selectStoreNameForSeller(keyword);
+        var result = sellerStoreService.selectStoreNameForSeller(keyword, null);
 
         // then
         assertThat(result.getContent()).isEmpty();
     }
 
-
     @Test
     @DisplayName("공백있는 문자열이 넘어오면 이를 제거한다")
     void selectStoreNameForSellerWithWhitespace() {
+
         // given
         String keyword = "  빵  ";
 
         // when
-        var result = sellerStoreService.selectStoreNameForSeller(keyword);
+        var result = sellerStoreService.selectStoreNameForSeller(keyword, null);
 
         // then
         assertThat(result.getContent())
-            .allMatch(info -> info.name().contains("빵"));
+            .allMatch(info -> info.name().replace(" ", "").contains("빵"));
     }
 
+    @Test
+    @DisplayName("다음 페이지가 존재하면 hasNext와 nextCursor를 반환한다.")
+    void cursorPagination_hasNext() {
+
+        // given
+        String keyword = " 빵 ";
+
+        // when
+        CursorPagination<StoreInfo> result = sellerStoreService.selectStoreNameForSeller(keyword, null);
+
+        // then
+        assertThat(result.getHasNext()).isTrue();
+        assertThat(result.getNextCursor()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("cursorId 이후 데이터만 조회된다.")
+    void cursorPagination_with_cursorId() {
+
+        // given
+        String keyword = " 빵 ";
+
+        CursorPagination<StoreInfo> firstPage = sellerStoreService.selectStoreNameForSeller(keyword, null);
+        Long cursorId = firstPage.getNextCursor();
+
+        // when
+        CursorPagination<StoreInfo> secondPage = sellerStoreService.selectStoreNameForSeller(keyword, cursorId);
+
+        // then
+        assertThat(secondPage.getContent())
+            .allMatch(info -> info.id() >= cursorId);
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/store/seller/service/SellerStoreServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/seller/service/SellerStoreServiceUnitTest.java
@@ -1,0 +1,124 @@
+package com.bbangle.bbangle.store.seller.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.bbangle.bbangle.common.page.CursorPagination;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.domain.StoreStatus;
+import com.bbangle.bbangle.store.repository.StoreRepository;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDetail;
+import com.bbangle.bbangle.store.seller.controller.mapper.SellerStoreMapper;
+import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo.StoreInfo;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[단위테스트] SellerStoreService")
+@ExtendWith(MockitoExtension.class)
+class SellerStoreServiceUnitTest {
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private SellerStoreMapper sellerStoreMapper;
+
+    @InjectMocks
+    private SellerStoreService sellerStoreService;
+
+    @Test
+    @DisplayName("스토어 이름 검색 시 모든 공백을 제거한 이름으로 조회한다.")
+    void selectStoreNameForSeller_normalizedStoreName() {
+
+        // given
+        String originalStoreName = "   Sto   r  e  Nam   e ";
+        String normalized = "StoreName";
+        Long cursorId = 10L;
+
+        CursorPagination<StoreInfo> mockResult = mock(CursorPagination.class);
+
+        given(storeRepository.findByStoreNameWithCursor(normalized, cursorId)).willReturn(mockResult);
+
+        // when
+        CursorPagination<StoreInfo> result = sellerStoreService.selectStoreNameForSeller(originalStoreName, cursorId);
+
+        // then
+        assertThat(result).isSameAs(mockResult);
+
+        verify(storeRepository).findByStoreNameWithCursor(normalized, cursorId);
+    }
+
+    @Test
+    @DisplayName("스토어가 존재하고 상태가 NONE이면 사용 가능하다.")
+    void checkStoreName_storeExists_available() {
+
+        // given
+        String originalStoreName = "   StoreA ";
+        String normalizedStoreName = "StoreA";
+
+        Store store = Store.createForSeller(normalizedStoreName);
+        SellerStoreDetail detail = mock(SellerStoreDetail.class);
+
+        given(storeRepository.findByStoreNameAndIsNotDeleted(normalizedStoreName)).willReturn(Optional.of(store));
+        given(sellerStoreMapper.toSellerStoreDetail(store)).willReturn(detail);
+
+        // when
+        StoreResponse.StoreNameCheck result = sellerStoreService.checkStoreName(originalStoreName);
+
+        // then
+        assertThat(result.available()).isTrue();
+        assertThat(result.store()).isEqualTo(detail);
+
+        verify(storeRepository).findByStoreNameAndIsNotDeleted(normalizedStoreName);
+        verify(sellerStoreMapper).toSellerStoreDetail(store);
+    }
+
+    @Test
+    @DisplayName("스토어가 존재하지만 상태가 NONE이 아니면 사용 불가")
+    void checkStoreName_storeExists_Unavailable() {
+
+        // given
+        String storeName = "StoreA";
+
+        Store store = Store.createForSeller(storeName);
+        store.changeStatus(StoreStatus.ACTIVE);
+
+        given(storeRepository.findByStoreNameAndIsNotDeleted(storeName)).willReturn(Optional.of(store));
+        given(sellerStoreMapper.toSellerStoreDetail(store)).willReturn(mock(SellerStoreDetail.class));
+
+        // when
+        StoreResponse.StoreNameCheck result = sellerStoreService.checkStoreName(storeName);
+
+        // then
+        assertThat(result.available()).isFalse();
+    }
+
+    @Test
+    @DisplayName("스토어가 존재하지 않으면 사용 가능하고 store는 null을 반환한다.")
+    void checkStoreName_storeNotExists() {
+
+        // given
+        String storeName = "UnknownStore";
+
+        given(storeRepository.findByStoreNameAndIsNotDeleted(storeName)).willReturn(Optional.empty());
+
+        // when
+        StoreResponse.StoreNameCheck result = sellerStoreService.checkStoreName(storeName);
+
+        // then
+        assertThat(result.available()).isTrue();
+        assertThat(result.store()).isNull();
+
+        verify(sellerStoreMapper, never()).toSellerStoreDetail(any());
+    }
+}


### PR DESCRIPTION
## Reviewer
1팀
- @kmindev 경민님
- @MSBANG 민수님

## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
- 연관된 이슈 : #571 
- 스토어 목록 조회
  - [개발 일정](https://www.notion.so/sideproject-unione/1-_-_-2e5622e86d3d80aca935e1ccd82ffb2e?source=copy_link)
  - [API 명세서](https://www.notion.so/sideproject-unione/2d7622e86d3d807689a6ce1e860023cb?v=2c6622e86d3d8157890d000cc857bdd2&source=copy_link)
- 스토어 이름 중복 체크 
  - [개발 일정](https://www.notion.so/sideproject-unione/1-_-_-2f8622e86d3d80cab93edf0ee6040b3b?source=copy_link)
  - [API 명세서](https://www.notion.so/sideproject-unione/2f8622e86d3d8061a734dbd91a3355db?v=2c6622e86d3d8157890d000cc857bdd2&source=copy_link)
## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
- (판매자) 스토어 목록 조회
- (판매자) 스토어 중복 체크

파라미터를 통해 스토어 이름을 입력 받으면 `storeId`와 `storeName`을 List로 만들어서 응답합니다.
이 때, 프론트에서 파라미터를 전송할 때 빈칸을 제거하고 전송해야합니다.
만일을 대비해서 서버 내에서 한번 더 빈칸을 제거합니다.

스토어 중복 체크 시에는 앞뒤 공백만 제거하고 전송해야합니다.

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->
- 스토어 목록 조회
<img width="717" height="208" alt="image" src="https://github.com/user-attachments/assets/d7b079fd-48ef-4eaa-af3c-3953817ec15c" />
<img width="193" height="616" alt="image" src="https://github.com/user-attachments/assets/95f51ea3-85c0-4299-ab0b-cf915ba16bf5" />

- 스토어 중복 체크
<img width="718" height="173" alt="image" src="https://github.com/user-attachments/assets/8fda97d6-6f96-4c7c-ac70-6d2eacc7df29" />
<img width="483" height="234" alt="image" src="https://github.com/user-attachments/assets/6ac76388-a9e1-4c8b-8a16-00ebd54232bd" />


## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 스토어명 기반 검색에 커서 기반 페이징 도입
  * 스토어명 중복 확인 응답에 가용 여부와 상점 요약 정보 추가

* **개선사항**
  * 검색 파라미터 검증 강화(빈값 차단, 공백 무시 매칭 안내)
  * 검색/응답 DTO 간소화 및 응답 형태 정비 (결과 항목 축소 및 필드 정리)
  * 체크명 엔드포인트 경로 및 응답 형식 개선 (/check-name)

* **테스트**
  * 컨트롤러·서비스 통합·단위 테스트 확장으로 검색·페이징 동작 검증 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->