### PR TITLE
[Feature] (판매자) 등록한 스토어 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
@@ -185,9 +185,9 @@ public class SellerOrderService {
 
         Sender sender = Sender.of(
             seller.getStore().getName(),
-            seller.getPhoneNumberVO() != null ? seller.getPhoneNumberVO().getPhoneNumber() : null,
-            seller.getOriginAddressLine(),
-            seller.getOriginAddressDetail(),
+            seller.getStore().getPhoneNumberVO() != null ? seller.getStore().getPhoneNumberVO().getPhoneNumber() : null,
+            seller.getStore().getOriginAddressLine(),
+            seller.getStore().getOriginAddressDetail(),
             null
         );
 

--- a/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
@@ -19,6 +19,7 @@ import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderCo
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentRegisterCommand;
 import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
+import com.bbangle.bbangle.store.domain.Store;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -182,12 +183,13 @@ public class SellerOrderService {
 
     private OrderDelivery createOrderDelivery(OrderItem orderItem, Seller seller) {
         Order order = orderItem.getOrder();
+        Store store = seller.getStore();
 
         Sender sender = Sender.of(
-            seller.getStore().getName(),
-            seller.getPhoneNumberVO() != null ? seller.getPhoneNumberVO().getPhoneNumber() : null,
-            seller.getOriginAddressLine(),
-            seller.getOriginAddressDetail(),
+            store.getName(),
+            store.getPhoneNumberVO() != null ? store.getPhoneNumberVO().getPhoneNumber() : null,
+            store.getOriginAddressLine(),
+            store.getOriginAddressDetail(),
             null
         );
 

--- a/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
@@ -19,6 +19,7 @@ import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderCo
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentRegisterCommand;
 import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
+import com.bbangle.bbangle.store.domain.Store;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -182,12 +183,13 @@ public class SellerOrderService {
 
     private OrderDelivery createOrderDelivery(OrderItem orderItem, Seller seller) {
         Order order = orderItem.getOrder();
+        Store store = seller.getStore();
 
         Sender sender = Sender.of(
-            seller.getStore().getName(),
-            seller.getStore().getPhoneNumberVO() != null ? seller.getStore().getPhoneNumberVO().getPhoneNumber() : null,
-            seller.getStore().getOriginAddressLine(),
-            seller.getStore().getOriginAddressDetail(),
+            store.getName(),
+            store.getPhoneNumberVO() != null ? store.getPhoneNumberVO().getPhoneNumber() : null,
+            store.getOriginAddressLine(),
+            store.getOriginAddressDetail(),
             null
         );
 

--- a/src/main/java/com/bbangle/bbangle/seller/seller/controller/SellerController.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/controller/SellerController.java
@@ -41,7 +41,9 @@ public class SellerController implements SellerApi {
 
     @Override
     @GetMapping()
-    public SingleResult<RegisteredStoreDetail> getRegisteredStoreDetail(Long sellerId) {
+    public SingleResult<RegisteredStoreDetail> getRegisteredStoreDetail(
+        @AuthenticationPrincipal Long sellerId
+    ) {
         return responseService.getSingleResult(
             sellerFacade.getRegisteredStoreDetail(sellerId)
         );

--- a/src/main/java/com/bbangle/bbangle/seller/seller/controller/SellerController.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/controller/SellerController.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.seller.seller.controller;
 
 import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.SellerApiPath;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.AccountVerificationRequest;
@@ -8,6 +9,7 @@ import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerAcco
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerDocumentsRegisterRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerStoreNameUpdateRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerUpdateRequest;
+import com.bbangle.bbangle.seller.seller.controller.dto.SellerResponse.RegisteredStoreDetail;
 import com.bbangle.bbangle.seller.seller.controller.swagger.SellerApi;
 import com.bbangle.bbangle.seller.seller.facade.SellerFacade;
 import com.bbangle.bbangle.seller.seller.service.AccountVerificationService;
@@ -18,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,6 +38,14 @@ public class SellerController implements SellerApi {
     private final SellerService sellerService;
     private final SellerFacade sellerFacade;
     private final AccountVerificationService accountVerificationService;
+
+    @Override
+    @GetMapping()
+    public SingleResult<RegisteredStoreDetail> getRegisteredStoreDetail(Long sellerId) {
+        return responseService.getSingleResult(
+            sellerFacade.getRegisteredStoreDetail(sellerId)
+        );
+    }
 
     @PostMapping(value = "/documents", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public CommonResult registerDocuments(

--- a/src/main/java/com/bbangle/bbangle/seller/seller/controller/dto/SellerResponse.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/controller/dto/SellerResponse.java
@@ -1,0 +1,15 @@
+package com.bbangle.bbangle.seller.seller.controller.dto;
+
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDetail;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+public class SellerResponse {
+
+    @Schema(description = "판매자가 등록한 스토어 상세 정보 DTO")
+    @Builder
+    public record RegisteredStoreDetail(
+        @Schema(description = "판매자 ID", example = "1") Long sellerId,
+        @Schema(description = "스토어 상세 정보 (등록한 스토어가 존재할 경우)", nullable = true) SellerStoreDetail store
+    ) {}
+}

--- a/src/main/java/com/bbangle/bbangle/seller/seller/controller/swagger/SellerApi.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/controller/swagger/SellerApi.java
@@ -1,12 +1,14 @@
 package com.bbangle.bbangle.seller.seller.controller.swagger;
 
 import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.exception.GlobalControllerAdvice;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.AccountVerificationRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerAccountUpdateRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerDocumentsRegisterRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerStoreNameUpdateRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerUpdateRequest;
+import com.bbangle.bbangle.seller.seller.controller.dto.SellerResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -19,6 +21,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Seller", description = "(판매자) 판매자 API")
 public interface SellerApi {
+
+    @Operation(
+        summary = "판매자 스토어 정보 조회",
+        description = "판매자가 등록한 스토어의 상세 정보를 조회합니다."
+    )
+    SingleResult<SellerResponse.RegisteredStoreDetail> getRegisteredStoreDetail(
+        @AuthenticationPrincipal Long sellerId
+    );
 
     @Operation(
         summary = "(판매자) 판매자 서류 등록",

--- a/src/main/java/com/bbangle/bbangle/seller/seller/facade/SellerFacade.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/facade/SellerFacade.java
@@ -1,13 +1,18 @@
 package com.bbangle.bbangle.seller.seller.facade;
 
 import com.bbangle.bbangle.image.customer.service.S3Service;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.seller.controller.dto.SellerResponse;
 import com.bbangle.bbangle.seller.seller.facade.command.RegisterDocumentsCommand;
 import com.bbangle.bbangle.seller.seller.facade.dto.DocumentUploadInfo;
 import com.bbangle.bbangle.seller.seller.facade.dto.UploadedDocument;
 import com.bbangle.bbangle.seller.seller.service.AccountVerificationService;
 import com.bbangle.bbangle.seller.seller.service.SellerDocumentService;
+import com.bbangle.bbangle.seller.seller.service.SellerService;
 import com.bbangle.bbangle.seller.seller.service.command.RegisterDocumentCommand;
 import com.bbangle.bbangle.seller.seller.service.info.SellerDocumentInfo;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.seller.controller.mapper.SellerStoreMapper;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +29,8 @@ public class SellerFacade {
     private final S3Service s3Service;
     private final SellerDocumentService sellerDocumentService;
     private final AccountVerificationService accountVerificationService;
+    private final SellerService sellerService;
+    private final SellerStoreMapper sellerStoreMapper;
 
     @Transactional
     public List<SellerDocumentInfo> registerDocuments(RegisterDocumentsCommand command) {
@@ -70,6 +77,23 @@ public class SellerFacade {
                 s3Service.deleteImage(doc.filePath());
             });
             throw e;
+        }
+    }
+
+    public SellerResponse.RegisteredStoreDetail getRegisteredStoreDetail(Long sellerId) {
+        Seller seller = sellerService.getSellerById(sellerId);
+        Store store = seller.getStore();
+
+        if (store == null) {
+            return SellerResponse.RegisteredStoreDetail.builder()
+                .sellerId(seller.getId())
+                .store(null)
+                .build();
+        } else {
+            return SellerResponse.RegisteredStoreDetail.builder()
+                .sellerId(seller.getId())
+                .store(sellerStoreMapper.toSellerStoreDetail(store))
+                .build();
         }
     }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/seller/facade/SellerFacade.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/facade/SellerFacade.java
@@ -82,16 +82,11 @@ public class SellerFacade {
     public SellerResponse.RegisteredStoreDetail getRegisteredStoreDetail(Long sellerId) {
         Seller seller = sellerService.getSellerById(sellerId);
 
-        if (seller.getStore() == null) {
-            return SellerResponse.RegisteredStoreDetail.builder()
-                .sellerId(seller.getId())
-                .store(null)
-                .build();
-        }
-
         return SellerResponse.RegisteredStoreDetail.builder()
             .sellerId(seller.getId())
-            .store(sellerStoreMapper.toSellerStoreDetail(seller.getStore()))
+            .store(seller.getStore() != null ?
+                sellerStoreMapper.toSellerStoreDetail(seller.getStore())
+                : null)
             .build();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/seller/facade/SellerFacade.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/facade/SellerFacade.java
@@ -11,7 +11,6 @@ import com.bbangle.bbangle.seller.seller.service.SellerDocumentService;
 import com.bbangle.bbangle.seller.seller.service.SellerService;
 import com.bbangle.bbangle.seller.seller.service.command.RegisterDocumentCommand;
 import com.bbangle.bbangle.seller.seller.service.info.SellerDocumentInfo;
-import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.seller.controller.mapper.SellerStoreMapper;
 import java.util.ArrayList;
 import java.util.List;
@@ -82,18 +81,17 @@ public class SellerFacade {
 
     public SellerResponse.RegisteredStoreDetail getRegisteredStoreDetail(Long sellerId) {
         Seller seller = sellerService.getSellerById(sellerId);
-        Store store = seller.getStore();
 
-        if (store == null) {
+        if (seller.getStore() == null) {
             return SellerResponse.RegisteredStoreDetail.builder()
                 .sellerId(seller.getId())
                 .store(null)
                 .build();
-        } else {
-            return SellerResponse.RegisteredStoreDetail.builder()
-                .sellerId(seller.getId())
-                .store(sellerStoreMapper.toSellerStoreDetail(store))
-                .build();
         }
+
+        return SellerResponse.RegisteredStoreDetail.builder()
+            .sellerId(seller.getId())
+            .store(sellerStoreMapper.toSellerStoreDetail(seller.getStore()))
+            .build();
     }
 }

--- a/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceTest.java
@@ -18,7 +18,7 @@ import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderRespo
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderConfirmCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentRegisterCommand;
 import com.bbangle.bbangle.seller.domain.Seller;
-import com.bbangle.bbangle.seller.domain.model.PhoneNumberVO;
+import com.bbangle.bbangle.store.domain.model.PhoneNumberVO;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.store.domain.Store;
 import org.junit.jupiter.api.DisplayName;
@@ -304,15 +304,13 @@ class SellerOrderServiceTest {
             Store store = newEntity(Store.class);
             ReflectionTestUtils.setField(store, "id", storeId);
             ReflectionTestUtils.setField(store, "name", "테스트 스토어");
-
-            PhoneNumberVO phoneNumberVO = PhoneNumberVO.of("01012345678", null);
+            ReflectionTestUtils.setField(store, "phoneNumberVO", PhoneNumberVO.of("01012345678", null));
+            ReflectionTestUtils.setField(store, "originAddressLine", "서울시 강남구");
+            ReflectionTestUtils.setField(store, "originAddressDetail", "테헤란로 123");
 
             Seller seller = newEntity(Seller.class);
             ReflectionTestUtils.setField(seller, "id", sellerId);
             ReflectionTestUtils.setField(seller, "store", store);
-            ReflectionTestUtils.setField(seller, "phoneNumberVO", phoneNumberVO);
-            ReflectionTestUtils.setField(seller, "originAddressLine", "서울시 강남구");
-            ReflectionTestUtils.setField(seller, "originAddressDetail", "테헤란로 123");
 
             ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
                     .sellerId(sellerId)
@@ -460,15 +458,13 @@ class SellerOrderServiceTest {
             Store store = newEntity(Store.class);
             ReflectionTestUtils.setField(store, "id", storeId);
             ReflectionTestUtils.setField(store, "name", "테스트 스토어");
-
-            PhoneNumberVO phoneNumberVO = PhoneNumberVO.of("01012345678", null);
+            ReflectionTestUtils.setField(store, "phoneNumberVO", PhoneNumberVO.of("01012345678", null));
+            ReflectionTestUtils.setField(store, "originAddressLine", "서울시 강남구");
+            ReflectionTestUtils.setField(store, "originAddressDetail", "테헤란로 123");
 
             Seller seller = newEntity(Seller.class);
             ReflectionTestUtils.setField(seller, "id", sellerId);
             ReflectionTestUtils.setField(seller, "store", store);
-            ReflectionTestUtils.setField(seller, "phoneNumberVO", phoneNumberVO);
-            ReflectionTestUtils.setField(seller, "originAddressLine", "서울시 강남구");
-            ReflectionTestUtils.setField(seller, "originAddressDetail", "테헤란로 123");
 
             ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
                     .sellerId(sellerId)

--- a/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceTest.java
@@ -1,5 +1,12 @@
 package com.bbangle.bbangle.order.seller.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
 import com.bbangle.bbangle.delivery.domain.Receiver;
 import com.bbangle.bbangle.delivery.domain.Sender;
 import com.bbangle.bbangle.delivery.domain.Shipping;
@@ -18,9 +25,12 @@ import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderRespo
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderConfirmCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentRegisterCommand;
 import com.bbangle.bbangle.seller.domain.Seller;
-import com.bbangle.bbangle.seller.domain.model.PhoneNumberVO;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.domain.model.PhoneNumberVO;
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,17 +39,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import java.lang.reflect.Constructor;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
 
 @DisplayName("[비즈니스 로직] SellerOrderService")
 @ExtendWith(MockitoExtension.class)
@@ -132,6 +131,16 @@ class SellerOrderServiceTest {
 
         assertThat(okItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED);
         assertThat(skipItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED);
+    }
+
+    private <T> T newEntity(Class<T> clazz) {
+        try {
+            Constructor<T> constructor = clazz.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Nested
@@ -501,16 +510,6 @@ class SellerOrderServiceTest {
             assertThat(result.successOrderItemIds())
                     .asList()
                     .containsExactly(10L);
-        }
-    }
-
-    private <T> T newEntity(Class<T> clazz) {
-        try {
-            Constructor<T> constructor = clazz.getDeclaredConstructor();
-            constructor.setAccessible(true);
-            return constructor.newInstance();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/seller/seller/controller/SellerControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/controller/SellerControllerTest.java
@@ -1,0 +1,125 @@
+package com.bbangle.bbangle.seller.seller.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
+import com.bbangle.bbangle.common.client.annotation.WithMockAuthenticationPrincipal;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.JsonDataEncoder;
+import com.bbangle.bbangle.config.security.SecurityConfig;
+import com.bbangle.bbangle.config.security.SellerApiPath;
+import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.seller.seller.controller.dto.SellerResponse;
+import com.bbangle.bbangle.seller.seller.facade.SellerFacade;
+import com.bbangle.bbangle.seller.seller.service.AccountVerificationService;
+import com.bbangle.bbangle.seller.seller.service.SellerService;
+import com.bbangle.bbangle.store.domain.StoreStatus;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDetail;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("[컨트롤러 테스트] SellerControllerTest")
+@WebMvcTest(controllers = SellerController.class)
+@Import({
+    TestSlackAdaptorConfig.class,
+    JsonDataEncoder.class,
+    TokenProvider.class,
+    TestJwtPropertiesConfig.class,
+    ResponseService.class,
+    SecurityConfig.class
+})
+@ActiveProfiles("test")
+class SellerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ResponseService responseService;
+
+    @MockBean
+    private SellerService sellerService;
+
+    @MockBean
+    private SellerFacade sellerFacade;
+
+    @MockBean
+    private AccountVerificationService accountVerificationService;
+
+    @Nested
+    @DisplayName("getRegisteredStoreDetail() 테스트")
+    class GetRegisteredStoreDetailTest {
+
+        @Test
+        @DisplayName("등록 신청한 스토어가 존재할 경우 해당 스토어 정보를 조회한다.")
+        @WithMockAuthenticationPrincipal(role = "SELLER")
+        void getRegisteredStoreDetail_exist_registeredStore() throws Exception {
+
+            // given
+            Long sellerId = 1L;
+            StoreResponse.SellerStoreDetail sellerStoreDetail =
+                new SellerStoreDetail(1L, "빵긋", "테스트", "test.png", StoreStatus.RESERVED, "01012345678", "01098765432", "123@test.com", "서울", "123동");
+
+            SellerResponse.RegisteredStoreDetail response = SellerResponse.RegisteredStoreDetail.builder()
+                .sellerId(1L)
+                .store(sellerStoreDetail)
+                .build();
+
+            given(sellerFacade.getRegisteredStoreDetail(sellerId)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get(SellerApiPath.PREFIX + "/sellers"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.sellerId").value(sellerId))
+                .andExpect(jsonPath("$.result.store.storeId").value(sellerStoreDetail.storeId()))
+                .andExpect(jsonPath("$.result.store.name").value(sellerStoreDetail.name()))
+                .andExpect(jsonPath("$.result.store.introduce").value(sellerStoreDetail.introduce()))
+                .andExpect(jsonPath("$.result.store.profile").value(sellerStoreDetail.profile()))
+                .andExpect(jsonPath("$.result.store.status").value(sellerStoreDetail.status().name()))
+                .andExpect(jsonPath("$.result.store.phoneNumber").value(sellerStoreDetail.phoneNumber()))
+                .andExpect(jsonPath("$.result.store.subPhoneNumber").value(sellerStoreDetail.subPhoneNumber()))
+                .andExpect(jsonPath("$.result.store.email").value(sellerStoreDetail.email()))
+                .andExpect(jsonPath("$.result.store.originAddress").value(sellerStoreDetail.originAddress()))
+                .andExpect(jsonPath("$.result.store.originAddressDetail").value(sellerStoreDetail.originAddressDetail()));
+
+            verify(sellerFacade).getRegisteredStoreDetail(sellerId);
+        }
+
+        @Test
+        @DisplayName("등록 신청한 스토어가 없을 경우 null을 반환한다.")
+        @WithMockAuthenticationPrincipal(role = "SELLER")
+        void getRegisteredStoreDetail_noExist_registeredStore() throws Exception {
+
+            // given
+            Long sellerId = 1L;
+
+            SellerResponse.RegisteredStoreDetail response = SellerResponse.RegisteredStoreDetail.builder()
+                .sellerId(1L)
+                .store(null)
+                .build();
+
+            given(sellerFacade.getRegisteredStoreDetail(sellerId)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get(SellerApiPath.PREFIX + "/sellers"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.sellerId").value(sellerId))
+                .andExpect(jsonPath("$.result.store").isEmpty());
+
+            verify(sellerFacade).getRegisteredStoreDetail(sellerId);
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/seller/seller/controller/SellerControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/controller/SellerControllerTest.java
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-@DisplayName("[컨트롤러 테스트] SellerControllerTest")
+@DisplayName("[컨트롤러 테스트] SellerController")
 @WebMvcTest(controllers = SellerController.class)
 @Import({
     TestSlackAdaptorConfig.class,

--- a/src/test/java/com/bbangle/bbangle/seller/seller/facade/SellerFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/facade/SellerFacadeIntegrationTest.java
@@ -1,0 +1,74 @@
+package com.bbangle.bbangle.seller.seller.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bbangle.bbangle.config.S3IntegrationTestSupport;
+import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
+import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
+import com.bbangle.bbangle.seller.seller.controller.dto.SellerResponse;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.domain.StoreStatus;
+import com.bbangle.bbangle.store.repository.StoreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[통합테스트] SellerFacadeUnitTest")
+@Transactional
+class SellerFacadeIntegrationTest extends S3IntegrationTestSupport {
+
+    @Autowired
+    SellerFacade sellerFacade;
+
+    @Autowired
+    private SellerRepository sellerRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Nested
+    @DisplayName("getRegisteredStoreDetail() 테스트")
+    class GetRegisteredStoreDetailTest {
+
+        private Seller saveNewSeller(Store store) {
+            Seller seller = SellerFixture.defaultSeller(store);
+            return sellerRepository.saveAndFlush(seller);
+        }
+
+        @Test
+        @DisplayName("등록 신청한 스토어가 존재할 경우 해당 스토어 정보를 조회한다.")
+        void getRegisteredStoreDetail_exist_registeredStore() {
+
+            // given
+            Store store = storeRepository.saveAndFlush(StoreFixture.defaultStore(StoreStatus.RESERVED));
+            Seller seller = saveNewSeller(store);
+
+            // when
+            SellerResponse.RegisteredStoreDetail result = sellerFacade.getRegisteredStoreDetail(seller.getId());
+
+            // then
+            assertThat(result.sellerId()).isEqualTo(seller.getId());
+            assertThat(result.store().storeId()).isEqualTo(store.getId());
+            assertThat(result.store().name()).isEqualTo(store.getName());
+        }
+
+        @Test
+        @DisplayName("등록 신청한 스토어가 없을 경우 null을 반환한다.")
+        void getRegisteredStoreDetail_noExist_registeredStore() {
+
+            // given
+            Seller seller = saveNewSeller(null);
+
+            // when
+            SellerResponse.RegisteredStoreDetail result = sellerFacade.getRegisteredStoreDetail(seller.getId());
+
+            // then
+            assertThat(result.sellerId()).isEqualTo(seller.getId());
+            assertThat(result.store()).isNull();
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/seller/seller/facade/SellerFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/facade/SellerFacadeIntegrationTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-@DisplayName("[통합테스트] SellerFacadeUnitTest")
+@DisplayName("[통합테스트] SellerFacade")
 @Transactional
 class SellerFacadeIntegrationTest extends S3IntegrationTestSupport {
 

--- a/src/test/java/com/bbangle/bbangle/seller/seller/facade/SellerFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/facade/SellerFacadeUnitTest.java
@@ -1,0 +1,106 @@
+package com.bbangle.bbangle.seller.seller.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
+import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.image.customer.service.S3Service;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
+import com.bbangle.bbangle.seller.seller.controller.dto.SellerResponse;
+import com.bbangle.bbangle.seller.seller.service.AccountVerificationService;
+import com.bbangle.bbangle.seller.seller.service.SellerDocumentService;
+import com.bbangle.bbangle.seller.seller.service.SellerService;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.domain.StoreStatus;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
+import com.bbangle.bbangle.store.seller.controller.mapper.SellerStoreMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[단위테스트] SellerFacadeUnitTest")
+@ExtendWith(MockitoExtension.class)
+class SellerFacadeUnitTest {
+
+    @InjectMocks
+    SellerFacade sellerFacade;
+
+    @Mock
+    S3Service s3Service;
+
+    @Mock
+    SellerDocumentService sellerDocumentService;
+
+    @Mock
+    AccountVerificationService accountVerificationService;
+
+    @Mock
+    SellerService sellerService;
+
+    @Mock
+    SellerStoreMapper sellerStoreMapper;
+
+    @Nested
+    @DisplayName("getRegisteredStoreDetail() 테스트")
+    class GetRegisteredStoreDetailTest {
+
+        @Test
+        @DisplayName("등록 신청한 스토어가 존재할 경우 해당 스토어 정보를 조회한다.")
+        void getRegisteredStoreDetail_exist_registeredStore() {
+
+            // given
+            Long sellerId = 1L;
+
+            Store store = StoreFixture.defaultStore(StoreStatus.RESERVED);
+            Seller seller = SellerFixture.withId(
+                SellerFixture.defaultSeller(store),
+                sellerId
+            );
+            StoreResponse.SellerStoreDetail storeDetail = mock(StoreResponse.SellerStoreDetail.class);
+
+            given(sellerService.getSellerById(sellerId)).willReturn(seller);
+            given(sellerStoreMapper.toSellerStoreDetail(store)).willReturn(storeDetail);
+
+            // when
+            SellerResponse.RegisteredStoreDetail result = sellerFacade.getRegisteredStoreDetail(sellerId);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.sellerId()).isEqualTo(sellerId);
+            assertThat(result.store()).isEqualTo(storeDetail);
+        }
+
+        @Test
+        @DisplayName("등록 신청한 스토어가 없을 경우 null을 반환한다.")
+        void getRegisteredStoreDetail_noExist_registeredStore() {
+
+            // given
+            Long sellerId = 1L;
+            Seller seller = SellerFixture.withId(
+                SellerFixture.defaultSeller(CertificationStatus.NEW),
+                sellerId
+            );
+
+            given(sellerService.getSellerById(sellerId)).willReturn(seller);
+
+            // when
+            SellerResponse.RegisteredStoreDetail result = sellerFacade.getRegisteredStoreDetail(sellerId);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.sellerId()).isEqualTo(sellerId);
+            assertThat(result.store()).isNull();
+            verify(sellerStoreMapper, never()).toSellerStoreDetail(any());
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/seller/seller/facade/SellerFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/facade/SellerFacadeUnitTest.java
@@ -28,7 +28,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@DisplayName("[단위테스트] SellerFacadeUnitTest")
+@DisplayName("[단위테스트] SellerFacade")
 @ExtendWith(MockitoExtension.class)
 class SellerFacadeUnitTest {
 

--- a/src/test/java/com/bbangle/bbangle/seller/seller/service/SellerServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/seller/service/SellerServiceIntegrationTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 
-@DisplayName("[통합테스트] SellerServiceIntegrationTest")
+@DisplayName("[통합테스트] SellerService")
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional


### PR DESCRIPTION
## Reviewer
1팀
- @kmindev 경민님

## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

- 연관된 이슈 : #591 
- [Notion 개발 일정](https://www.notion.so/sideproject-unione/1-_-_-307622e86d3d808f9fd7d6aaf3993607?source=copy_link)
- [API 명세서](https://www.notion.so/sideproject-unione/307622e86d3d80b8a129d1b683c3c84c?v=2c6622e86d3d8157890d000cc857bdd2&source=copy_link)

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

- (판매자) 등록한 스토어 정보 조회

해당 판매자가 등록한 스토어의 상세 정보를 조회합니다.
해당 API는 판매자 회원가입 페이지와 판매자 스토어 정보 수정 페이지에서 사용할 예정입니다.

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->
<img width="292" height="33" alt="image" src="https://github.com/user-attachments/assets/ce4ac74b-6184-426c-8559-1be06bd4fdd0" />
<img width="689" height="313" alt="image" src="https://github.com/user-attachments/assets/250b34fd-4576-4e6d-81a3-563e231c6a2f" />

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 판매자가 등록한 매장 정보를 조회하는 신규 GET API 엔드포인트 추가

* **버그 수정**
  * 배송 주문 생성 시 발신자 정보(매장명, 전화번호, 발신지 주소)를 매장 정보에서 정확히 가져오도록 수정

* **테스트**
  * 신규 단위/통합/컨트롤러 테스트 추가로 조회 흐름과 응답 포맷 검증 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->