### PR TITLE
[Feature] (판매자) 계좌인증 API

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -109,6 +109,8 @@ public enum BbangleErrorCode {
     ORDER_NOT_FOUND(-716, "존재하지 않는 주문입니다.", NOT_FOUND),
     ORDER_ITEM_NOT_FOUND(-717, "존재하지 않는 주문상품입니다.", NOT_FOUND),
     ORDER_ACCESS_DENIED(-718, "해당 주문에 대한 접근 권한이 없습니다.", FORBIDDEN),
+    ENCRYPTION_FAILED(-719, "암호화 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    DECRYPTION_FAILED(-720, "복호화 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // Store Error (721~740)
     INVALID_STORE(-721, "유효하지 않은 스토어 객체입니다.", BAD_REQUEST),

--- a/src/main/java/com/bbangle/bbangle/seller/domain/AccountVerification.java
+++ b/src/main/java/com/bbangle/bbangle/seller/domain/AccountVerification.java
@@ -24,8 +24,8 @@ public class AccountVerification extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "bank_name", columnDefinition = "VARCHAR(50)")
-    private String bankName;
+    @Column(name = "bank_code", columnDefinition = "VARCHAR(10)")
+    private String bankCode;
 
     @Column(name = "account_number", columnDefinition = "VARBINARY(255)")
     private String accountNumber;
@@ -40,12 +40,17 @@ public class AccountVerification extends BaseEntity {
     @JoinColumn(name = "seller_id")
     private Seller seller;
 
-    public AccountVerification(String bankName, String accountNumber, String accountHolder, boolean verified,
-                               Seller seller) {
-        this.bankName = bankName;
-        this.accountNumber = accountNumber;
+    private AccountVerification(String bankCode, String encryptedAccountNumber, String accountHolder,
+                                boolean verified, Seller seller) {
+        this.bankCode = bankCode;
+        this.accountNumber = encryptedAccountNumber;
         this.accountHolder = accountHolder;
         this.verified = verified;
         this.seller = seller;
+    }
+
+    public static AccountVerification create(String bankCode, String encryptedAccountNumber,
+                                             String accountHolder, boolean verified, Seller seller) {
+        return new AccountVerification(bankCode, encryptedAccountNumber, accountHolder, verified, seller);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/seller/controller/SellerController.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/controller/SellerController.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.seller.seller.controller;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.SellerApiPath;
+import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.AccountVerificationRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerAccountUpdateRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerCreateRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerDocumentsRegisterRequest;
@@ -10,7 +11,9 @@ import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerStor
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerUpdateRequest;
 import com.bbangle.bbangle.seller.seller.controller.swagger.SellerApi;
 import com.bbangle.bbangle.seller.seller.facade.SellerFacade;
+import com.bbangle.bbangle.seller.seller.service.AccountVerificationService;
 import com.bbangle.bbangle.seller.seller.service.SellerService;
+import com.bbangle.bbangle.seller.seller.service.info.AccountVerificationInfo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -34,6 +37,7 @@ public class SellerController implements SellerApi {
     private final ResponseService responseService;
     private final SellerService sellerService;
     private final SellerFacade sellerFacade;
+    private final AccountVerificationService accountVerificationService;
 
     @PostMapping(value = "/documents", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public CommonResult registerDocuments(
@@ -87,9 +91,14 @@ public class SellerController implements SellerApi {
     }
 
 
+    @PostMapping("/account-verifications")
     @Override
-    public CommonResult accountVerification(String accountNumber, String sellerName) {
-        return responseService.getSuccessResult();
+    public CommonResult accountVerification(
+        @RequestBody @Valid AccountVerificationRequest request,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        AccountVerificationInfo info = accountVerificationService.verifyAccount(request.toCommand(sellerId));
+        return responseService.getSingleResult(info);
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/seller/seller/controller/dto/SellerRequest.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/controller/dto/SellerRequest.java
@@ -4,6 +4,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.bbangle.bbangle.seller.seller.facade.command.RegisterDocumentsCommand;
 import com.bbangle.bbangle.seller.seller.service.command.SellerCreateCommand;
+import com.bbangle.bbangle.seller.seller.service.command.VerifyAccountCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -15,6 +16,22 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Builder
 public class SellerRequest {
+
+    @Schema(description = "계좌 인증 요청 DTO")
+    public record AccountVerificationRequest(
+        @Schema(description = "은행코드 (토스페이먼츠 표준)", example = "92")
+        @NotBlank(message = "은행코드는 필수입니다.")
+        String bankCode,
+
+        @Schema(description = "계좌번호", example = "123412341234")
+        @NotBlank(message = "계좌번호는 필수입니다.")
+        String accountNumber
+    ) {
+
+        public VerifyAccountCommand toCommand(Long sellerId) {
+            return new VerifyAccountCommand(sellerId, bankCode, accountNumber);
+        }
+    }
 
     public record SellerDocumentsRegisterRequest(
         @Schema(description = "사업자 등록증", requiredMode = REQUIRED, type = "string", format = "binary")

--- a/src/main/java/com/bbangle/bbangle/seller/seller/controller/swagger/SellerApi.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/controller/swagger/SellerApi.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.seller.seller.controller.swagger;
 
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.exception.GlobalControllerAdvice;
+import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.AccountVerificationRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerAccountUpdateRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerCreateRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerDocumentsRegisterRequest;
@@ -147,9 +148,12 @@ public interface SellerApi {
 
     @Operation(
         summary = "계좌 인증",
-        description = "판매자의 계좌를 인증합니다, 외부 Open API spec에 따라 변경가능성이 있습니다."
+        description = """
+            판매자의 계좌를 인증합니다.
+            - 토스페이먼츠 표준 은행코드를 사용합니다.
+            - PG 계약 이슈로 API가 변경될 수 있습니다.
+            """
     )
-
     @ApiResponses(value = {
         @ApiResponse(
             responseCode = "200",
@@ -161,10 +165,16 @@ public interface SellerApi {
                     summary = "성공응답 예시",
                     value = """
                         {
-                            "success" : true,
-                            "code" : 0,
-                            "message" : "SUCCESS"
-                        } 
+                            "success": true,
+                            "code": 0,
+                            "message": "SUCCESS",
+                            "result": {
+                                "id": 1,
+                                "sellerId": 1,
+                                "verified": true,
+                                "createdAt": "2025-12-10T14:32:10"
+                            }
+                        }
                         """
                 )
             )
@@ -178,7 +188,7 @@ public interface SellerApi {
         )
     })
     CommonResult accountVerification(
-        String accountNumber,
-        String sellerName);
+        @RequestBody AccountVerificationRequest request,
+        @AuthenticationPrincipal Long sellerId);
 
 }

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationService.java
@@ -2,10 +2,17 @@ package com.bbangle.bbangle.seller.seller.service;
 
 import static com.bbangle.bbangle.exception.BbangleErrorCode.ACCOUNT_NOT_VERIFIED;
 import static com.bbangle.bbangle.exception.BbangleErrorCode.ACCOUNT_VERIFICATION_NOT_FOUND;
+import static com.bbangle.bbangle.exception.BbangleErrorCode.SELLER_NOT_FOUND;
 
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.domain.AccountVerification;
+import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.repository.AccountVerificationRepository;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
+import com.bbangle.bbangle.seller.seller.service.client.AccountVerificationClient;
+import com.bbangle.bbangle.seller.seller.service.command.VerifyAccountCommand;
+import com.bbangle.bbangle.seller.seller.service.info.AccountVerificationInfo;
+import com.bbangle.bbangle.util.AesEncryptionUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +23,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class AccountVerificationService {
 
     private final AccountVerificationRepository accountVerificationRepository;
+    private final SellerRepository sellerRepository;
+    private final AccountVerificationClient accountVerificationClient;
+    private final AesEncryptionUtil aesEncryptionUtil;
 
     public void confirmAccount(Long accountVerificationId) {
         AccountVerification accountVerification = accountVerificationRepository.findById(accountVerificationId)
@@ -24,5 +34,31 @@ public class AccountVerificationService {
         if (!accountVerification.isVerified()) {
             throw new BbangleException(ACCOUNT_NOT_VERIFIED);
         }
+    }
+
+    @Transactional
+    public AccountVerificationInfo verifyAccount(VerifyAccountCommand command) {
+        Seller seller = sellerRepository.findById(command.sellerId())
+            .orElseThrow(() -> new BbangleException(SELLER_NOT_FOUND));
+
+        String accountHolder = accountVerificationClient.verifyAccount(
+            command.bankCode(),
+            command.accountNumber()
+        );
+
+        boolean verified = accountHolder != null && !accountHolder.isEmpty();
+        String encryptedAccountNumber = aesEncryptionUtil.encrypt(command.accountNumber());
+
+        AccountVerification accountVerification = AccountVerification.create(
+            command.bankCode(),
+            encryptedAccountNumber,
+            accountHolder,
+            verified,
+            seller
+        );
+
+        AccountVerification saved = accountVerificationRepository.save(accountVerification);
+
+        return AccountVerificationInfo.from(saved);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationService.java
@@ -57,8 +57,8 @@ public class AccountVerificationService {
             seller
         );
 
-        AccountVerification saved = accountVerificationRepository.save(accountVerification);
+        accountVerificationRepository.save(accountVerification);
 
-        return AccountVerificationInfo.from(saved);
+        return AccountVerificationInfo.from(accountVerification);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationService.java
@@ -57,8 +57,6 @@ public class AccountVerificationService {
             seller
         );
 
-        accountVerificationRepository.save(accountVerification);
-
-        return AccountVerificationInfo.from(accountVerification);
+        return AccountVerificationInfo.from(accountVerificationRepository.save(accountVerification));
     }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/client/AccountVerificationClient.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/client/AccountVerificationClient.java
@@ -1,0 +1,6 @@
+package com.bbangle.bbangle.seller.seller.service.client;
+
+public interface AccountVerificationClient {
+
+    String verifyAccount(String bankCode, String accountNumber);
+}

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/client/TossAccountVerificationClient.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/client/TossAccountVerificationClient.java
@@ -1,0 +1,14 @@
+package com.bbangle.bbangle.seller.seller.service.client;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class TossAccountVerificationClient implements AccountVerificationClient {
+
+    @Override
+    public String verifyAccount(String bankCode, String accountNumber) {
+        // TODO: 토스페이먼츠 API 연동 후 실제 구현 예정
+        // 현재는 Fake 예금주명 반환
+        return "테스트예금주";
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/command/VerifyAccountCommand.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/command/VerifyAccountCommand.java
@@ -1,0 +1,9 @@
+package com.bbangle.bbangle.seller.seller.service.command;
+
+public record VerifyAccountCommand(
+    Long sellerId,
+    String bankCode,
+    String accountNumber
+) {
+
+}

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/info/AccountVerificationInfo.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/info/AccountVerificationInfo.java
@@ -1,0 +1,30 @@
+package com.bbangle.bbangle.seller.seller.service.info;
+
+import com.bbangle.bbangle.seller.domain.AccountVerification;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "계좌 인증 응답")
+public record AccountVerificationInfo(
+    @Schema(description = "계좌인증 ID", example = "1")
+    Long id,
+
+    @Schema(description = "판매자 ID", example = "1")
+    Long sellerId,
+
+    @Schema(description = "계좌인증 성공 여부", example = "true")
+    boolean verified,
+
+    @Schema(description = "생성 일시", example = "2025-12-10T14:32:10")
+    LocalDateTime createdAt
+) {
+
+    public static AccountVerificationInfo from(AccountVerification accountVerification) {
+        return new AccountVerificationInfo(
+            accountVerification.getId(),
+            accountVerification.getSeller().getId(),
+            accountVerification.isVerified(),
+            accountVerification.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/util/AesEncryptionUtil.java
+++ b/src/main/java/com/bbangle/bbangle/util/AesEncryptionUtil.java
@@ -1,0 +1,59 @@
+package com.bbangle.bbangle.util;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AesEncryptionUtil {
+
+    private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
+    private static final String AES = "AES";
+
+    private final SecretKeySpec secretKeySpec;
+    private final IvParameterSpec ivParameterSpec;
+
+    public AesEncryptionUtil(@Value("${encryption.aes.secret-key}") String secretKey) {
+        byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
+        if (keyBytes.length != 16 && keyBytes.length != 24 && keyBytes.length != 32) {
+            throw new IllegalArgumentException("AES key must be 16, 24, or 32 bytes");
+        }
+        this.secretKeySpec = new SecretKeySpec(keyBytes, AES);
+        this.ivParameterSpec = new IvParameterSpec(keyBytes, 0, 16);
+    }
+
+    public String encrypt(String plainText) {
+        if (plainText == null || plainText.isEmpty()) {
+            return plainText;
+        }
+        try {
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, ivParameterSpec);
+            byte[] encrypted = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (Exception e) {
+            throw new BbangleException(BbangleErrorCode.ENCRYPTION_FAILED);
+        }
+    }
+
+    public String decrypt(String encryptedText) {
+        if (encryptedText == null || encryptedText.isEmpty()) {
+            return encryptedText;
+        }
+        try {
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivParameterSpec);
+            byte[] decoded = Base64.getDecoder().decode(encryptedText);
+            byte[] decrypted = cipher.doFinal(decoded);
+            return new String(decrypted, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new BbangleException(BbangleErrorCode.DECRYPTION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/util/AesEncryptionUtil.java
+++ b/src/main/java/com/bbangle/bbangle/util/AesEncryptionUtil.java
@@ -3,9 +3,11 @@ package com.bbangle.bbangle.util;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.Base64;
 import javax.crypto.Cipher;
-import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -13,11 +15,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class AesEncryptionUtil {
 
-    private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
     private static final String AES = "AES";
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH = 128;
 
     private final SecretKeySpec secretKeySpec;
-    private final IvParameterSpec ivParameterSpec;
+    private final SecureRandom secureRandom;
 
     public AesEncryptionUtil(@Value("${encryption.aes.secret-key}") String secretKey) {
         byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
@@ -25,7 +29,7 @@ public class AesEncryptionUtil {
             throw new IllegalArgumentException("AES key must be 16, 24, or 32 bytes");
         }
         this.secretKeySpec = new SecretKeySpec(keyBytes, AES);
-        this.ivParameterSpec = new IvParameterSpec(keyBytes, 0, 16);
+        this.secureRandom = new SecureRandom();
     }
 
     public String encrypt(String plainText) {
@@ -33,10 +37,19 @@ public class AesEncryptionUtil {
             return plainText;
         }
         try {
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            secureRandom.nextBytes(iv);
+
             Cipher cipher = Cipher.getInstance(ALGORITHM);
-            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, ivParameterSpec);
+            GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH, iv);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, gcmParameterSpec);
             byte[] encrypted = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
-            return Base64.getEncoder().encodeToString(encrypted);
+
+            byte[] combined = new byte[iv.length + encrypted.length];
+            System.arraycopy(iv, 0, combined, 0, iv.length);
+            System.arraycopy(encrypted, 0, combined, iv.length, encrypted.length);
+
+            return Base64.getEncoder().encodeToString(combined);
         } catch (Exception e) {
             throw new BbangleException(BbangleErrorCode.ENCRYPTION_FAILED);
         }
@@ -47,11 +60,16 @@ public class AesEncryptionUtil {
             return encryptedText;
         }
         try {
+            byte[] combined = Base64.getDecoder().decode(encryptedText);
+
+            byte[] iv = Arrays.copyOfRange(combined, 0, GCM_IV_LENGTH);
+            byte[] encrypted = Arrays.copyOfRange(combined, GCM_IV_LENGTH, combined.length);
+
             Cipher cipher = Cipher.getInstance(ALGORITHM);
-            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivParameterSpec);
-            byte[] decoded = Base64.getDecoder().decode(encryptedText);
-            byte[] decrypted = cipher.doFinal(decoded);
-            return new String(decrypted, StandardCharsets.UTF_8);
+            GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH, iv);
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, gcmParameterSpec);
+
+            return new String(cipher.doFinal(encrypted), StandardCharsets.UTF_8);
         } catch (Exception e) {
             throw new BbangleException(BbangleErrorCode.DECRYPTION_FAILED);
         }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -115,3 +115,7 @@ springdoc:
 app:
   cookie:
     domain: ${COOKIE_DOMAIN}
+
+encryption:
+  aes:
+    secret-key: ${AES_SECRET_KEY}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -115,3 +115,7 @@ slack:
 app:
   cookie:
     domain: ${COOKIE_DOMAIN}
+
+encryption:
+  aes:
+    secret-key: ${AES_SECRET_KEY}

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -116,3 +116,7 @@ management:
     health:
       probes:
         enabled: true
+
+encryption:
+  aes:
+    secret-key: ${AES_SECRET_KEY}

--- a/src/main/resources/flyway/V32__app.sql
+++ b/src/main/resources/flyway/V32__app.sql
@@ -1,0 +1,2 @@
+-- account_verifications 테이블의 bank_name 컬럼을 bank_code로 변경
+ALTER TABLE account_verifications CHANGE COLUMN bank_name bank_code VARCHAR(10);

--- a/src/test/java/com/bbangle/bbangle/seller/domain/AccountVerificationUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/domain/AccountVerificationUnitTest.java
@@ -1,0 +1,59 @@
+package com.bbangle.bbangle.seller.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[단위 테스트] AccountVerification")
+@ExtendWith(MockitoExtension.class)
+class AccountVerificationUnitTest {
+
+    @Mock
+    private Seller seller;
+
+    @Test
+    @DisplayName("계좌 인증 정보 생성에 성공한다")
+    void success_create_account_verification() {
+        // arrange
+        String bankCode = "92";
+        String encryptedAccountNumber = "encryptedValue123";
+        String accountHolder = "홍길동";
+        boolean verified = true;
+
+        // act
+        AccountVerification accountVerification = AccountVerification.create(
+            bankCode, encryptedAccountNumber, accountHolder, verified, seller
+        );
+
+        // assert
+        assertThat(accountVerification).isNotNull();
+        assertThat(accountVerification.getBankCode()).isEqualTo(bankCode);
+        assertThat(accountVerification.getAccountNumber()).isEqualTo(encryptedAccountNumber);
+        assertThat(accountVerification.getAccountHolder()).isEqualTo(accountHolder);
+        assertThat(accountVerification.isVerified()).isTrue();
+        assertThat(accountVerification.getSeller()).isEqualTo(seller);
+    }
+
+    @Test
+    @DisplayName("미인증 상태의 계좌 인증 정보 생성에 성공한다")
+    void success_create_unverified_account_verification() {
+        // arrange
+        String bankCode = "88";
+        String encryptedAccountNumber = "encryptedValue456";
+        String accountHolder = "김철수";
+        boolean verified = false;
+
+        // act
+        AccountVerification accountVerification = AccountVerification.create(
+            bankCode, encryptedAccountNumber, accountHolder, verified, seller
+        );
+
+        // assert
+        assertThat(accountVerification).isNotNull();
+        assertThat(accountVerification.isVerified()).isFalse();
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationServiceIntegrationTest.java
@@ -119,9 +119,9 @@ class AccountVerificationServiceIntegrationTest {
      * 테스트용 AccountVerification 생성 헬퍼 메서드
      */
     private AccountVerification createAccountVerification(Seller seller, boolean verified) {
-        AccountVerification accountVerification = new AccountVerification(
-            "테스트은행",
-            "1234567890",
+        AccountVerification accountVerification = AccountVerification.create(
+            "92",
+            "encryptedAccountNumber",
             "홍길동",
             verified,
             seller

--- a/src/test/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.seller.seller.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -10,6 +11,8 @@ import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import com.bbangle.bbangle.seller.repository.AccountVerificationRepository;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
+import com.bbangle.bbangle.seller.seller.service.command.VerifyAccountCommand;
+import com.bbangle.bbangle.seller.seller.service.info.AccountVerificationInfo;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.repository.StoreRepository;
 import jakarta.persistence.EntityManager;
@@ -113,6 +116,43 @@ class AccountVerificationServiceIntegrationTest {
         // act & assert
         assertThatThrownBy(() -> accountVerificationService.confirmAccount(null))
             .isInstanceOf(Exception.class);
+    }
+
+    @Test
+    @DisplayName("계좌 인증 요청이 성공한다")
+    void success_verify_account() {
+        // arrange
+        Seller seller = sellerRepository.findById(testSeller.getId()).orElseThrow();
+        VerifyAccountCommand command = new VerifyAccountCommand(
+            seller.getId(),
+            "92",
+            "123412341234"
+        );
+
+        // act
+        AccountVerificationInfo result = accountVerificationService.verifyAccount(command);
+
+        // assert
+        assertThat(result).isNotNull();
+        assertThat(result.sellerId()).isEqualTo(seller.getId());
+        assertThat(result.verified()).isTrue();
+        assertThat(result.createdAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 판매자로 계좌 인증 요청 시 예외가 발생한다")
+    void fail_verify_account_with_non_existent_seller() {
+        // arrange
+        VerifyAccountCommand command = new VerifyAccountCommand(
+            99999L,
+            "92",
+            "123412341234"
+        );
+
+        // act & assert
+        assertThatThrownBy(() -> accountVerificationService.verifyAccount(command))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.SELLER_NOT_FOUND.getMessage());
     }
 
     /**

--- a/src/test/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/service/AccountVerificationServiceUnitTest.java
@@ -1,0 +1,151 @@
+package com.bbangle.bbangle.seller.seller.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.seller.domain.AccountVerification;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.repository.AccountVerificationRepository;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
+import com.bbangle.bbangle.seller.seller.service.client.AccountVerificationClient;
+import com.bbangle.bbangle.seller.seller.service.command.VerifyAccountCommand;
+import com.bbangle.bbangle.seller.seller.service.info.AccountVerificationInfo;
+import com.bbangle.bbangle.util.AesEncryptionUtil;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[단위 테스트] AccountVerificationService")
+@ExtendWith(MockitoExtension.class)
+class AccountVerificationServiceUnitTest {
+
+    @InjectMocks
+    private AccountVerificationService accountVerificationService;
+
+    @Mock
+    private AccountVerificationRepository accountVerificationRepository;
+
+    @Mock
+    private SellerRepository sellerRepository;
+
+    @Mock
+    private AccountVerificationClient accountVerificationClient;
+
+    @Mock
+    private AesEncryptionUtil aesEncryptionUtil;
+
+    @Mock
+    private Seller seller;
+
+    @Mock
+    private AccountVerification accountVerification;
+
+    @Test
+    @DisplayName("계좌 인증 요청이 성공한다")
+    void success_verify_account() {
+        // arrange
+        Long sellerId = 1L;
+        String bankCode = "92";
+        String accountNumber = "123412341234";
+        String encryptedAccountNumber = "encryptedValue";
+        String accountHolder = "홍길동";
+
+        VerifyAccountCommand command = new VerifyAccountCommand(sellerId, bankCode, accountNumber);
+
+        given(sellerRepository.findById(sellerId)).willReturn(Optional.of(seller));
+        given(accountVerificationClient.verifyAccount(bankCode, accountNumber)).willReturn(accountHolder);
+        given(aesEncryptionUtil.encrypt(accountNumber)).willReturn(encryptedAccountNumber);
+        given(accountVerificationRepository.save(any(AccountVerification.class)))
+            .willReturn(accountVerification);
+        given(accountVerification.getId()).willReturn(1L);
+        given(accountVerification.getSeller()).willReturn(seller);
+        given(accountVerification.isVerified()).willReturn(true);
+        given(accountVerification.getCreatedAt()).willReturn(null);
+        given(seller.getId()).willReturn(sellerId);
+
+        // act
+        AccountVerificationInfo result = accountVerificationService.verifyAccount(command);
+
+        // assert
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(1L);
+        assertThat(result.sellerId()).isEqualTo(sellerId);
+        assertThat(result.verified()).isTrue();
+
+        verify(sellerRepository).findById(sellerId);
+        verify(accountVerificationClient).verifyAccount(bankCode, accountNumber);
+        verify(aesEncryptionUtil).encrypt(accountNumber);
+        verify(accountVerificationRepository).save(any(AccountVerification.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 판매자로 인해 계좌 인증이 실패한다")
+    void fail_verify_account_with_non_existent_seller() {
+        // arrange
+        Long sellerId = 999L;
+        VerifyAccountCommand command = new VerifyAccountCommand(sellerId, "92", "123412341234");
+
+        given(sellerRepository.findById(sellerId)).willReturn(Optional.empty());
+
+        // act & assert
+        assertThatThrownBy(() -> accountVerificationService.verifyAccount(command))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.SELLER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("인증된 계좌 확인에 성공한다")
+    void success_confirm_verified_account() {
+        // arrange
+        Long accountVerificationId = 1L;
+
+        given(accountVerificationRepository.findById(accountVerificationId))
+            .willReturn(Optional.of(accountVerification));
+        given(accountVerification.isVerified()).willReturn(true);
+
+        // act & assert
+        accountVerificationService.confirmAccount(accountVerificationId);
+
+        verify(accountVerificationRepository).findById(accountVerificationId);
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 계좌 확인 시 예외가 발생한다")
+    void fail_confirm_unverified_account() {
+        // arrange
+        Long accountVerificationId = 1L;
+
+        given(accountVerificationRepository.findById(accountVerificationId))
+            .willReturn(Optional.of(accountVerification));
+        given(accountVerification.isVerified()).willReturn(false);
+
+        // act & assert
+        assertThatThrownBy(() -> accountVerificationService.confirmAccount(accountVerificationId))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.ACCOUNT_NOT_VERIFIED.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 계좌 인증 ID로 확인 시 예외가 발생한다")
+    void fail_confirm_with_non_existent_id() {
+        // arrange
+        Long accountVerificationId = 999L;
+
+        given(accountVerificationRepository.findById(accountVerificationId))
+            .willReturn(Optional.empty());
+
+        // act & assert
+        assertThatThrownBy(() -> accountVerificationService.confirmAccount(accountVerificationId))
+            .isInstanceOf(BbangleException.class)
+            .hasMessageContaining(BbangleErrorCode.ACCOUNT_VERIFICATION_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/util/AesEncryptionUtilTest.java
+++ b/src/test/java/com/bbangle/bbangle/util/AesEncryptionUtilTest.java
@@ -1,0 +1,94 @@
+package com.bbangle.bbangle.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[단위 테스트] AesEncryptionUtil")
+class AesEncryptionUtilTest {
+
+    private AesEncryptionUtil aesEncryptionUtil;
+
+    @BeforeEach
+    void setUp() {
+        String testSecretKey = "1234567890123456";
+        aesEncryptionUtil = new AesEncryptionUtil(testSecretKey);
+    }
+
+    @Test
+    @DisplayName("평문 암호화에 성공한다")
+    void success_encrypt_plain_text() {
+        // arrange
+        String plainText = "123412341234";
+
+        // act
+        String encrypted = aesEncryptionUtil.encrypt(plainText);
+
+        // assert
+        assertThat(encrypted).isNotNull();
+        assertThat(encrypted).isNotEqualTo(plainText);
+    }
+
+    @Test
+    @DisplayName("암호문 복호화에 성공한다")
+    void success_decrypt_encrypted_text() {
+        // arrange
+        String plainText = "123412341234";
+        String encrypted = aesEncryptionUtil.encrypt(plainText);
+
+        // act
+        String decrypted = aesEncryptionUtil.decrypt(encrypted);
+
+        // assert
+        assertThat(decrypted).isEqualTo(plainText);
+    }
+
+    @Test
+    @DisplayName("null 값 암호화 시 null을 반환한다")
+    void return_null_when_encrypt_null() {
+        // act
+        String result = aesEncryptionUtil.encrypt(null);
+
+        // assert
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("빈 문자열 암호화 시 빈 문자열을 반환한다")
+    void return_empty_when_encrypt_empty_string() {
+        // act
+        String result = aesEncryptionUtil.encrypt("");
+
+        // assert
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("암호화/복호화 라운드트립 테스트")
+    void success_round_trip_encryption() {
+        // arrange
+        String accountNumber = "1234567890123456";
+
+        // act
+        String encrypted = aesEncryptionUtil.encrypt(accountNumber);
+        String decrypted = aesEncryptionUtil.decrypt(encrypted);
+
+        // assert
+        assertThat(decrypted).isEqualTo(accountNumber);
+    }
+
+    @Test
+    @DisplayName("잘못된 키 길이로 인스턴스 생성 시 예외가 발생한다")
+    void fail_create_with_invalid_key_length() {
+        // arrange
+        String invalidKey = "short";
+
+        // act & assert
+        assertThatThrownBy(() -> new AesEncryptionUtil(invalidKey))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("AES key must be 16, 24, or 32 bytes");
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/util/AesEncryptionUtilTest.java
+++ b/src/test/java/com/bbangle/bbangle/util/AesEncryptionUtilTest.java
@@ -91,4 +91,20 @@ class AesEncryptionUtilTest {
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("AES key must be 16, 24, or 32 bytes");
     }
+
+    @Test
+    @DisplayName("같은 평문을 암호화해도 매번 다른 암호문이 생성된다")
+    void success_encrypt_produces_different_ciphertext_each_time() {
+        // arrange
+        String plainText = "123412341234";
+
+        // act
+        String encrypted1 = aesEncryptionUtil.encrypt(plainText);
+        String encrypted2 = aesEncryptionUtil.encrypt(plainText);
+
+        // assert
+        assertThat(encrypted1).isNotEqualTo(encrypted2);
+        assertThat(aesEncryptionUtil.decrypt(encrypted1)).isEqualTo(plainText);
+        assertThat(aesEncryptionUtil.decrypt(encrypted2)).isEqualTo(plainText);
+    }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -61,3 +61,7 @@ logging:
 jwt:
   issuer: testStore53525
   secret_key: testKey123443555
+
+encryption:
+  aes:
+    secret-key: 1234567890123456


### PR DESCRIPTION
## Reviewer
1팀
- @kmindev 경민님

## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->
- 연관된 이슈 : #578 
## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
- (판매자) 계좌정보 인증 

- 기존 은행 이름 방식에서 은행 코드 방식으로 변경 (API 연동 표준화 및 정확성 향상)                                                                   
- 계좌번호는 AES-256 양방향 암호화하여 DB에 저장 (정산 등 필요 시 복호화하여 사용)     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 판매자 계좌 검증 엔드포인트 추가 및 외부 계좌조회 연동 포인트 도입
  * AES 암호화 유틸리티 및 암호화/복호화 오류 코드 추가

* **개선사항**
  * 요청 필드 표준화: 은행명→은행코드(bankCode)로 변경 및 생성 팩토리 도입
  * 검증 결과를 반환하는 응답 포맷 강화

* **테스트**
  * 계좌 검증 및 암호화 유틸 관련 단·통합 테스트 추가

* **DB 마이그레이션**
  * 계좌 테이블 컬럼명 변경 마이그레이션 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->