### PR TITLE
[Feature] (셀러) 주문 취소 승인 / 거절 API

### DIFF
--- a/src/main/java/com/bbangle/bbangle/claim/domain/CancelRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/CancelRequest.java
@@ -1,13 +1,22 @@
 package com.bbangle.bbangle.claim.domain;
 
+import static com.bbangle.bbangle.claim.domain.constant.CancelRequestStatus.APPROVED;
+import static com.bbangle.bbangle.claim.domain.constant.CancelRequestStatus.REJECTED;
+import static com.bbangle.bbangle.claim.domain.constant.CancelRequestStatus.REQUESTED;
+
 import com.bbangle.bbangle.claim.domain.constant.CancelRequestStatus;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.order.domain.OrderItem;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,4 +31,34 @@ public class CancelRequest extends Claim {
     @Enumerated(EnumType.STRING)
     private CancelRequestStatus status;
 
+    private String sellerComment;
+
+    @Builder
+    public CancelRequest(
+        OrderItem orderItem,
+        String detailReason,
+        LocalDateTime decidedAt,
+        CancelRequestStatus status
+    ) {
+        super(orderItem, detailReason, decidedAt);
+        this.status = status;
+    }
+
+    public void approve(String reason) {
+        if (status != REQUESTED) {
+            throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
+        }
+        this.status = APPROVED;
+        this.sellerComment = reason;
+        super.decide();
+    }
+
+    public void reject(String reason) {
+        if (status != REQUESTED) {
+            throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
+        }
+        this.status = REJECTED;
+        this.sellerComment = reason;
+        super.decide();
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerCancelController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerCancelController.java
@@ -1,0 +1,36 @@
+package com.bbangle.bbangle.claim.seller.controller;
+
+import com.bbangle.bbangle.claim.seller.controller.dto.CancelDecisionRequest;
+import com.bbangle.bbangle.claim.seller.controller.swagger.SellerCancelApi;
+import com.bbangle.bbangle.claim.seller.service.SellerClaimService;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.SellerApiPath;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping(SellerApiPath.PREFIX + "/cancels")
+@RestController
+public class SellerCancelController implements SellerCancelApi {
+
+    private final ResponseService responseService;
+    private final SellerClaimService sellerClaimService;
+
+    @PostMapping("/{cancelId}/decision")
+    public CommonResult cancelDecision(
+        @PathVariable Long cancelId,
+        @Valid @RequestBody CancelDecisionRequest cancelDecisionRequest,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        sellerClaimService.decision(cancelId, sellerId,
+            cancelDecisionRequest.decisionType(), cancelDecisionRequest.reason());
+        return responseService.getSuccessResult();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/CancelDecisionRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/CancelDecisionRequest.java
@@ -1,0 +1,18 @@
+package com.bbangle.bbangle.claim.seller.controller.dto;
+
+import com.bbangle.bbangle.claim.domain.constant.DecisionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "취소 요청 승인/거절 요청 DTO")
+public record CancelDecisionRequest(
+
+    @Schema(description = "처리 유형", example = "APPROVE", allowableValues = {"APPROVE", "REJECT"})
+    @NotNull
+    DecisionType decisionType,
+
+    @Schema(description = "처리 사유", example = "취소 승인", maxLength = 500)
+    String reason
+
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerCancelApi.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerCancelApi.java
@@ -1,0 +1,22 @@
+package com.bbangle.bbangle.claim.seller.controller.swagger;
+
+import com.bbangle.bbangle.claim.seller.controller.dto.CancelDecisionRequest;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Cancel", description = "(셀러) 취소 관리 API")
+public interface SellerCancelApi {
+
+    @Operation(
+        summary = "취소 요청 승인/거절",
+        description = "취소 요청에 대해 승인 또는 거절 처리를 수행한다."
+    )
+    CommonResult cancelDecision(
+        @Parameter(description = "취소 요청 ID", example = "101", required = true)
+        Long cancelId,
+        CancelDecisionRequest cancelDecisionRequest,
+        @Parameter(hidden = true) Long sellerId
+    );
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerClaimService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerClaimService.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.claim.seller.service;
 
+import com.bbangle.bbangle.claim.domain.CancelRequest;
 import com.bbangle.bbangle.claim.domain.Claim;
 import com.bbangle.bbangle.claim.domain.ReturnRequest;
 import com.bbangle.bbangle.claim.domain.constant.DecisionType;
@@ -30,26 +31,50 @@ public class SellerClaimService {
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.CLAIM_NOT_FOUND));
 
         if (claim instanceof ReturnRequest returnRequest) {
-            switch (decisionType) {
-                case APPROVE -> {
-                    returnRequest.approve(reason);
-                    OrderItem orderItem = returnRequest.getOrderItem();
-                    orderItem.returnApprove();
-                    OrderItemHistory history = OrderItemHistory.create(orderItem);
-                    orderItemHistoryRepository.save(history);
-                }
-                case REJECT -> {
-                    returnRequest.reject(reason);
-                    OrderItem orderItem = returnRequest.getOrderItem();
-                    orderItem.returnReject();
-                    OrderItemHistory history = OrderItemHistory.create(orderItem);
-                    orderItemHistoryRepository.save(history);
-                }
-            }
-            return;
+            processReturnDecision(returnRequest, decisionType, reason);
+        } else if (claim instanceof CancelRequest cancelRequest) {
+            processCancelDecision(cancelRequest, decisionType, reason);
+        } else {
+            throw new BbangleException(BbangleErrorCode.CLAIM_NOT_FOUND);
         }
+    }
 
-        throw new BbangleException(BbangleErrorCode.CLAIM_NOT_FOUND);
+    private void processCancelDecision(CancelRequest cancelRequest, DecisionType decisionType, String reason) {
+        switch (decisionType) {
+            case APPROVE -> {
+                cancelRequest.approve(reason);
+                OrderItem orderItem = cancelRequest.getOrderItem();
+                orderItem.cancelApprove();
+                OrderItemHistory history = OrderItemHistory.create(orderItem);
+                orderItemHistoryRepository.save(history);
+            }
+            case REJECT -> {
+                cancelRequest.reject(reason);
+                OrderItem orderItem = cancelRequest.getOrderItem();
+                orderItem.cancelReject();
+                OrderItemHistory history = OrderItemHistory.create(orderItem);
+                orderItemHistoryRepository.save(history);
+            }
+        }
+    }
+
+    private void processReturnDecision(ReturnRequest returnRequest, DecisionType decisionType, String reason) {
+        switch (decisionType) {
+            case APPROVE -> {
+                returnRequest.approve(reason);
+                OrderItem orderItem = returnRequest.getOrderItem();
+                orderItem.returnApprove();
+                OrderItemHistory history = OrderItemHistory.create(orderItem);
+                orderItemHistoryRepository.save(history);
+            }
+            case REJECT -> {
+                returnRequest.reject(reason);
+                OrderItem orderItem = returnRequest.getOrderItem();
+                orderItem.returnReject();
+                OrderItemHistory history = OrderItemHistory.create(orderItem);
+                orderItemHistoryRepository.save(history);
+            }
+        }
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.order.domain;
 
+import static com.bbangle.bbangle.order.domain.model.OrderStatus.CANCEL_REQUESTED;
 import static com.bbangle.bbangle.order.domain.model.OrderStatus.RETURN_REQUESTED;
 
 import com.bbangle.bbangle.board.domain.Product;
@@ -103,5 +104,19 @@ public class OrderItem extends BaseEntity {
             throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
         }
         this.orderStatus = OrderStatus.RETURN_REJECTED;
+    }
+
+    public void cancelApprove() {
+        if (orderStatus != CANCEL_REQUESTED) {
+            throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
+        }
+        this.orderStatus = OrderStatus.CANCEL_APPROVED;
+    }
+
+    public void cancelReject() {
+        if (orderStatus != CANCEL_REQUESTED) {
+            throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
+        }
+        this.orderStatus = OrderStatus.CANCEL_REJECTED;
     }
 }

--- a/src/test/java/com/bbangle/bbangle/claim/seller/controller/SellerCancelControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/controller/SellerCancelControllerTest.java
@@ -1,0 +1,248 @@
+package com.bbangle.bbangle.claim.seller.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bbangle.bbangle.claim.domain.constant.DecisionType;
+import com.bbangle.bbangle.claim.seller.controller.dto.CancelDecisionRequest;
+import com.bbangle.bbangle.claim.seller.service.SellerClaimService;
+import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.JsonDataEncoder;
+import com.bbangle.bbangle.config.security.SecurityConfig;
+import com.bbangle.bbangle.config.security.SellerApiPath;
+import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("[컨트롤러 테스트] SellerCancelController")
+@WebMvcTest(controllers = SellerCancelController.class)
+@Import({
+    TestSlackAdaptorConfig.class,
+    JsonDataEncoder.class,
+    TokenProvider.class,
+    TestJwtPropertiesConfig.class,
+    ResponseService.class,
+    SecurityConfig.class
+})
+@ActiveProfiles("test")
+class SellerCancelControllerTest {
+
+    private static final String BASE_URL = SellerApiPath.PREFIX + "/cancels";
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private JsonDataEncoder jsonDataEncoder;
+
+    @MockBean
+    private SellerClaimService sellerClaimService;
+
+    @Nested
+    @DisplayName("POST /api/v1/seller/cancels/{cancelId}/decision")
+    class CancelDecision {
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("APPROVE 요청이 정상적으로 처리되면 200 OK와 success=true를 반환한다")
+        void given_approveRequest_when_decision_then_success() throws Exception {
+            // given
+            Long cancelId = 1L;
+            CancelDecisionRequest request = new CancelDecisionRequest(DecisionType.APPROVE, "취소 승인");
+
+            willDoNothing().given(sellerClaimService)
+                .decision(any(), any(), any(DecisionType.class), any());
+
+            // when & then
+            mvc.perform(
+                    post(BASE_URL + "/{cancelId}/decision", cancelId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.message").value("SUCCESS"));
+
+            then(sellerClaimService).should()
+                .decision(eq(cancelId), isNull(), eq(DecisionType.APPROVE), eq("취소 승인"));
+        }
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("REJECT 요청이 정상적으로 처리되면 200 OK와 success=true를 반환한다")
+        void given_rejectRequest_when_decision_then_success() throws Exception {
+            // given
+            Long cancelId = 1L;
+            CancelDecisionRequest request = new CancelDecisionRequest(DecisionType.REJECT, "취소 거절 사유");
+
+            willDoNothing().given(sellerClaimService)
+                .decision(any(), any(), any(DecisionType.class), any());
+
+            // when & then
+            mvc.perform(
+                    post(BASE_URL + "/{cancelId}/decision", cancelId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.message").value("SUCCESS"));
+
+            then(sellerClaimService).should()
+                .decision(eq(cancelId), isNull(), eq(DecisionType.REJECT), eq("취소 거절 사유"));
+        }
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("decisionType이 null이면 400 Bad Request를 반환한다")
+        void given_nullDecisionType_when_decision_then_badRequest() throws Exception {
+            // given
+            Long cancelId = 1L;
+            CancelDecisionRequest request = new CancelDecisionRequest(null, "사유");
+
+            // when & then
+            mvc.perform(
+                    post(BASE_URL + "/{cancelId}/decision", cancelId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("존재하지 않는 claim이면 400 Bad Request와 에러코드 -771을 반환한다")
+        void given_nonExistentClaim_when_decision_then_claimNotFound() throws Exception {
+            // given
+            Long cancelId = 999L;
+            CancelDecisionRequest request = new CancelDecisionRequest(DecisionType.APPROVE, "승인");
+
+            willThrow(new BbangleException(BbangleErrorCode.CLAIM_NOT_FOUND))
+                .given(sellerClaimService)
+                .decision(any(), any(), any(DecisionType.class), any());
+
+            // when & then
+            mvc.perform(
+                    post(BASE_URL + "/{cancelId}/decision", cancelId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(-771))
+                .andExpect(jsonPath("$.message").value(BbangleErrorCode.CLAIM_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("판매자와 claim이 일치하지 않으면 401 Unauthorized와 에러코드 -772를 반환한다")
+        void given_mismatchedSeller_when_decision_then_unauthorized() throws Exception {
+            // given
+            Long cancelId = 1L;
+            CancelDecisionRequest request = new CancelDecisionRequest(DecisionType.APPROVE, "승인");
+
+            willThrow(new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH))
+                .given(sellerClaimService)
+                .decision(any(), any(), any(DecisionType.class), any());
+
+            // when & then
+            mvc.perform(
+                    post(BASE_URL + "/{cancelId}/decision", cancelId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(-772))
+                .andExpect(jsonPath("$.message").value(BbangleErrorCode.SELLER_CLAIM_MISMATCH.getMessage()));
+        }
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("이미 처리된 claim이면 400 Bad Request와 에러코드 -773을 반환한다")
+        void given_alreadyProcessedClaim_when_decision_then_invalidStatus() throws Exception {
+            // given
+            Long cancelId = 1L;
+            CancelDecisionRequest request = new CancelDecisionRequest(DecisionType.APPROVE, "승인");
+
+            willThrow(new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS))
+                .given(sellerClaimService)
+                .decision(any(), any(), any(DecisionType.class), any());
+
+            // when & then
+            mvc.perform(
+                    post(BASE_URL + "/{cancelId}/decision", cancelId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(-773))
+                .andExpect(jsonPath("$.message").value(BbangleErrorCode.CLAIM_INVALID_STATUS.getMessage()));
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 401 Unauthorized를 반환한다")
+        void given_unauthenticatedUser_when_decision_then_unauthorized() throws Exception {
+            // given
+            Long cancelId = 1L;
+            CancelDecisionRequest request = new CancelDecisionRequest(DecisionType.APPROVE, "승인");
+
+            // when & then
+            mvc.perform(
+                    post(BASE_URL + "/{cancelId}/decision", cancelId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockUser("ADMIN")
+        @DisplayName("SELLER 권한이 아닌 사용자가 요청하면 403 Forbidden을 반환한다")
+        void given_nonSellerUser_when_decision_then_forbidden() throws Exception {
+            // given
+            Long cancelId = 1L;
+            CancelDecisionRequest request = new CancelDecisionRequest(DecisionType.APPROVE, "승인");
+
+            // when & then
+            mvc.perform(
+                    post(BASE_URL + "/{cancelId}/decision", cancelId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isForbidden());
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerClaimServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerClaimServiceIntegrationTest.java
@@ -5,13 +5,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.bbangle.bbangle.board.domain.Product;
 import com.bbangle.bbangle.board.repository.ProductRepository;
+import com.bbangle.bbangle.claim.domain.CancelRequest;
 import com.bbangle.bbangle.claim.domain.ReturnRequest;
+import com.bbangle.bbangle.claim.domain.constant.CancelRequestStatus;
 import com.bbangle.bbangle.claim.domain.constant.DecisionType;
 import com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus;
 import com.bbangle.bbangle.claim.repository.ClaimRepository;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.board.domain.ProductFixture;
+import com.bbangle.bbangle.fixture.claim.CancelRequestFixture;
 import com.bbangle.bbangle.fixture.claim.ReturnRequestFixture;
 import com.bbangle.bbangle.fixture.order.OrderItemFixture;
 import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
@@ -67,25 +70,29 @@ class SellerClaimServiceIntegrationTest {
     private Store store;
     private Seller seller;
     private Product product;
-    private OrderItem orderItem;
-    private ReturnRequest returnRequest;
 
     @BeforeEach
     void setUp() {
-        // Store → Product → OrderItem → ReturnRequest, Store ← Seller
         store = storeRepository.save(StoreFixture.defaultStore());
         seller = sellerRepository.save(SellerFixture.defaultSeller(store));
         product = productRepository.save(ProductFixture.defaultProductWithStore(store));
-        orderItem = orderItemRepository.save(OrderItemFixture.returnRequestedWithProduct(product));
-        returnRequest = claimRepository.save(ReturnRequestFixture.requested(orderItem));
-
-        em.flush();
-        em.clear();
     }
 
     @Nested
-    @DisplayName("decision()")
-    class Decision {
+    @DisplayName("반품 decision()")
+    class return_decision {
+
+        private OrderItem orderItem;
+        private ReturnRequest returnRequest;
+
+        @BeforeEach
+        void setUp() {
+            orderItem = orderItemRepository.save(OrderItemFixture.returnRequestedWithProduct(product));
+            returnRequest = claimRepository.save(ReturnRequestFixture.requested(orderItem));
+
+            em.flush();
+            em.clear();
+        }
 
         @Test
         @DisplayName("판매자가 반품 요청을 승인하면 ReturnRequest는 APPROVED, OrderItem은 RETURN_APPROVED, OrderItemHistory가 생성된다")
@@ -184,6 +191,127 @@ class SellerClaimServiceIntegrationTest {
             // when & then
             assertThatThrownBy(() ->
                 sut.decision(returnRequest.getId(), seller.getId(), DecisionType.APPROVE, "승인"))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(ex -> {
+                    BbangleException bex = (BbangleException) ex;
+                    assertThat(bex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+                });
+        }
+    }
+
+    @Nested
+    @DisplayName("취소 decision()")
+    class cancel_decision {
+
+        private OrderItem cancelOrderItem;
+        private CancelRequest cancelRequest;
+
+        @BeforeEach
+        void setUp() {
+            cancelOrderItem = orderItemRepository.save(OrderItemFixture.cancelRequestedWithProduct(product));
+            cancelRequest = claimRepository.save(CancelRequestFixture.requested(cancelOrderItem));
+
+            em.flush();
+            em.clear();
+        }
+
+        @Test
+        @DisplayName("판매자가 취소 요청을 승인하면 CancelRequest는 APPROVED, OrderItem은 CANCEL_APPROVED, OrderItemHistory가 생성된다")
+        void given_validSellerAndClaim_when_approve_then_statusChangedToApproved() {
+            // when
+            sut.decision(cancelRequest.getId(), seller.getId(), DecisionType.APPROVE, "취소 승인");
+            em.flush();
+            em.clear();
+
+            // then
+            CancelRequest found = (CancelRequest) claimRepository.findById(cancelRequest.getId()).get();
+            OrderItem foundOrderItem = orderItemRepository.findById(cancelOrderItem.getId()).get();
+            long historyCount = orderItemHistoryRepository.count();
+
+            assertThat(found.getStatus()).isEqualTo(CancelRequestStatus.APPROVED);
+            assertThat(foundOrderItem.getOrderStatus()).isEqualTo(OrderStatus.CANCEL_APPROVED);
+            assertThat(historyCount).isGreaterThan(0);
+        }
+
+        @Test
+        @DisplayName("판매자가 취소 요청을 거절하면 CancelRequest는 REJECTED, OrderItem은 CANCEL_REJECTED, OrderItemHistory가 생성된다")
+        void given_validSellerAndClaim_when_reject_then_statusChangedToRejected() {
+            // when
+            sut.decision(cancelRequest.getId(), seller.getId(), DecisionType.REJECT, "취소 거절 사유");
+            em.flush();
+            em.clear();
+
+            // then
+            CancelRequest found = (CancelRequest) claimRepository.findById(cancelRequest.getId()).get();
+            OrderItem foundOrderItem = orderItemRepository.findById(cancelOrderItem.getId()).get();
+            long historyCount = orderItemHistoryRepository.count();
+
+            assertThat(found.getStatus()).isEqualTo(CancelRequestStatus.REJECTED);
+            assertThat(foundOrderItem.getOrderStatus()).isEqualTo(OrderStatus.CANCEL_REJECTED);
+            assertThat(historyCount).isGreaterThan(0);
+        }
+
+        @Test
+        @DisplayName("판매자와 취소 요청이 매칭되지 않으면 SELLER_CLAIM_MISMATCH 예외가 발생한다")
+        void given_mismatchedSeller_when_decision_then_throwSellerClaimMismatch() {
+            // given
+            Long otherSellerId = 99999L;
+
+            // when & then
+            assertThatThrownBy(() ->
+                sut.decision(cancelRequest.getId(), otherSellerId, DecisionType.APPROVE, "승인"))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(ex -> {
+                    BbangleException bex = (BbangleException) ex;
+                    assertThat(bex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+                });
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 취소 요청 ID로 호출하면 SELLER_CLAIM_MISMATCH 예외가 발생한다")
+        void given_nonExistentClaimId_when_decision_then_throwException() {
+            // given
+            Long nonExistentCancelId = 99999L;
+
+            // when & then
+            assertThatThrownBy(() ->
+                sut.decision(nonExistentCancelId, seller.getId(), DecisionType.APPROVE, "승인"))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(ex -> {
+                    BbangleException bex = (BbangleException) ex;
+                    assertThat(bex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+                });
+        }
+
+        @Test
+        @DisplayName("이미 승인된 취소 요청을 다시 승인하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void given_alreadyApprovedClaim_when_approveAgain_then_throwInvalidStatus() {
+            // given
+            sut.decision(cancelRequest.getId(), seller.getId(), DecisionType.APPROVE, "취소 승인");
+            em.flush();
+            em.clear();
+
+            // when & then
+            assertThatThrownBy(() ->
+                sut.decision(cancelRequest.getId(), seller.getId(), DecisionType.APPROVE, "재승인"))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(ex -> {
+                    BbangleException bex = (BbangleException) ex;
+                    assertThat(bex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+                });
+        }
+
+        @Test
+        @DisplayName("이미 거절된 취소 요청을 승인하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void given_alreadyRejectedClaim_when_approve_then_throwInvalidStatus() {
+            // given
+            sut.decision(cancelRequest.getId(), seller.getId(), DecisionType.REJECT, "거절 사유");
+            em.flush();
+            em.clear();
+
+            // when & then
+            assertThatThrownBy(() ->
+                sut.decision(cancelRequest.getId(), seller.getId(), DecisionType.APPROVE, "승인"))
                 .isInstanceOf(BbangleException.class)
                 .satisfies(ex -> {
                     BbangleException bex = (BbangleException) ex;

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerClaimServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerClaimServiceUnitTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
+import com.bbangle.bbangle.claim.domain.CancelRequest;
 import com.bbangle.bbangle.claim.domain.ReturnRequest;
 import com.bbangle.bbangle.claim.domain.constant.DecisionType;
 import com.bbangle.bbangle.claim.repository.ClaimRepository;
@@ -19,6 +20,7 @@ import com.bbangle.bbangle.order.domain.OrderItemHistory;
 import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -38,91 +40,150 @@ class SellerClaimServiceUnitTest {
     @Mock
     private OrderItemHistoryRepository orderItemHistoryRepository;
 
-    @Test
-    @DisplayName("반품 승인 - 판매자와 반품 요청이 일치하면 approve가 호출되고 OrderItemHistory가 저장된다")
-    void decision_approve_success() {
-        // given
-        Long returnId = 1L;
-        Long sellerId = 10L;
-        String reason = "승인 사유";
+    @Nested
+    @DisplayName("반품 decision()")
+    class return_decision {
 
-        ReturnDecisionRequest request = new ReturnDecisionRequest(DecisionType.APPROVE, reason);
-        ReturnRequest returnRequest = mock(ReturnRequest.class);
-        OrderItem orderItem = mock(OrderItem.class);
+        @Test
+        @DisplayName("반품 승인 - 판매자와 반품 요청이 일치하면 approve가 호출되고 OrderItemHistory가 저장된다")
+        void decision_approve_success() {
+            // given
+            Long returnId = 1L;
+            Long sellerId = 10L;
+            String reason = "승인 사유";
+            ReturnRequest returnRequest = mock(ReturnRequest.class);
+            OrderItem orderItem = mock(OrderItem.class);
 
-        given(claimRepository.existsClaimRequestBySeller(returnId, sellerId)).willReturn(true);
-        given(claimRepository.findById(returnId)).willReturn(Optional.of(returnRequest));
-        given(returnRequest.getOrderItem()).willReturn(orderItem);
+            given(claimRepository.existsClaimRequestBySeller(returnId, sellerId)).willReturn(true);
+            given(claimRepository.findById(returnId)).willReturn(Optional.of(returnRequest));
+            given(returnRequest.getOrderItem()).willReturn(orderItem);
 
-        // when
-        sut.decision(returnId, sellerId, request.decisionType(), request.reason());
+            // when
+            sut.decision(returnId, sellerId, DecisionType.APPROVE, reason);
 
-        // then
-        then(returnRequest).should(times(1)).approve(reason);
-        then(returnRequest).should(never()).reject(any());
-        then(orderItem).should(times(1)).returnApprove();
-        then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+            // then
+            then(returnRequest).should(times(1)).approve(reason);
+            then(returnRequest).should(never()).reject(any());
+            then(orderItem).should(times(1)).returnApprove();
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("반품 거절 - 판매자와 반품 요청이 일치하면 reject가 호출되고 OrderItemHistory가 저장된다")
+        void decision_reject_success() {
+            // given
+            Long returnId = 1L;
+            Long sellerId = 10L;
+            String reason = "거절 사유";
+            ReturnRequest returnRequest = mock(ReturnRequest.class);
+            OrderItem orderItem = mock(OrderItem.class);
+
+            given(claimRepository.existsClaimRequestBySeller(returnId, sellerId)).willReturn(true);
+            given(claimRepository.findById(returnId)).willReturn(Optional.of(returnRequest));
+            given(returnRequest.getOrderItem()).willReturn(orderItem);
+
+            // when
+            sut.decision(returnId, sellerId, DecisionType.REJECT, reason);
+
+            // then
+            then(returnRequest).should(times(1)).reject(reason);
+            then(returnRequest).should(never()).approve(any());
+            then(orderItem).should(times(1)).returnReject();
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
     }
 
-    @Test
-    @DisplayName("반품 거절 - 판매자와 반품 요청이 일치하면 reject가 호출되고 OrderItemHistory가 저장된다")
-    void decision_reject_success() {
-        // given
-        Long returnId = 1L;
-        Long sellerId = 10L;
-        String reason = "거절 사유";
-        ReturnDecisionRequest request = new ReturnDecisionRequest(DecisionType.REJECT, reason);
-        ReturnRequest returnRequest = mock(ReturnRequest.class);
-        OrderItem orderItem = mock(OrderItem.class);
+    @Nested
+    @DisplayName("취소 decision()")
+    class cancel_decision {
 
-        given(claimRepository.existsClaimRequestBySeller(returnId, sellerId)).willReturn(true);
-        given(claimRepository.findById(returnId)).willReturn(Optional.of(returnRequest));
-        given(returnRequest.getOrderItem()).willReturn(orderItem);
+        @Test
+        @DisplayName("취소 승인 - 판매자와 취소 요청이 일치하면 approve가 호출되고 OrderItemHistory가 저장된다")
+        void decision_cancel_approve_success() {
+            // given
+            Long cancelId = 1L;
+            Long sellerId = 10L;
+            String reason = "취소 승인 사유";
 
-        // when
-        sut.decision(returnId, sellerId, request.decisionType(), request.reason());
+            CancelRequest cancelRequest = mock(CancelRequest.class);
+            OrderItem orderItem = mock(OrderItem.class);
 
-        // then
-        then(returnRequest).should(times(1)).reject(reason);
-        then(returnRequest).should(never()).approve(any());
-        then(orderItem).should(times(1)).returnReject();
-        then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+            given(claimRepository.existsClaimRequestBySeller(cancelId, sellerId)).willReturn(true);
+            given(claimRepository.findById(cancelId)).willReturn(Optional.of(cancelRequest));
+            given(cancelRequest.getOrderItem()).willReturn(orderItem);
+
+            // when
+            sut.decision(cancelId, sellerId, DecisionType.APPROVE, reason);
+
+            // then
+            then(cancelRequest).should(times(1)).approve(reason);
+            then(cancelRequest).should(never()).reject(any());
+            then(orderItem).should(times(1)).cancelApprove();
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("취소 거절 - 판매자와 취소 요청이 일치하면 reject가 호출되고 OrderItemHistory가 저장된다")
+        void decision_cancel_reject_success() {
+            // given
+            Long cancelId = 1L;
+            Long sellerId = 10L;
+            String reason = "취소 거절 사유";
+            CancelRequest cancelRequest = mock(CancelRequest.class);
+            OrderItem orderItem = mock(OrderItem.class);
+
+            given(claimRepository.existsClaimRequestBySeller(cancelId, sellerId)).willReturn(true);
+            given(claimRepository.findById(cancelId)).willReturn(Optional.of(cancelRequest));
+            given(cancelRequest.getOrderItem()).willReturn(orderItem);
+
+            // when
+            sut.decision(cancelId, sellerId, DecisionType.REJECT, reason);
+
+            // then
+            then(cancelRequest).should(times(1)).reject(reason);
+            then(cancelRequest).should(never()).approve(any());
+            then(orderItem).should(times(1)).cancelReject();
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
     }
 
-    @Test
-    @DisplayName("판매자와 반품 요청이 매칭되지 않으면 예외가 발생한다")
-    void decision_sellerMismatch_throwException() {
-        // given
-        Long returnId = 1L;
-        Long sellerId = 10L;
+    @Nested
+    @DisplayName("공통 예외")
+    class common_exception {
 
-        ReturnDecisionRequest request = new ReturnDecisionRequest(DecisionType.APPROVE, "사유");
+        @Test
+        @DisplayName("판매자와 요청이 매칭되지 않으면 예외가 발생한다")
+        void decision_sellerMismatch_throwException() {
+            // given
+            Long returnId = 1L;
+            Long sellerId = 10L;
 
-        given(claimRepository.existsClaimRequestBySeller(returnId, sellerId)).willReturn(false);
+            ReturnDecisionRequest request = new ReturnDecisionRequest(DecisionType.APPROVE, "사유");
 
-        // when & then
-        assertThatThrownBy(() -> sut.decision(returnId, sellerId, request.decisionType(), request.reason()))
-            .isInstanceOf(BbangleException.class)
-            .hasMessageContaining(BbangleErrorCode.SELLER_CLAIM_MISMATCH.getMessage());
+            given(claimRepository.existsClaimRequestBySeller(returnId, sellerId)).willReturn(false);
 
-        then(claimRepository).should(never()).findById(any());
-    }
+            // when & then
+            assertThatThrownBy(() -> sut.decision(returnId, sellerId, DecisionType.APPROVE, "사유"))
+                .isInstanceOf(BbangleException.class)
+                .hasMessageContaining(BbangleErrorCode.SELLER_CLAIM_MISMATCH.getMessage());
 
-    @Test
-    @DisplayName("반품 요청이 존재하지 않으면 예외가 발생한다")
-    void decision_claimNotFound_throwException() {
-        // given
-        Long returnId = 1L;
-        Long sellerId = 10L;
+            then(claimRepository).should(never()).findById(any());
+        }
 
-        ReturnDecisionRequest request = new ReturnDecisionRequest(DecisionType.APPROVE, "사유");
+        @Test
+        @DisplayName("요청이 존재하지 않으면 예외가 발생한다")
+        void decision_claimNotFound_throwException() {
+            // given
+            Long returnId = 1L;
+            Long sellerId = 10L;
 
-        given(claimRepository.existsClaimRequestBySeller(returnId, sellerId)).willReturn(true);
-        given(claimRepository.findById(returnId)).willReturn(Optional.empty());
+            given(claimRepository.existsClaimRequestBySeller(returnId, sellerId)).willReturn(true);
+            given(claimRepository.findById(returnId)).willReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> sut.decision(returnId, sellerId, request.decisionType(), request.reason()))
-            .isInstanceOf(BbangleException.class)
-            .hasMessageContaining(BbangleErrorCode.CLAIM_NOT_FOUND.getMessage());
+            // when & then
+            assertThatThrownBy(() -> sut.decision(returnId, sellerId, DecisionType.APPROVE, "사유"))
+                .isInstanceOf(BbangleException.class)
+                .hasMessageContaining(BbangleErrorCode.CLAIM_NOT_FOUND.getMessage());
+        }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/fixture/claim/CancelRequestFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/claim/CancelRequestFixture.java
@@ -1,0 +1,45 @@
+package com.bbangle.bbangle.fixture.claim;
+
+import com.bbangle.bbangle.claim.domain.CancelRequest;
+import com.bbangle.bbangle.claim.domain.constant.CancelRequestStatus;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import java.time.LocalDateTime;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class CancelRequestFixture {
+
+    private CancelRequestFixture() {
+    }
+
+    public static CancelRequest withStatus(CancelRequestStatus status, OrderItem orderItem) {
+        return CancelRequest.builder()
+            .orderItem(orderItem)              // 부모(Claim) 필드
+            .detailReason("테스트 사유")        // 부모(Claim) 필드(필요 없으면 null 가능)
+            .decidedAt(null)                   // 부모(Claim) 필드(결정 전이면 null)
+            .status(status)                    // 자식(CancelRequest) 필드
+            .build();
+    }
+
+    public static CancelRequest requested(OrderItem orderItem) {
+        return withStatus(CancelRequestStatus.REQUESTED, orderItem);
+    }
+
+    public static CancelRequest approved(OrderItem orderItem) {
+        return withStatus(CancelRequestStatus.APPROVED, orderItem);
+    }
+
+    public static CancelRequest rejected(OrderItem orderItem) {
+        return withStatus(CancelRequestStatus.REJECTED, orderItem);
+    }
+
+    public static CancelRequest withId(CancelRequest cr, Long id) {
+        ReflectionTestUtils.setField(cr, "id", id); // Claim의 id 필드
+        return cr;
+    }
+
+    public static CancelRequest withDecidedAt(CancelRequest cr, LocalDateTime decidedAt) {
+        ReflectionTestUtils.setField(cr, "decidedAt", decidedAt); // Claim 필드
+        return cr;
+    }
+
+}

--- a/src/test/java/com/bbangle/bbangle/fixture/order/OrderItemFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/order/OrderItemFixture.java
@@ -31,6 +31,17 @@ public class OrderItemFixture {
             .build();
     }
 
+    public static OrderItem cancelRequestedWithProduct(Product product) {
+        return OrderItem.builder()
+            .product(product)
+            .quantity(1)
+            .productPrice(10000)
+            .unitPrice(10000)
+            .totalPrice(10000)
+            .orderStatus(OrderStatus.CANCEL_REQUESTED)
+            .build();
+    }
+
     public static OrderItem paymentCompleted() {
         return orderItemWithStatus(OrderStatus.PAYMENT_COMPLETED);
     }


### PR DESCRIPTION
## History
- [테스트](https://www.notion.so/sideproject-unione/1-_-_-2e7622e86d3d805982ffcc6a087bdeb0?source=copy_link)
- [API 명세서](https://www.notion.so/sideproject-unione/2d6622e86d3d8088b35cd9af925fa184?source=copy_link)

## 🚀 Major Changes & Explanations
- (셀러) 주문 취소 승인 / 거절 API 기능 개발


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 판매자가 고객의 주문 취소 요청을 승인 또는 거절할 수 있는 기능 추가
  * 취소 결정 처리를 위한 새로운 API 엔드포인트 제공

* **Tests**
  * 취소 요청 결정 처리 관련 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->