### PR TITLE
[Feat] 판매자 주문 운송장 입력 API 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/delivery/domain/Receiver.java
+++ b/src/main/java/com/bbangle/bbangle/delivery/domain/Receiver.java
@@ -11,22 +11,37 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public class Receiver {
 
-    @Column(length = 20)
+    @Column(name = "recipient_name", length = 20)
     private String recipientName;
 
-    @Column(length = 20)
+    @Column(name = "recipient_phone1", length = 20)
     private String recipientPhone1;
 
-    @Column(length = 20)
+    @Column(name = "recipient_phone2", length = 20)
     private String recipientPhone2;
 
-    @Column(length = 200)
+    @Column(name = "recipient_address", length = 200)
     private String recipientAddress;
 
-    @Column(length = 200)
+    @Column(name = "recipient_address_detail", length = 200)
     private String recipientAddressDetail;
 
-    @Column(length = 10)
+    @Column(name = "recipient_zip_code", length = 10)
     private String recipientZipCode;
+
+    private Receiver(String recipientName, String recipientPhone1, String recipientPhone2,
+                     String recipientAddress, String recipientAddressDetail, String recipientZipCode) {
+        this.recipientName = recipientName;
+        this.recipientPhone1 = recipientPhone1;
+        this.recipientPhone2 = recipientPhone2;
+        this.recipientAddress = recipientAddress;
+        this.recipientAddressDetail = recipientAddressDetail;
+        this.recipientZipCode = recipientZipCode;
+    }
+
+    public static Receiver of(String name, String phone1, String phone2,
+                              String address, String addressDetail, String zipCode) {
+        return new Receiver(name, phone1, phone2, address, addressDetail, zipCode);
+    }
 
 }

--- a/src/main/java/com/bbangle/bbangle/delivery/domain/Sender.java
+++ b/src/main/java/com/bbangle/bbangle/delivery/domain/Sender.java
@@ -11,19 +11,33 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public class Sender {
 
-    @Column(length = 20)
+    @Column(name = "sender_name", length = 20)
     private String senderName;
 
-    @Column(length = 20)
+    @Column(name = "sender_phone", length = 20)
     private String senderPhone;
 
-    @Column(length = 200)
+    @Column(name = "sender_address", length = 200)
     private String senderAddress;
 
-    @Column(length = 200)
+    @Column(name = "sender_address_detail", length = 200)
     private String senderAddressDetail;
 
-    @Column(length = 10)
+    @Column(name = "sender_zip_code", length = 10)
     private String senderZipCode;
+
+    private Sender(String senderName, String senderPhone, String senderAddress,
+                   String senderAddressDetail, String senderZipCode) {
+        this.senderName = senderName;
+        this.senderPhone = senderPhone;
+        this.senderAddress = senderAddress;
+        this.senderAddressDetail = senderAddressDetail;
+        this.senderZipCode = senderZipCode;
+    }
+
+    public static Sender of(String name, String phone, String address,
+                            String addressDetail, String zipCode) {
+        return new Sender(name, phone, address, addressDetail, zipCode);
+    }
 
 }

