### PR TITLE
[Feature] (판매자) 발주확인 API 응답 구조 개선 및 테스트 보완

### DIFF
--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/response/SellerOrderResponse.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/response/SellerOrderResponse.java
@@ -10,21 +10,73 @@ public class SellerOrderResponse {
     @Schema(description = "판매자 주문상품 발주 확인 응답 DTO")
     public record OrderConfirmResponse(
 
-        @Schema(description = "주문 ID")
-        Long orderId,
-
-        @Schema(description = "발주 확인 완료된 주문상품 ID 목록")
-        List<Long> confirmedOrderItemIds
+        @Schema(description = "발주 확인 결과 컨텐츠")
+        Content content
 
     ) {
 
-        public static OrderConfirmResponse of(
-            Long orderId,
-            List<Long> confirmedOrderItemIds
-        ) {
+        public static OrderConfirmResponse of(Content content) {
             return OrderConfirmResponse.builder()
+                .content(content)
+                .build();
+        }
+    }
+
+    @Builder
+    @Schema(description = "발주 확인 응답 컨텐츠")
+    public record Content(
+
+        @Schema(description = "주문 ID")
+        Long orderId,
+
+        @Schema(description = "발주 확인 요약 정보")
+        Summary summary,
+
+        @Schema(description = "발주 확인 완료된 주문상품 ID 목록")
+        List<Long> confirmedOrderItemIds,
+
+        @Schema(description = "발주 확인 실패한 주문상품 ID 목록")
+        List<Long> failedOrderItemIds
+
+    ) {
+        public static Content of(
+            Long orderId,
+            Summary summary,
+            List<Long> confirmedOrderItemIds,
+            List<Long> failedOrderItemIds
+        ) {
+            return Content.builder()
                 .orderId(orderId)
+                .summary(summary)
                 .confirmedOrderItemIds(confirmedOrderItemIds)
+                .failedOrderItemIds(failedOrderItemIds)
+                .build();
+        }
+    }
+
+    @Builder
+    @Schema(description = "발주 확인 요약 정보")
+    public record Summary(
+
+        @Schema(description = "요청한 주문상품 수")
+        int requestedCount,
+
+        @Schema(description = "발주 확인 성공 수")
+        int successCount,
+
+        @Schema(description = "발주 확인 실패 수")
+        int failCount
+
+    ) {
+        public static Summary of(
+            int requestedCount,
+            int successCount,
+            int failCount
+        ) {
+            return Summary.builder()
+                .requestedCount(requestedCount)
+                .successCount(successCount)
+                .failCount(failCount)
                 .build();
         }
     }

--- a/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
@@ -6,6 +6,7 @@ import com.bbangle.bbangle.order.domain.Order;
 import com.bbangle.bbangle.order.domain.OrderItem;
 import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.order.repository.OrderRepository;
+import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderConfirmCommand;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
@@ -33,6 +34,8 @@ public class SellerOrderService {
             .distinct()
             .toList();
 
+        int requestedCount = uniqueOrderItemIds.size();
+
         Order order = orderRepository.findById(command.orderId())
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
 
@@ -56,11 +59,39 @@ public class SellerOrderService {
             uniqueOrderItemIds
         );
 
-        List<Long> confirmedOrderItemIds = orderItems.stream()
-            .filter(OrderItem::confirmOrder)
+        java.util.Set<Long> foundIds = orderItems.stream()
             .map(OrderItem::getId)
+            .collect(java.util.stream.Collectors.toSet());
+
+        List<Long> notFoundIds = uniqueOrderItemIds.stream()
+            .filter(id -> !foundIds.contains(id))
             .toList();
 
-        return OrderConfirmResponse.of(order.getId(), confirmedOrderItemIds);
+        List<Long> confirmedOrderItemIds = new java.util.ArrayList<>();
+        List<Long> failedOrderItemIds = new java.util.ArrayList<>(notFoundIds);
+
+        for (OrderItem orderItem : orderItems) {
+            if (orderItem.confirmOrder()) {
+                confirmedOrderItemIds.add(orderItem.getId());
+            } else {
+                failedOrderItemIds.add(orderItem.getId());
+            }
+        }
+
+        int successCount = confirmedOrderItemIds.size();
+        int failCount = failedOrderItemIds.size();
+
+        SellerOrderResponse.Summary summary =
+            SellerOrderResponse.Summary.of(requestedCount, successCount, failCount);
+
+        SellerOrderResponse.Content content =
+            SellerOrderResponse.Content.of(
+                order.getId(),
+                summary,
+                confirmedOrderItemIds,
+                failedOrderItemIds
+            );
+
+        return OrderConfirmResponse.of(content);
     }
 }

--- a/src/test/java/com/bbangle/bbangle/order/seller/controller/SellerOrderControllerSliceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/controller/SellerOrderControllerSliceTest.java
@@ -23,6 +23,7 @@ import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.exception.GlobalControllerAdvice;
 import com.bbangle.bbangle.order.seller.controller.dto.request.SellerOrderRequest.OrderConfirmRequest;
+import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
 import com.bbangle.bbangle.order.seller.service.SellerOrderService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -77,8 +78,15 @@ class SellerOrderControllerSliceTest {
 
         OrderConfirmRequest request = new OrderConfirmRequest(List.of(100L, 101L, 102L));
 
-        // 부분 성공 정책 예시: 100, 102만 확정됨
-        OrderConfirmResponse serviceResponse = OrderConfirmResponse.of(orderId, List.of(100L, 102L));
+        // 부분 성공 정책 예시: 100, 102만 확정됨 (101은 실패)
+        SellerOrderResponse.Summary summary = SellerOrderResponse.Summary.of(3, 2, 1);
+        SellerOrderResponse.Content content = SellerOrderResponse.Content.of(
+            orderId,
+            summary,
+            List.of(100L, 102L),  // confirmedOrderItemIds
+            List.of(101L)          // failedOrderItemIds
+        );
+        OrderConfirmResponse serviceResponse = OrderConfirmResponse.of(content);
 
         given(sellerOrderService.confirmOrder(any())).willReturn(serviceResponse);
 
@@ -96,9 +104,13 @@ class SellerOrderControllerSliceTest {
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
             .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
-            .andExpect(jsonPath("$.result.orderId").value(orderId))
-            .andExpect(jsonPath("$.result.confirmedOrderItemIds[0]").value(100))
-            .andExpect(jsonPath("$.result.confirmedOrderItemIds[1]").value(102));
+            .andExpect(jsonPath("$.result.content.orderId").value(orderId))
+            .andExpect(jsonPath("$.result.content.summary.requestedCount").value(3))
+            .andExpect(jsonPath("$.result.content.summary.successCount").value(2))
+            .andExpect(jsonPath("$.result.content.summary.failCount").value(1))
+            .andExpect(jsonPath("$.result.content.confirmedOrderItemIds[0]").value(100))
+            .andExpect(jsonPath("$.result.content.confirmedOrderItemIds[1]").value(102))
+            .andExpect(jsonPath("$.result.content.failedOrderItemIds[0]").value(101));
 
         then(sellerOrderService).should(times(1)).confirmOrder(any());
         then(responseService).should(times(1)).getSingleResult(serviceResponse);
@@ -140,7 +152,7 @@ class SellerOrderControllerSliceTest {
     void givenEmptyOrderItemIds_whenConfirmOrder_thenReturns400() throws Exception {
         // Given
         Long orderId = 10L;
-        OrderConfirmRequest request = new OrderConfirmRequest(List.of()); // @NotEmpty 위반
+        OrderConfirmRequest request = new OrderConfirmRequest(List.of());
 
         // When & Then
         mvc.perform(post("/api/v1/seller/orders/{orderId}/confirm", orderId)

--- a/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceTest.java
@@ -15,6 +15,7 @@ import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.order.repository.OrderRepository;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderConfirmCommand;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
 import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Optional;
@@ -39,13 +40,16 @@ class SellerOrderServiceTest {
     @Mock
     private OrderItemRepository orderItemRepository;
 
+    @Mock
+    private SellerRepository sellerRepository;
+
     @DisplayName("주문이 존재하지 않으면 ORDER_NOT_FOUND 예외가 발생한다.")
     @Test
     void givenNonExistingOrderId_whenConfirmOrder_thenThrowsException() {
         // given
         Long orderId = 999L;
         OrderConfirmCommand command = OrderConfirmCommand.builder()
-            .sellerId(1L) // 지금은 검증 안 해도 command 형태 맞추려고 넣어둠
+            .sellerId(1L)
             .orderId(orderId)
             .orderItemIds(List.of(1L, 2L))
             .build();
@@ -61,11 +65,13 @@ class SellerOrderServiceTest {
         assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_NOT_FOUND);
     }
 
-    @DisplayName("결제 완료(PAYMENT_COMPLETED)인 주문상품만 발주확인(ORDER_CONFIRMED)되고, 나머지는 부분 성공으로 스킵된다.")
+    @DisplayName("결제 완료(PAYMENT_COMPLETED)인 주문상품만 발주확인(ORDER_CONFIRMED)되며, 성공/실패 결과가 요약 정보로 반환된다.")
     @Test
     void givenMixedOrderItems_whenConfirmOrder_thenConfirmOnlyPaymentCompleted() {
         // given
         Long orderId = 1L;
+        Long sellerId = 1L;
+        Long storeId = 100L;
 
         Order order = newEntity(Order.class);
         ReflectionTestUtils.setField(order, "id", orderId);
@@ -77,16 +83,19 @@ class SellerOrderServiceTest {
 
         OrderItem skipItem = newEntity(OrderItem.class);
         ReflectionTestUtils.setField(skipItem, "id", 11L);
-        ReflectionTestUtils.setField(skipItem, "orderStatus", OrderStatus.ORDER_CONFIRMED); // 이미 확정된 상태라고 가정
+        ReflectionTestUtils.setField(skipItem, "orderStatus", OrderStatus.ORDER_CONFIRMED);
         ReflectionTestUtils.setField(skipItem, "order", order);
 
         OrderConfirmCommand command = OrderConfirmCommand.builder()
-            .sellerId(1L)
+            .sellerId(sellerId)
             .orderId(orderId)
             .orderItemIds(List.of(10L, 11L))
             .build();
 
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(sellerRepository.findStoreIdBySellerId(sellerId)).willReturn(storeId);
+        given(orderItemRepository.countOwnedOrderItems(orderId, List.of(10L, 11L), storeId))
+            .willReturn(2L);
         given(orderItemRepository.findByOrderIdAndIdIn(orderId, List.of(10L, 11L)))
             .willReturn(List.of(okItem, skipItem));
 
@@ -95,18 +104,60 @@ class SellerOrderServiceTest {
 
         // then
         then(orderRepository).should(times(1)).findById(orderId);
+        then(sellerRepository).should(times(1)).findStoreIdBySellerId(sellerId);
+        then(orderItemRepository).should(times(1)).countOwnedOrderItems(orderId, List.of(10L, 11L), storeId);
         then(orderItemRepository).should(times(1)).findByOrderIdAndIdIn(orderId, List.of(10L, 11L));
 
-        // 응답 검증: PAYMENT_COMPLETED였던 것만 포함
         assertThat(result).isNotNull();
-        assertThat(result.orderId()).isEqualTo(orderId);
-        assertThat(result.confirmedOrderItemIds())
+        assertThat(result.content()).isNotNull();
+        assertThat(result.content().orderId()).isEqualTo(orderId);
+        assertThat(result.content().summary()).isNotNull();
+        assertThat(result.content().summary().requestedCount()).isEqualTo(2);
+        assertThat(result.content().summary().successCount()).isEqualTo(1);
+        assertThat(result.content().summary().failCount()).isEqualTo(1);
+        assertThat(result.content().confirmedOrderItemIds())
             .asList()
             .containsExactly(10L);
+        assertThat(result.content().failedOrderItemIds())
+            .asList()
+            .containsExactly(11L);
 
         // 상태 변경 검증
         assertThat(okItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED);
-        assertThat(skipItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED); // 원래부터 confirmed였으면 그대로
+        assertThat(skipItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED);
+    }
+
+    @DisplayName("주문상품이 판매자 소유가 아니면 ORDER_ACCESS_DENIED 예외가 발생한다.")
+    @Test
+    void givenOrderItemNotOwnedBySeller_whenConfirmOrder_thenThrowsAccessDeniedException() {
+        // given
+        Long orderId = 1L;
+        Long sellerId = 1L;
+        Long storeId = 100L;
+
+        Order order = newEntity(Order.class);
+        ReflectionTestUtils.setField(order, "id", orderId);
+
+        OrderConfirmCommand command = OrderConfirmCommand.builder()
+            .sellerId(sellerId)
+            .orderId(orderId)
+            .orderItemIds(List.of(10L, 11L))
+            .build();
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(sellerRepository.findStoreIdBySellerId(sellerId)).willReturn(storeId);
+        given(orderItemRepository.countOwnedOrderItems(orderId, List.of(10L, 11L), storeId))
+            .willReturn(1L); // 2개 요청했지만 1개만 소유 → 접근 거부
+
+        // when
+        BbangleException result = assertThrows(BbangleException.class,
+            () -> sut.confirmOrder(command));
+
+        // then
+        then(orderRepository).should(times(1)).findById(orderId);
+        then(sellerRepository).should(times(1)).findStoreIdBySellerId(sellerId);
+        then(orderItemRepository).should(times(1)).countOwnedOrderItems(orderId, List.of(10L, 11L), storeId);
+        assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_ACCESS_DENIED);
     }
 
     private <T> T newEntity(Class<T> clazz) {


### PR DESCRIPTION
## History
- 연관된 이슈 : #577 #573 #504 

## 🚀 Major Changes & Explanations
- 발주확인 API 응답 구조 개선
- SellerOrderService 단위 테스트 보완

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->
- 발주확인 성공
<img width="902" height="412" alt="image" src="https://github.com/user-attachments/assets/016fe15a-0809-4954-b30e-aa7db5cefa6d" />
<img width="868" height="329" alt="image" src="https://github.com/user-attachments/assets/4811450f-c331-4071-a7ab-154387a0047d" />

- 부분 성공
<img width="911" height="430" alt="image" src="https://github.com/user-attachments/assets/28ebc367-f862-433e-8d7a-bffde51c25f8" />
<img width="864" height="352" alt="image" src="https://github.com/user-attachments/assets/cf2863c6-6e48-4202-9d4a-b113f6f78fa0" />

- 판매자 불일치 케이스
<img width="909" height="428" alt="image" src="https://github.com/user-attachments/assets/b3c25256-d990-458c-b85f-7bca2ba0bd9f" />
<img width="872" height="221" alt="image" src="https://github.com/user-attachments/assets/fa0d446a-6b58-4ccd-94b6-c45ecddce6cc" />

- 테스트 코드
<img width="969" height="160" alt="image" src="https://github.com/user-attachments/assets/f5eeedbf-5fe1-4ab3-a042-862eadf8774d" />


## 💡 ETC
- 로컬 테스트 수행 결과: SellerOrderServiceTest 포함 전체 테스트 통과 확인





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 판매자 주문 확인 응답에 처리 결과 요약 정보 추가 (요청된 항목, 성공한 항목, 실패한 항목의 개수)
  * 확인되지 않은 주문 항목 ID를 명시적으로 별도 리스트로 제공

* **Tests**
  * 판매자 접근 권한 검증 로직에 대한 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->