### PR TITLE
[Refactor] Seller → Store 연락처 이관에 따른 createOrderDelivery 수정

### DIFF
--- a/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
@@ -19,6 +19,7 @@ import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderCo
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentRegisterCommand;
 import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
+import com.bbangle.bbangle.store.domain.Store;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -182,12 +183,13 @@ public class SellerOrderService {
 
     private OrderDelivery createOrderDelivery(OrderItem orderItem, Seller seller) {
         Order order = orderItem.getOrder();
+        Store store = seller.getStore();
 
         Sender sender = Sender.of(
-            seller.getStore().getName(),
-            seller.getPhoneNumberVO() != null ? seller.getPhoneNumberVO().getPhoneNumber() : null,
-            seller.getOriginAddressLine(),
-            seller.getOriginAddressDetail(),
+            store.getName(),
+            store.getPhoneNumberVO() != null ? store.getPhoneNumberVO().getPhoneNumber() : null,
+            store.getOriginAddressLine(),
+            store.getOriginAddressDetail(),
             null
         );
 

--- a/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceTest.java
@@ -18,7 +18,7 @@ import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderRespo
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderConfirmCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentRegisterCommand;
 import com.bbangle.bbangle.seller.domain.Seller;
-import com.bbangle.bbangle.seller.domain.model.PhoneNumberVO;
+import com.bbangle.bbangle.store.domain.model.PhoneNumberVO;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.store.domain.Store;
 import org.junit.jupiter.api.DisplayName;
@@ -304,15 +304,13 @@ class SellerOrderServiceTest {
             Store store = newEntity(Store.class);
             ReflectionTestUtils.setField(store, "id", storeId);
             ReflectionTestUtils.setField(store, "name", "테스트 스토어");
-
-            PhoneNumberVO phoneNumberVO = PhoneNumberVO.of("01012345678", null);
+            ReflectionTestUtils.setField(store, "phoneNumberVO", PhoneNumberVO.of("01012345678", null));
+            ReflectionTestUtils.setField(store, "originAddressLine", "서울시 강남구");
+            ReflectionTestUtils.setField(store, "originAddressDetail", "테헤란로 123");
 
             Seller seller = newEntity(Seller.class);
             ReflectionTestUtils.setField(seller, "id", sellerId);
             ReflectionTestUtils.setField(seller, "store", store);
-            ReflectionTestUtils.setField(seller, "phoneNumberVO", phoneNumberVO);
-            ReflectionTestUtils.setField(seller, "originAddressLine", "서울시 강남구");
-            ReflectionTestUtils.setField(seller, "originAddressDetail", "테헤란로 123");
 
             ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
                     .sellerId(sellerId)
@@ -460,15 +458,13 @@ class SellerOrderServiceTest {
             Store store = newEntity(Store.class);
             ReflectionTestUtils.setField(store, "id", storeId);
             ReflectionTestUtils.setField(store, "name", "테스트 스토어");
-
-            PhoneNumberVO phoneNumberVO = PhoneNumberVO.of("01012345678", null);
+            ReflectionTestUtils.setField(store, "phoneNumberVO", PhoneNumberVO.of("01012345678", null));
+            ReflectionTestUtils.setField(store, "originAddressLine", "서울시 강남구");
+            ReflectionTestUtils.setField(store, "originAddressDetail", "테헤란로 123");
 
             Seller seller = newEntity(Seller.class);
             ReflectionTestUtils.setField(seller, "id", sellerId);
             ReflectionTestUtils.setField(seller, "store", store);
-            ReflectionTestUtils.setField(seller, "phoneNumberVO", phoneNumberVO);
-            ReflectionTestUtils.setField(seller, "originAddressLine", "서울시 강남구");
-            ReflectionTestUtils.setField(seller, "originAddressDetail", "테헤란로 123");
 
             ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
                     .sellerId(sellerId)


### PR DESCRIPTION
## History

* #593 

---

## 🚀 Major Changes & Explanations

- Seller 엔티티에 존재하던 연락처 및 출고지 주소 필드를 Store 엔티티로 이관
- `SellerOrderService#createOrderDelivery`에서 Sender 생성 시
  기존 Seller 기반 참조를 Store 기준으로 수정
- Seller의 phone / origin_address 관련 필드 접근 제거
- Store를 통해 Sender 정보 생성하도록 로직 변경
- 도메인 구조 변경으로 인한 컴파일 에러 해결

---

## 📷 Test Image

- 애플리케이션 정상 기동 확인
- 운송장 등록 API 정상 동작 확인
- 기존 주문/배송 흐름 영향 없음 확인



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **리팩토링**
  * 내부 코드 개선 및 유지보수가 진행되었습니다. 사용자에게 보이는 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->