--- a/src/main/java/com/bbangle/bbangle/delivery/domain/Shipping.java
+++ b/src/main/java/com/bbangle/bbangle/delivery/domain/Shipping.java
@@ -12,18 +12,42 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public class Shipping {
 
-    @Column(length = 255)
-    private String deliveryMemo;
-
-    @Column(length = 50)
+    @Column(name = "courier_name", length = 50)
     private String courierName;
 
-    @Column(length = 50)
+    @Column(name = "tracking_number", length = 50)
     private String trackingNumber;
 
+    @Column(name = "shipped_at")
+    private LocalDateTime shippedAt;
+
+    @Column(name = "delivered_at")
+    private LocalDateTime deliveredAt;
+
+    @Column(name = "fee")
     private Integer fee;
 
-    private LocalDateTime shippedAt;
-    private LocalDateTime deliveredAt;
+    @Column(name = "delivery_memo", length = 255)
+    private String deliveryMemo;
+
+    private Shipping(String courierName, String trackingNumber, LocalDateTime shippedAt) {
+        this.courierName = courierName;
+        this.trackingNumber = trackingNumber;
+        this.shippedAt = shippedAt;
+    }
+
+    public static Shipping of(String courierName, String trackingNumber) {
+        return new Shipping(courierName, trackingNumber, LocalDateTime.now());
+    }
+
+    public static Shipping empty() {
+        return new Shipping(null, null, null);
+    }
+
+    public void updateShippingInfo(String courierName, String trackingNumber) {
+        this.courierName = courierName;
+        this.trackingNumber = trackingNumber;
+        this.shippedAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderDelivery.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderDelivery.java
@@ -29,6 +29,7 @@ public class OrderDelivery extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
 
     @Embedded
@@ -41,11 +42,34 @@ public class OrderDelivery extends BaseEntity {
     private Shipping shipping;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", columnDefinition = "VARCHAR(20)")
+    @Column(name = "status", length = 30)
     private OrderDeliveryStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_item_id")
     private OrderItem orderItem;
+
+    private OrderDelivery(Sender sender, Receiver receiver, Shipping shipping,
+                          OrderDeliveryStatus status, OrderItem orderItem) {
+        this.sender = sender;
+        this.receiver = receiver;
+        this.shipping = shipping;
+        this.status = status;
+        this.orderItem = orderItem;
+    }
+
+    public static OrderDelivery create(Sender sender, Receiver receiver, Shipping shipping,
+                                       OrderDeliveryStatus status, OrderItem orderItem) {
+        return new OrderDelivery(sender, receiver, shipping, status, orderItem);
+    }
+
+    public void registerShipment(String courierName, String trackingNumber) {
+        if (this.shipping == null) {
+            this.shipping = Shipping.of(courierName, trackingNumber);
+        } else {
+            this.shipping.updateShippingInfo(courierName, trackingNumber);
+        }
+        this.status = OrderDeliveryStatus.DELIVERING;
+    }
 
 }

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -65,5 +65,9 @@ public class OrderItem extends BaseEntity {
         return true;
     }
 
+    public void shipOrder() {
+        this.orderStatus = OrderStatus.SHIPPED;
+    }
+
 
 }

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderDeliveryRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderDeliveryRepository.java
@@ -1,0 +1,18 @@
+package com.bbangle.bbangle.order.repository;
+
+import com.bbangle.bbangle.order.domain.OrderDelivery;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OrderDeliveryRepository extends JpaRepository<OrderDelivery, Long> {
+
+    @Query("SELECT od FROM OrderDelivery od WHERE od.orderItem.id = :orderItemId")
+    Optional<OrderDelivery> findByOrderItemId(@Param("orderItemId") Long orderItemId);
+
+    @Query("SELECT od FROM OrderDelivery od JOIN FETCH od.orderItem WHERE od.orderItem.id IN :orderItemIds")
+    List<OrderDelivery> findByOrderItemIdIn(@Param("orderItemIds") List<Long> orderItemIds);
+
+}

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderItemRepository.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.order.repository;
 
 import com.bbangle.bbangle.order.domain.OrderItem;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +10,12 @@ import org.springframework.data.repository.query.Param;
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
 
     List<OrderItem> findByOrderIdAndIdIn(Long orderId, List<Long> ids);
+
+    @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.order WHERE oi.id = :id")
+    Optional<OrderItem> findByIdWithOrder(@Param("id") Long id);
+
+    @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.order WHERE oi.order.id = :orderId AND oi.id IN :ids")
+    List<OrderItem> findByOrderIdAndIdInWithOrder(@Param("orderId") Long orderId, @Param("ids") List<Long> ids);
 
     @Query(value = """
         SELECT COUNT(*)

--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/SellerOrderApi.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/SellerOrderApi.java
@@ -13,6 +13,7 @@ import com.bbangle.bbangle.order.seller.controller.dto.response.OrderDetailRespo
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse.OrderItemDetailResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse.OrderSearchResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
+import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.ShipmentRegisterResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -183,5 +184,12 @@ public interface SellerOrderApi {
         @AuthenticationPrincipal Long sellerId,
         @PathVariable Long orderId,
         @Valid @RequestBody SellerOrderRequest.OrderConfirmRequest request
+    );
+
+    @Operation(summary = "(판매자) 운송장 입력")
+    SingleResult<ShipmentRegisterResponse> registerShipment(
+        @AuthenticationPrincipal Long sellerId,
+        @PathVariable Long orderId,
+        @Valid @RequestBody SellerOrderRequest.ShipmentRegisterRequest request
     );
 }

--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/SellerOrderController.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/SellerOrderController.java
@@ -13,6 +13,7 @@ import com.bbangle.bbangle.order.seller.controller.dto.response.OrderDetailRespo
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse.OrderItemDetailResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse.OrderSearchResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
+import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.ShipmentRegisterResponse;
 import com.bbangle.bbangle.order.seller.service.SellerOrderService;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
@@ -164,6 +165,16 @@ public class SellerOrderController implements SellerOrderApi {
         @Valid @RequestBody SellerOrderRequest.OrderConfirmRequest request
     ) {
         var result = sellerOrderService.confirmOrder(request.toCommand(sellerId, orderId));
+        return responseService.getSingleResult(result);
+    }
+
+    @PostMapping("/{orderId}/shipment")
+    public SingleResult<ShipmentRegisterResponse> registerShipment(
+        @AuthenticationPrincipal Long sellerId,
+        @PathVariable Long orderId,
+        @Valid @RequestBody SellerOrderRequest.ShipmentRegisterRequest request
+    ) {
+        var result = sellerOrderService.registerShipment(request.toCommand(sellerId, orderId));
         return responseService.getSingleResult(result);
     }
 

--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/request/SellerOrderRequest.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/request/SellerOrderRequest.java
@@ -1,7 +1,9 @@
 package com.bbangle.bbangle.order.seller.controller.dto.request;
 
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderConfirmCommand;
+import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentRegisterCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
@@ -21,6 +23,34 @@ public class SellerOrderRequest {
                 .sellerId(sellerId)
                 .orderId(orderId)
                 .orderItemIds(orderItemIds)
+                .build();
+        }
+    }
+
+    @Schema(description = "판매자 운송장 정보 등록 요청 DTO")
+    public record ShipmentRegisterRequest(
+
+        @Schema(description = "운송장 등록 대상 주문상품 ID 목록")
+        @NotEmpty(message = "orderItemIds는 필수입니다.")
+        List<Long> orderItemIds,
+
+        @Schema(description = "택배사명", example = "CJ대한통운")
+        @NotBlank(message = "택배사명은 필수입니다.")
+        String courierName,
+
+        @Schema(description = "운송장번호", example = "1234567890")
+        @NotBlank(message = "운송장번호는 필수입니다.")
+        String trackingNumber
+
+    ) {
+
+        public ShipmentRegisterCommand toCommand(Long sellerId, Long orderId) {
+            return ShipmentRegisterCommand.builder()
+                .sellerId(sellerId)
+                .orderId(orderId)
+                .orderItemIds(orderItemIds)
+                .courierName(courierName)
+                .trackingNumber(trackingNumber)
                 .build();
         }
     }

--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/response/SellerOrderResponse.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/response/SellerOrderResponse.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.order.seller.controller.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 
@@ -25,6 +26,48 @@ public class SellerOrderResponse {
             return OrderConfirmResponse.builder()
                 .orderId(orderId)
                 .confirmedOrderItemIds(confirmedOrderItemIds)
+                .build();
+        }
+    }
+
+    @Builder
+    @Schema(description = "판매자 운송장 정보 등록 응답 DTO")
+    public record ShipmentRegisterResponse(
+
+        @Schema(description = "주문 ID")
+        Long orderId,
+
+        @Schema(description = "운송장 등록 성공한 주문상품 ID 목록")
+        List<Long> successOrderItemIds,
+
+        @Schema(description = "운송장 등록 실패한 주문상품 ID 목록")
+        List<Long> failedOrderItemIds,
+
+        @Schema(description = "택배사명")
+        String courierName,
+
+        @Schema(description = "운송장번호")
+        String trackingNumber,
+
+        @Schema(description = "출고 일시")
+        LocalDateTime shippedAt
+
+    ) {
+        public static ShipmentRegisterResponse of(
+            Long orderId,
+            List<Long> successOrderItemIds,
+            List<Long> failedOrderItemIds,
+            String courierName,
+            String trackingNumber,
+            LocalDateTime shippedAt
+        ) {
+            return ShipmentRegisterResponse.builder()
+                .orderId(orderId)
+                .successOrderItemIds(successOrderItemIds)
+                .failedOrderItemIds(failedOrderItemIds)
+                .courierName(courierName)
+                .trackingNumber(trackingNumber)
+                .shippedAt(shippedAt)
                 .build();
         }
     }

--- a/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
@@ -1,16 +1,30 @@
 package com.bbangle.bbangle.order.seller.service;
 
+import com.bbangle.bbangle.delivery.domain.Receiver;
+import com.bbangle.bbangle.delivery.domain.Sender;
+import com.bbangle.bbangle.delivery.domain.Shipping;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderDelivery;
 import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
+import com.bbangle.bbangle.order.repository.OrderDeliveryRepository;
 import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.order.repository.OrderRepository;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
+import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.ShipmentRegisterResponse;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderConfirmCommand;
+import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentRegisterCommand;
+import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,11 +34,11 @@ public class SellerOrderService {
 
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
+    private final OrderDeliveryRepository orderDeliveryRepository;
     private final SellerRepository sellerRepository;
 
     @Transactional
     public OrderConfirmResponse confirmOrder(OrderConfirmCommand command) {
-
         if (command.orderItemIds() == null || command.orderItemIds().isEmpty()) {
             throw new BbangleException(BbangleErrorCode.ORDER_ITEM_NOT_FOUND);
         }
@@ -36,20 +50,8 @@ public class SellerOrderService {
         Order order = orderRepository.findById(command.orderId())
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
 
-        Long storeId = sellerRepository.findStoreIdBySellerId(command.sellerId());
-        if (storeId == null) {
-            throw new BbangleException(BbangleErrorCode.SELLER_NOT_FOUND);
-        }
-
-        long ownedCount = orderItemRepository.countOwnedOrderItems(
-            order.getId(),
-            uniqueOrderItemIds,
-            storeId
-        );
-
-        if (ownedCount != uniqueOrderItemIds.size()) {
-            throw new BbangleException(BbangleErrorCode.ORDER_ACCESS_DENIED);
-        }
+        Long storeId = getStoreIdOrThrow(command.sellerId());
+        assertOwnedOrderItems(order.getId(), uniqueOrderItemIds, storeId);
 
         List<OrderItem> orderItems = orderItemRepository.findByOrderIdAndIdIn(
             order.getId(),
@@ -62,5 +64,124 @@ public class SellerOrderService {
             .toList();
 
         return OrderConfirmResponse.of(order.getId(), confirmedOrderItemIds);
+    }
+
+    @Transactional
+    public ShipmentRegisterResponse registerShipment(ShipmentRegisterCommand command) {
+        // 1. orderItemIds null/empty 체크
+        if (command.orderItemIds() == null || command.orderItemIds().isEmpty()) {
+            throw new BbangleException(BbangleErrorCode.ORDER_ITEM_NOT_FOUND);
+        }
+
+        // 2. 중복 제거
+        List<Long> uniqueOrderItemIds = command.orderItemIds().stream()
+            .distinct()
+            .toList();
+
+        // 3. 주문 조회
+        Order order = orderRepository.findById(command.orderId())
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
+
+        // 4. 판매자 + 스토어 fetch join 조회 (createOrderDelivery에서 필요)
+        Seller seller = sellerRepository.findByIdWithStore(command.sellerId())
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.SELLER_NOT_FOUND));
+
+        // 5. 소유자 검증
+        Long storeId = seller.getStore().getId();
+        assertOwnedOrderItems(order.getId(), uniqueOrderItemIds, storeId);
+
+        // 6. OrderItem 목록 조회 (Order fetch join으로 LAZY 로딩 방지)
+        List<OrderItem> orderItems = orderItemRepository.findByOrderIdAndIdInWithOrder(
+            order.getId(),
+            uniqueOrderItemIds
+        );
+
+        // 7. 기존 OrderDelivery 일괄 조회 (N+1 방지)
+        List<OrderDelivery> existingDeliveries = orderDeliveryRepository.findByOrderItemIdIn(uniqueOrderItemIds);
+        Map<Long, OrderDelivery> deliveryMap = existingDeliveries.stream()
+            .collect(Collectors.toMap(od -> od.getOrderItem().getId(), Function.identity()));
+
+        // 8. 각 orderItem에 대해 운송장 등록 처리
+        List<Long> successOrderItemIds = new ArrayList<>();
+        List<Long> failedOrderItemIds = new ArrayList<>();
+        LocalDateTime shippedAt = null;
+
+        for (OrderItem orderItem : orderItems) {
+            try {
+                // OrderDelivery 조회 또는 생성
+                OrderDelivery orderDelivery = deliveryMap.get(orderItem.getId());
+                if (orderDelivery == null) {
+                    orderDelivery = createOrderDelivery(orderItem, seller);
+                    orderDeliveryRepository.save(orderDelivery);
+                }
+
+                // 운송장 정보 등록
+                orderDelivery.registerShipment(command.courierName(), command.trackingNumber());
+
+                // OrderItem 상태 변경
+                orderItem.shipOrder();
+
+                successOrderItemIds.add(orderItem.getId());
+                shippedAt = orderDelivery.getShipping().getShippedAt();
+            } catch (Exception e) {
+                failedOrderItemIds.add(orderItem.getId());
+            }
+        }
+
+        // 9. 응답 생성
+        return ShipmentRegisterResponse.of(
+            order.getId(),
+            successOrderItemIds,
+            failedOrderItemIds,
+            command.courierName(),
+            command.trackingNumber(),
+            shippedAt
+        );
+    }
+
+    private Long getStoreIdOrThrow(Long sellerId) {
+        Long storeId = sellerRepository.findStoreIdBySellerId(sellerId);
+        if (storeId == null) {
+            throw new BbangleException(BbangleErrorCode.SELLER_NOT_FOUND);
+        }
+        return storeId;
+    }
+
+    private void assertOwnedOrderItems(Long orderId, List<Long> orderItemIds, Long storeId) {
+        long ownedCount = orderItemRepository.countOwnedOrderItems(orderId, orderItemIds, storeId);
+        if (ownedCount != orderItemIds.size()) {
+            throw new BbangleException(BbangleErrorCode.ORDER_ACCESS_DENIED);
+        }
+    }
+
+    private OrderDelivery createOrderDelivery(OrderItem orderItem, Seller seller) {
+        Order order = orderItem.getOrder();
+
+        Sender sender = Sender.of(
+            seller.getStore().getName(),
+            seller.getPhoneNumberVO() != null ? seller.getPhoneNumberVO().getPhoneNumber() : null,
+            seller.getOriginAddressLine(),
+            seller.getOriginAddressDetail(),
+            null
+        );
+
+        Receiver receiver = Receiver.of(
+            order.getBuyerName(),
+            order.getBuyerPhone(),
+            order.getBuyerSubPhone(),
+            null,
+            null,
+            null
+        );
+
+        Shipping shipping = Shipping.empty();
+
+        return OrderDelivery.create(
+            sender,
+            receiver,
+            shipping,
+            OrderDeliveryStatus.PREPARING,
+            orderItem
+        );
     }
 }

--- a/src/main/java/com/bbangle/bbangle/order/seller/service/model/SellerOrderCommand.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/service/model/SellerOrderCommand.java
@@ -12,4 +12,14 @@ public class SellerOrderCommand {
         Long sellerId
     ) {
     }
+
+    @Builder
+    public record ShipmentRegisterCommand(
+        Long orderId,
+        List<Long> orderItemIds,
+        String courierName,
+        String trackingNumber,
+        Long sellerId
+    ) {
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/repository/SellerRepository.java
+++ b/src/main/java/com/bbangle/bbangle/seller/repository/SellerRepository.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.seller.repository;
 
 import com.bbangle.bbangle.seller.domain.Seller;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,4 +10,7 @@ public interface SellerRepository extends JpaRepository<Seller, Long> {
 
     @Query("select s.store.id from Seller s where s.id = :sellerId")
     Long findStoreIdBySellerId(@Param("sellerId") Long sellerId);
+
+    @Query("select s from Seller s join fetch s.store where s.id = :sellerId")
+    Optional<Seller> findByIdWithStore(@Param("sellerId") Long sellerId);
 }

--- a/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceTest.java
@@ -2,23 +2,37 @@ package com.bbangle.bbangle.order.seller.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
+import com.bbangle.bbangle.delivery.domain.Receiver;
+import com.bbangle.bbangle.delivery.domain.Sender;
+import com.bbangle.bbangle.delivery.domain.Shipping;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderDelivery;
 import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
 import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderDeliveryRepository;
 import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.order.repository.OrderRepository;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
+import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.ShipmentRegisterResponse;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderConfirmCommand;
+import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentRegisterCommand;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.domain.model.PhoneNumberVO;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
+import com.bbangle.bbangle.store.domain.Store;
 import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -39,13 +53,19 @@ class SellerOrderServiceTest {
     @Mock
     private OrderItemRepository orderItemRepository;
 
+    @Mock
+    private OrderDeliveryRepository orderDeliveryRepository;
+
+    @Mock
+    private SellerRepository sellerRepository;
+
     @DisplayName("주문이 존재하지 않으면 ORDER_NOT_FOUND 예외가 발생한다.")
     @Test
     void givenNonExistingOrderId_whenConfirmOrder_thenThrowsException() {
         // given
         Long orderId = 999L;
         OrderConfirmCommand command = OrderConfirmCommand.builder()
-            .sellerId(1L) // 지금은 검증 안 해도 command 형태 맞추려고 넣어둠
+            .sellerId(1L)
             .orderId(orderId)
             .orderItemIds(List.of(1L, 2L))
             .build();
@@ -66,6 +86,8 @@ class SellerOrderServiceTest {
     void givenMixedOrderItems_whenConfirmOrder_thenConfirmOnlyPaymentCompleted() {
         // given
         Long orderId = 1L;
+        Long sellerId = 1L;
+        Long storeId = 100L;
 
         Order order = newEntity(Order.class);
         ReflectionTestUtils.setField(order, "id", orderId);
@@ -77,16 +99,19 @@ class SellerOrderServiceTest {
 
         OrderItem skipItem = newEntity(OrderItem.class);
         ReflectionTestUtils.setField(skipItem, "id", 11L);
-        ReflectionTestUtils.setField(skipItem, "orderStatus", OrderStatus.ORDER_CONFIRMED); // 이미 확정된 상태라고 가정
+        ReflectionTestUtils.setField(skipItem, "orderStatus", OrderStatus.ORDER_CONFIRMED);
         ReflectionTestUtils.setField(skipItem, "order", order);
 
         OrderConfirmCommand command = OrderConfirmCommand.builder()
-            .sellerId(1L)
+            .sellerId(sellerId)
             .orderId(orderId)
             .orderItemIds(List.of(10L, 11L))
             .build();
 
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(sellerRepository.findStoreIdBySellerId(sellerId)).willReturn(storeId);
+        given(orderItemRepository.countOwnedOrderItems(orderId, List.of(10L, 11L), storeId))
+            .willReturn(2L);
         given(orderItemRepository.findByOrderIdAndIdIn(orderId, List.of(10L, 11L)))
             .willReturn(List.of(okItem, skipItem));
 
@@ -95,18 +120,387 @@ class SellerOrderServiceTest {
 
         // then
         then(orderRepository).should(times(1)).findById(orderId);
+        then(sellerRepository).should(times(1)).findStoreIdBySellerId(sellerId);
         then(orderItemRepository).should(times(1)).findByOrderIdAndIdIn(orderId, List.of(10L, 11L));
 
-        // 응답 검증: PAYMENT_COMPLETED였던 것만 포함
         assertThat(result).isNotNull();
         assertThat(result.orderId()).isEqualTo(orderId);
         assertThat(result.confirmedOrderItemIds())
             .asList()
             .containsExactly(10L);
 
-        // 상태 변경 검증
         assertThat(okItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED);
-        assertThat(skipItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED); // 원래부터 confirmed였으면 그대로
+        assertThat(skipItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED);
+    }
+
+    @Nested
+    @DisplayName("운송장 입력 테스트")
+    class RegisterShipmentTest {
+
+        @DisplayName("orderItemIds가 null이면 ORDER_ITEM_NOT_FOUND 예외가 발생한다.")
+        @Test
+        void givenNullOrderItemIds_whenRegisterShipment_thenThrowsException() {
+            // given
+            ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
+                .sellerId(1L)
+                .orderId(1L)
+                .orderItemIds(null)
+                .courierName("CJ대한통운")
+                .trackingNumber("1234567890")
+                .build();
+
+            // when
+            BbangleException result = assertThrows(BbangleException.class,
+                () -> sut.registerShipment(command));
+
+            // then
+            assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_ITEM_NOT_FOUND);
+        }
+
+        @DisplayName("orderItemIds가 비어있으면 ORDER_ITEM_NOT_FOUND 예외가 발생한다.")
+        @Test
+        void givenEmptyOrderItemIds_whenRegisterShipment_thenThrowsException() {
+            // given
+            ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
+                .sellerId(1L)
+                .orderId(1L)
+                .orderItemIds(List.of())
+                .courierName("CJ대한통운")
+                .trackingNumber("1234567890")
+                .build();
+
+            // when
+            BbangleException result = assertThrows(BbangleException.class,
+                () -> sut.registerShipment(command));
+
+            // then
+            assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_ITEM_NOT_FOUND);
+        }
+
+        @DisplayName("주문이 존재하지 않으면 ORDER_NOT_FOUND 예외가 발생한다.")
+        @Test
+        void givenNonExistingOrderId_whenRegisterShipment_thenThrowsException() {
+            // given
+            Long orderId = 999L;
+            ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
+                .sellerId(1L)
+                .orderId(orderId)
+                .orderItemIds(List.of(1L, 2L))
+                .courierName("CJ대한통운")
+                .trackingNumber("1234567890")
+                .build();
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.empty());
+
+            // when
+            BbangleException result = assertThrows(BbangleException.class,
+                () -> sut.registerShipment(command));
+
+            // then
+            then(orderRepository).should(times(1)).findById(orderId);
+            assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_NOT_FOUND);
+        }
+
+        @DisplayName("판매자가 존재하지 않으면 SELLER_NOT_FOUND 예외가 발생한다.")
+        @Test
+        void givenNonExistingSeller_whenRegisterShipment_thenThrowsException() {
+            // given
+            Long orderId = 1L;
+            Long sellerId = 999L;
+
+            Order order = newEntity(Order.class);
+            ReflectionTestUtils.setField(order, "id", orderId);
+
+            ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
+                .sellerId(sellerId)
+                .orderId(orderId)
+                .orderItemIds(List.of(1L, 2L))
+                .courierName("CJ대한통운")
+                .trackingNumber("1234567890")
+                .build();
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(sellerRepository.findByIdWithStore(sellerId)).willReturn(Optional.empty());
+
+            // when
+            BbangleException result = assertThrows(BbangleException.class,
+                () -> sut.registerShipment(command));
+
+            // then
+            then(orderRepository).should(times(1)).findById(orderId);
+            then(sellerRepository).should(times(1)).findByIdWithStore(sellerId);
+            assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.SELLER_NOT_FOUND);
+        }
+
+        @DisplayName("판매자가 해당 주문상품의 소유자가 아니면 ORDER_ACCESS_DENIED 예외가 발생한다.")
+        @Test
+        void givenNonOwnerSeller_whenRegisterShipment_thenThrowsException() {
+            // given
+            Long orderId = 1L;
+            Long sellerId = 1L;
+            Long storeId = 100L;
+
+            Order order = newEntity(Order.class);
+            ReflectionTestUtils.setField(order, "id", orderId);
+
+            Store store = newEntity(Store.class);
+            ReflectionTestUtils.setField(store, "id", storeId);
+
+            Seller seller = newEntity(Seller.class);
+            ReflectionTestUtils.setField(seller, "id", sellerId);
+            ReflectionTestUtils.setField(seller, "store", store);
+
+            ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
+                .sellerId(sellerId)
+                .orderId(orderId)
+                .orderItemIds(List.of(1L, 2L))
+                .courierName("CJ대한통운")
+                .trackingNumber("1234567890")
+                .build();
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(sellerRepository.findByIdWithStore(sellerId)).willReturn(Optional.of(seller));
+            given(orderItemRepository.countOwnedOrderItems(orderId, List.of(1L, 2L), storeId))
+                .willReturn(0L);
+
+            // when
+            BbangleException result = assertThrows(BbangleException.class,
+                () -> sut.registerShipment(command));
+
+            // then
+            then(orderRepository).should(times(1)).findById(orderId);
+            then(sellerRepository).should(times(1)).findByIdWithStore(sellerId);
+            then(orderItemRepository).should(times(1))
+                .countOwnedOrderItems(orderId, List.of(1L, 2L), storeId);
+            assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_ACCESS_DENIED);
+        }
+
+        @DisplayName("여러 주문상품에 대해 운송장 정보가 정상적으로 등록된다.")
+        @Test
+        void givenMultipleOrderItems_whenRegisterShipment_thenRegistersShipmentForAll() {
+            // given
+            Long orderId = 1L;
+            Long sellerId = 1L;
+            Long storeId = 100L;
+            String courierName = "CJ대한통운";
+            String trackingNumber = "1234567890";
+
+            Order order = newEntity(Order.class);
+            ReflectionTestUtils.setField(order, "id", orderId);
+            ReflectionTestUtils.setField(order, "buyerName", "홍길동");
+            ReflectionTestUtils.setField(order, "buyerPhone", "01098765432");
+
+            OrderItem orderItem1 = newEntity(OrderItem.class);
+            ReflectionTestUtils.setField(orderItem1, "id", 10L);
+            ReflectionTestUtils.setField(orderItem1, "order", order);
+            ReflectionTestUtils.setField(orderItem1, "orderStatus", OrderStatus.ORDER_CONFIRMED);
+
+            OrderItem orderItem2 = newEntity(OrderItem.class);
+            ReflectionTestUtils.setField(orderItem2, "id", 11L);
+            ReflectionTestUtils.setField(orderItem2, "order", order);
+            ReflectionTestUtils.setField(orderItem2, "orderStatus", OrderStatus.ORDER_CONFIRMED);
+
+            Store store = newEntity(Store.class);
+            ReflectionTestUtils.setField(store, "id", storeId);
+            ReflectionTestUtils.setField(store, "name", "테스트 스토어");
+
+            PhoneNumberVO phoneNumberVO = PhoneNumberVO.of("01012345678", null);
+
+            Seller seller = newEntity(Seller.class);
+            ReflectionTestUtils.setField(seller, "id", sellerId);
+            ReflectionTestUtils.setField(seller, "store", store);
+            ReflectionTestUtils.setField(seller, "phoneNumberVO", phoneNumberVO);
+            ReflectionTestUtils.setField(seller, "originAddressLine", "서울시 강남구");
+            ReflectionTestUtils.setField(seller, "originAddressDetail", "테헤란로 123");
+
+            ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
+                .sellerId(sellerId)
+                .orderId(orderId)
+                .orderItemIds(List.of(10L, 11L))
+                .courierName(courierName)
+                .trackingNumber(trackingNumber)
+                .build();
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(sellerRepository.findByIdWithStore(sellerId)).willReturn(Optional.of(seller));
+            given(orderItemRepository.countOwnedOrderItems(orderId, List.of(10L, 11L), storeId))
+                .willReturn(2L);
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(10L, 11L)))
+                .willReturn(List.of(orderItem1, orderItem2));
+            given(orderDeliveryRepository.findByOrderItemIdIn(List.of(10L, 11L)))
+                .willReturn(List.of());
+            given(orderDeliveryRepository.save(any(OrderDelivery.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            ShipmentRegisterResponse result = sut.registerShipment(command);
+
+            // then
+            then(orderRepository).should(times(1)).findById(orderId);
+            then(sellerRepository).should(times(1)).findByIdWithStore(sellerId);
+            then(orderItemRepository).should(times(1))
+                .countOwnedOrderItems(orderId, List.of(10L, 11L), storeId);
+            then(orderItemRepository).should(times(1))
+                .findByOrderIdAndIdInWithOrder(orderId, List.of(10L, 11L));
+            then(orderDeliveryRepository).should(times(1)).findByOrderItemIdIn(List.of(10L, 11L));
+            then(orderDeliveryRepository).should(times(2)).save(any(OrderDelivery.class));
+
+            assertThat(result).isNotNull();
+            assertThat(result.orderId()).isEqualTo(orderId);
+            assertThat(result.successOrderItemIds())
+                .asList()
+                .containsExactlyInAnyOrder(10L, 11L);
+            assertThat(result.failedOrderItemIds())
+                .asList()
+                .isEmpty();
+            assertThat(result.courierName()).isEqualTo(courierName);
+            assertThat(result.trackingNumber()).isEqualTo(trackingNumber);
+            assertThat(result.shippedAt()).isNotNull();
+
+            assertThat(orderItem1.getOrderStatus()).isEqualTo(OrderStatus.SHIPPED);
+            assertThat(orderItem2.getOrderStatus()).isEqualTo(OrderStatus.SHIPPED);
+        }
+
+        @DisplayName("기존 OrderDelivery가 있으면 해당 레코드를 업데이트한다.")
+        @Test
+        void givenExistingOrderDelivery_whenRegisterShipment_thenUpdatesExisting() {
+            // given
+            Long orderId = 1L;
+            Long sellerId = 1L;
+            Long storeId = 100L;
+            String courierName = "CJ대한통운";
+            String trackingNumber = "1234567890";
+
+            Order order = newEntity(Order.class);
+            ReflectionTestUtils.setField(order, "id", orderId);
+            ReflectionTestUtils.setField(order, "buyerName", "홍길동");
+            ReflectionTestUtils.setField(order, "buyerPhone", "01098765432");
+
+            OrderItem orderItem1 = newEntity(OrderItem.class);
+            ReflectionTestUtils.setField(orderItem1, "id", 10L);
+            ReflectionTestUtils.setField(orderItem1, "order", order);
+            ReflectionTestUtils.setField(orderItem1, "orderStatus", OrderStatus.ORDER_CONFIRMED);
+
+            Store store = newEntity(Store.class);
+            ReflectionTestUtils.setField(store, "id", storeId);
+            ReflectionTestUtils.setField(store, "name", "테스트 스토어");
+
+            Seller seller = newEntity(Seller.class);
+            ReflectionTestUtils.setField(seller, "id", sellerId);
+            ReflectionTestUtils.setField(seller, "store", store);
+
+            Shipping shipping = Shipping.empty();
+            OrderDelivery existingDelivery = OrderDelivery.create(
+                Sender.of("테스트 스토어", "01012345678", "서울시", "강남구", "12345"),
+                Receiver.of("홍길동", "01098765432", null, null, null, null),
+                shipping,
+                OrderDeliveryStatus.PREPARING,
+                orderItem1
+            );
+            ReflectionTestUtils.setField(existingDelivery, "id", 1L);
+
+            ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
+                .sellerId(sellerId)
+                .orderId(orderId)
+                .orderItemIds(List.of(10L))
+                .courierName(courierName)
+                .trackingNumber(trackingNumber)
+                .build();
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(sellerRepository.findByIdWithStore(sellerId)).willReturn(Optional.of(seller));
+            given(orderItemRepository.countOwnedOrderItems(orderId, List.of(10L), storeId))
+                .willReturn(1L);
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(10L)))
+                .willReturn(List.of(orderItem1));
+            given(orderDeliveryRepository.findByOrderItemIdIn(List.of(10L)))
+                .willReturn(List.of(existingDelivery));
+
+            // when
+            ShipmentRegisterResponse result = sut.registerShipment(command);
+
+            // then
+            then(orderDeliveryRepository).should(times(0)).save(any(OrderDelivery.class));
+
+            assertThat(result).isNotNull();
+            assertThat(result.orderId()).isEqualTo(orderId);
+            assertThat(result.successOrderItemIds())
+                .asList()
+                .containsExactly(10L);
+            assertThat(result.failedOrderItemIds())
+                .asList()
+                .isEmpty();
+
+            assertThat(existingDelivery.getStatus()).isEqualTo(OrderDeliveryStatus.DELIVERING);
+            assertThat(existingDelivery.getShipping().getCourierName()).isEqualTo(courierName);
+            assertThat(existingDelivery.getShipping().getTrackingNumber()).isEqualTo(trackingNumber);
+        }
+
+        @DisplayName("중복된 orderItemIds는 distinct 처리된다.")
+        @Test
+        void givenDuplicateOrderItemIds_whenRegisterShipment_thenDeduplicates() {
+            // given
+            Long orderId = 1L;
+            Long sellerId = 1L;
+            Long storeId = 100L;
+            String courierName = "CJ대한통운";
+            String trackingNumber = "1234567890";
+
+            Order order = newEntity(Order.class);
+            ReflectionTestUtils.setField(order, "id", orderId);
+            ReflectionTestUtils.setField(order, "buyerName", "홍길동");
+            ReflectionTestUtils.setField(order, "buyerPhone", "01098765432");
+
+            OrderItem orderItem1 = newEntity(OrderItem.class);
+            ReflectionTestUtils.setField(orderItem1, "id", 10L);
+            ReflectionTestUtils.setField(orderItem1, "order", order);
+            ReflectionTestUtils.setField(orderItem1, "orderStatus", OrderStatus.ORDER_CONFIRMED);
+
+            Store store = newEntity(Store.class);
+            ReflectionTestUtils.setField(store, "id", storeId);
+            ReflectionTestUtils.setField(store, "name", "테스트 스토어");
+
+            PhoneNumberVO phoneNumberVO = PhoneNumberVO.of("01012345678", null);
+
+            Seller seller = newEntity(Seller.class);
+            ReflectionTestUtils.setField(seller, "id", sellerId);
+            ReflectionTestUtils.setField(seller, "store", store);
+            ReflectionTestUtils.setField(seller, "phoneNumberVO", phoneNumberVO);
+            ReflectionTestUtils.setField(seller, "originAddressLine", "서울시 강남구");
+            ReflectionTestUtils.setField(seller, "originAddressDetail", "테헤란로 123");
+
+            ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
+                .sellerId(sellerId)
+                .orderId(orderId)
+                .orderItemIds(List.of(10L, 10L, 10L))
+                .courierName(courierName)
+                .trackingNumber(trackingNumber)
+                .build();
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(sellerRepository.findByIdWithStore(sellerId)).willReturn(Optional.of(seller));
+            given(orderItemRepository.countOwnedOrderItems(orderId, List.of(10L), storeId))
+                .willReturn(1L);
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(10L)))
+                .willReturn(List.of(orderItem1));
+            given(orderDeliveryRepository.findByOrderItemIdIn(List.of(10L)))
+                .willReturn(List.of());
+            given(orderDeliveryRepository.save(any(OrderDelivery.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            ShipmentRegisterResponse result = sut.registerShipment(command);
+
+            // then
+            then(orderItemRepository).should(times(1))
+                .countOwnedOrderItems(orderId, List.of(10L), storeId);
+            then(orderItemRepository).should(times(1))
+                .findByOrderIdAndIdInWithOrder(orderId, List.of(10L));
+
+            assertThat(result.successOrderItemIds())
+                .asList()
+                .containsExactly(10L);
+        }
     }
 
     private <T> T newEntity(Class<T> clazz) {


### PR DESCRIPTION
## History
-  연관된 이슈 : #506 

## 🚀 Major Changes & Explanations
- 운송장 입력을 위한 주문 배송 이력 도메인(OrderDelivery) 및 Repository 추가
- 운송장 입력/조회 흐름을 위한 판매자 주문 API/Controller 및 요청·응답 DTO 수정
- 판매자 소유자(권한) 검증 및 주문/주문상품 미존재 등 ErrorCode(BbangIeErrorCode) 기반 예외 처리
- 서비스 로직 변경에 맞춰 SellerOrderServiceTest 테스트 케이스 보강

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->
- 운송장 입력 API 정상 케이스
<img width="1291" height="491" alt="image" src="https://github.com/user-attachments/assets/81db3c54-dc25-4371-9219-19b58e83c4a5" />
<img width="474" height="287" alt="image" src="https://github.com/user-attachments/assets/d62e3a0a-a94a-4a65-a304-6b9131ed857c" />
<img width="1692" height="104" alt="image" src="https://github.com/user-attachments/assets/968d60dc-359f-45fa-95cc-ff5228b9966d" />

- 권한/소유자 검증 실패 케이스
<img width="1278" height="435" alt="image" src="https://github.com/user-attachments/assets/88376338-a4ce-46f6-a944-9f1538539fdf" />
<img width="1245" height="176" alt="image" src="https://github.com/user-attachments/assets/366eb9f8-2f23-4ea8-96a0-5f1abd9b823d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 판매자가 주문에 대한 배송 정보(택배사, 추적 번호)를 등록할 수 있는 배송 등록 기능 추가
  * 배송 상태 추적 및 업데이트 기능 개선

* **리팩터**
  * 배송 및 주문 관련 도메인 모델 구조 정규화로 데이터 일관성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->