### PR TITLE
[Refactor] (판매자) 발주확인 API 판매자 소유 검증 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import java.util.stream.Stream;
@@ -106,6 +107,7 @@ public enum BbangleErrorCode {
     ACCOUNT_NOT_VERIFIED(-715, "인증되지 않은 계좌입니다.", BAD_REQUEST),
     ORDER_NOT_FOUND(-716, "존재하지 않는 주문입니다.", NOT_FOUND),
     ORDER_ITEM_NOT_FOUND(-717, "존재하지 않는 주문상품입니다.", NOT_FOUND),
+    ORDER_ACCESS_DENIED(-718, "해당 주문에 대한 접근 권한이 없습니다.", FORBIDDEN),
 
     // Store Error (721~740)
     INVALID_STORE(-721, "유효하지 않은 스토어 객체입니다.", BAD_REQUEST),

--- a/src/main/java/com/bbangle/bbangle/order/controller/swagger/SellerOrderApi.java
+++ b/src/main/java/com/bbangle/bbangle/order/controller/swagger/SellerOrderApi.java
@@ -27,7 +27,6 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Seller Order", description = "(판매자) 주문 API")
@@ -179,7 +178,7 @@ public interface SellerOrderApi {
         @Valid
         OrderRequest.OrderSearchRequest request);
 
-    @PostMapping("/{orderId}/confirm")
+    @Operation(summary = "(판매자) 발주 확인")
     SingleResult<OrderConfirmResponse> confirmOrder(
         @AuthenticationPrincipal Long sellerId,
         @PathVariable Long orderId,

--- a/src/main/java/com/bbangle/bbangle/order/domain/Order.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/Order.java
@@ -42,15 +42,14 @@ public class Order extends BaseEntity{
     private String buyerSubPhone;
 
     @Column(name = "delivery_fee")
-    private int deliveryFee;
+    private Integer deliveryFee;
 
     @Column(name = "total_amount")
-    private int totalAmount;
+    private Integer totalAmount;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
-
 
 
 }

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -30,13 +30,13 @@ public class OrderItem extends BaseEntity {
     private Long id;
 
     @Column(name = "quantity")
-    private int quantity;
+    private Integer quantity;
 
     @Column(name = "product_price")
-    private int productPrice;
+    private Integer productPrice;
 
     @Column(name = "unit_price")
-    private int unitPrice;
+    private Integer unitPrice;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "order_status", columnDefinition = "VARCHAR(20)")
@@ -47,7 +47,7 @@ public class OrderItem extends BaseEntity {
     private OrderDeliveryStatus orderDeliveryStatus;
 
     @Column(name = "total_price")
-    private int totalPrice;
+    private Integer totalPrice;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id")

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderItemRepository.java
@@ -3,8 +3,24 @@ package com.bbangle.bbangle.order.repository;
 import com.bbangle.bbangle.order.domain.OrderItem;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
 
     List<OrderItem> findByOrderIdAndIdIn(Long orderId, List<Long> ids);
+
+    @Query(value = """
+        SELECT COUNT(*)
+        FROM order_item oi
+        JOIN product p ON p.id = oi.product_id
+        WHERE oi.order_id = :orderId
+          AND oi.id IN (:orderItemIds)
+          AND p.store_id = :storeId
+        """, nativeQuery = true)
+    long countOwnedOrderItems(
+        @Param("orderId") Long orderId,
+        @Param("orderItemIds") List<Long> orderItemIds,
+        @Param("storeId") Long storeId
+    );
 }

--- a/src/main/java/com/bbangle/bbangle/order/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/service/SellerOrderService.java
@@ -25,6 +25,14 @@ public class SellerOrderService {
     @Transactional
     public OrderConfirmResponse confirmOrder(OrderConfirmCommand command) {
 
+        if (command.orderItemIds() == null || command.orderItemIds().isEmpty()) {
+            throw new BbangleException(BbangleErrorCode.ORDER_ITEM_NOT_FOUND);
+        }
+
+        List<Long> uniqueOrderItemIds = command.orderItemIds().stream()
+            .distinct()
+            .toList();
+
         Order order = orderRepository.findById(command.orderId())
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
 
@@ -35,17 +43,17 @@ public class SellerOrderService {
 
         long ownedCount = orderItemRepository.countOwnedOrderItems(
             order.getId(),
-            command.orderItemIds(),
+            uniqueOrderItemIds,
             storeId
         );
 
-        if (ownedCount != command.orderItemIds().size()) {
+        if (ownedCount != uniqueOrderItemIds.size()) {
             throw new BbangleException(BbangleErrorCode.ORDER_ACCESS_DENIED);
         }
 
         List<OrderItem> orderItems = orderItemRepository.findByOrderIdAndIdIn(
             order.getId(),
-            command.orderItemIds()
+            uniqueOrderItemIds
         );
 
         List<Long> confirmedOrderItemIds = orderItems.stream()

--- a/src/main/java/com/bbangle/bbangle/order/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/service/SellerOrderService.java
@@ -8,6 +8,7 @@ import com.bbangle.bbangle.order.domain.OrderItem;
 import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.order.repository.OrderRepository;
 import com.bbangle.bbangle.order.service.model.SellerOrderCommand.OrderConfirmCommand;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,12 +20,28 @@ public class SellerOrderService {
 
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
+    private final SellerRepository sellerRepository;
 
     @Transactional
     public OrderConfirmResponse confirmOrder(OrderConfirmCommand command) {
 
         Order order = orderRepository.findById(command.orderId())
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
+
+        Long storeId = sellerRepository.findStoreIdBySellerId(command.sellerId());
+        if (storeId == null) {
+            throw new BbangleException(BbangleErrorCode.SELLER_NOT_FOUND);
+        }
+
+        long ownedCount = orderItemRepository.countOwnedOrderItems(
+            order.getId(),
+            command.orderItemIds(),
+            storeId
+        );
+
+        if (ownedCount != command.orderItemIds().size()) {
+            throw new BbangleException(BbangleErrorCode.ORDER_ACCESS_DENIED);
+        }
 
         List<OrderItem> orderItems = orderItemRepository.findByOrderIdAndIdIn(
             order.getId(),

--- a/src/main/java/com/bbangle/bbangle/order/service/model/SellerOrderCommand.java
+++ b/src/main/java/com/bbangle/bbangle/order/service/model/SellerOrderCommand.java
@@ -7,9 +7,9 @@ public class SellerOrderCommand {
 
     @Builder
     public record OrderConfirmCommand(
-        Long sellerId,
         Long orderId,
-        List<Long> orderItemIds
+        List<Long> orderItemIds,
+        Long sellerId
     ) {
     }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/repository/SellerRepository.java
+++ b/src/main/java/com/bbangle/bbangle/seller/repository/SellerRepository.java
@@ -2,6 +2,11 @@ package com.bbangle.bbangle.seller.repository;
 
 import com.bbangle.bbangle.seller.domain.Seller;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SellerRepository extends JpaRepository<Seller, Long> {
+
+    @Query("select s.store.id from Seller s where s.id = :sellerId")
+    Long findStoreIdBySellerId(@Param("sellerId") Long sellerId);
 }

--- a/src/main/resources/flyway/V31__app.sql
+++ b/src/main/resources/flyway/V31__app.sql
@@ -1,0 +1,12 @@
+ALTER TABLE product ADD COLUMN store_id BIGINT;
+
+UPDATE product p
+JOIN product_board pb ON pb.id = p.product_board_id
+SET p.store_id = pb.store_id
+WHERE p.store_id IS NULL;
+
+ALTER TABLE product MODIFY store_id BIGINT NOT NULL;
+
+ALTER TABLE product
+ADD CONSTRAINT fk_product_store
+FOREIGN KEY (store_id) REFERENCES store(id);


### PR DESCRIPTION
## History
- 리뷰어 : 형재님, 현호님
- 연관된 이슈 : #573 #504 

## 🚀 Major Changes & Explanations
- product.store_id 컬럼 및 FK 추가
- 발주확인 API 판매자 소유 검증 로직 추가

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->
- 정상 케이스: 판매자 소유 주문상품만 발주확인 → 200 응답
<img width="1434" height="759" alt="image" src="https://github.com/user-attachments/assets/7fdfd888-c35d-42de-9feb-174de417f55a" />
<img width="1391" height="262" alt="image" src="https://github.com/user-attachments/assets/84ba5731-569e-4e73-b2ea-d9375b5e8aa6" />

- 실패 케이스: 타 스토어 주문상품 포함 → 403 (ORDER_ACCESS_DENIED)
<img width="1450" height="755" alt="image" src="https://github.com/user-attachments/assets/5c16c0b3-2e14-4184-9df8-0a9c9a530cfc" />
<img width="1394" height="223" alt="image" src="https://github.com/user-attachments/assets/18faf21f-3a77-4e8a-9fdd-ae79afbdf214" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 판매자의 주문 확인 시 접근 권한 검증 추가 — 자신의 스토어에 속하지 않은 주문은 확인할 수 없습니다.
  * 접근 거부 상황에 대한 명확한 오류 응답 추가.

* **Refactor**
  * 주문 및 주문항목의 숫자 필드 null 처리 개선으로 데이터 유연성 향상.
  * 상품 테이블에 스토어 연계 칼럼 추가 및 제약조건 강화로 DB 무결성 향상.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->