### PR TITLE
[Feature] (판매자) 상품수정 API 작업

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/domain/Board.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Board.java
@@ -206,6 +206,36 @@ public class Board extends SoftDeleteBaseEntity {
         return price - discountValue;
     }
 
+    public void update(
+        String title,
+        Integer price,
+        String discountType,
+        Integer discountValue,
+        Integer deliveryFee,
+        Integer freeShippingConditions,
+        Boolean isFresh,
+        String productionStartTime,
+        String deliveryCondition,
+        String deliveryCompany
+    ) {
+        DiscountType parsedDiscountType = DiscountType.from(discountType);
+        ProductionStartTime parsedProductionStartTime = ProductionStartTime.from(productionStartTime);
+        validate(title, price, parsedDiscountType, discountValue, deliveryFee);
+
+        this.title = title;
+        this.price = price;
+        this.discountType = parsedDiscountType;
+        this.discountValue = discountValue;
+        this.discountRate = calculateDiscountRate(price, parsedDiscountType, discountValue);
+        this.discountPrice = calculateDiscountPrice(price, parsedDiscountType, discountValue);
+        this.deliveryFee = deliveryFee;
+        this.freeShippingConditions = freeShippingConditions;
+        this.isFresh = isFresh;
+        this.productionStartTime = parsedProductionStartTime;
+        this.deliveryCondition = deliveryCondition;
+        this.courier = deliveryCompany;
+    }
+
     public List<String> getTags() {
         return products.stream()
             .map(Product::getTags)

--- a/src/main/java/com/bbangle/bbangle/board/domain/BoardDetail.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/BoardDetail.java
@@ -39,6 +39,10 @@ public class BoardDetail extends SoftDeleteBaseEntity {
         return HtmlUtils.convertHtmlWithFullImageUrls2(content);
     }
 
+    public void update(String content) {
+        this.content = content;
+    }
+
     public void updateBoard(Board board) {
         this.board = board;
     }

--- a/src/main/java/com/bbangle/bbangle/board/domain/Product.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Product.java
@@ -186,7 +186,7 @@ public class Product extends SoftDeleteBaseEntity {
         validate(title, monday, tuesday, wednesday, thursday, friday, saturday, sunday);
 
         this.title = title;
-        this.price = this.board.getPrice() + plusPriceWithBoardPrice;
+        this.price = plusPriceWithBoardPrice;
         this.category = Category.from(category);
         this.stock = stock;
         this.soldout = stock == 0;

--- a/src/main/java/com/bbangle/bbangle/board/domain/Product.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/Product.java
@@ -164,6 +164,47 @@ public class Product extends SoftDeleteBaseEntity {
         }
     }
 
+    public void update(
+        String title,
+        int plusPriceWithBoardPrice,
+        String category,
+        int stock,
+        boolean glutenFreeTag,
+        boolean highProteinTag,
+        boolean sugarFreeTag,
+        boolean veganTag,
+        boolean ketogenicTag,
+        boolean monday,
+        boolean tuesday,
+        boolean wednesday,
+        boolean thursday,
+        boolean friday,
+        boolean saturday,
+        boolean sunday,
+        Nutrition nutrition
+    ) {
+        validate(title, monday, tuesday, wednesday, thursday, friday, saturday, sunday);
+
+        this.title = title;
+        this.price = this.board.getPrice() + plusPriceWithBoardPrice;
+        this.category = Category.from(category);
+        this.stock = stock;
+        this.soldout = stock == 0;
+        this.glutenFreeTag = glutenFreeTag;
+        this.highProteinTag = highProteinTag;
+        this.sugarFreeTag = sugarFreeTag;
+        this.veganTag = veganTag;
+        this.ketogenicTag = ketogenicTag;
+        this.monday = monday;
+        this.tuesday = tuesday;
+        this.wednesday = wednesday;
+        this.thursday = thursday;
+        this.friday = friday;
+        this.saturday = saturday;
+        this.sunday = sunday;
+        this.nutrition = nutrition;
+    }
+
     // True인 태그 스트링 리스트로 만들어 반환
     public List<String> getTags() {
         return Stream.of(

--- a/src/main/java/com/bbangle/bbangle/board/domain/ProductInfoNotice.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/ProductInfoNotice.java
@@ -56,6 +56,37 @@ public class ProductInfoNotice extends SoftDeleteBaseEntity {
         this.importFood = importFood;
     }
 
+    public void update(
+        String productName,
+        String foodType,
+        String manufacturer,
+        String originLocation,
+        String manufactureDate,
+        String expirationDate,
+        String storageGuide,
+        String packagingQuantityUnit,
+        String rawMaterialName,
+        String nutritionInfo,
+        String transgenic,
+        String customerWarning,
+        String importFood
+    ) {
+        validate(productName);
+        this.productName = productName;
+        this.foodType = foodType;
+        this.manufacturer = manufacturer;
+        this.originLocation = originLocation;
+        this.manufactureDate = manufactureDate;
+        this.expirationDate = expirationDate;
+        this.storageGuide = storageGuide;
+        this.packagingQuantityUnit = packagingQuantityUnit;
+        this.rawMaterialName = rawMaterialName;
+        this.nutritionInfo = nutritionInfo;
+        this.transgenic = transgenic;
+        this.customerWarning = customerWarning;
+        this.importFood = importFood;
+    }
+
     private void validate(String productName) {
         if (productName == null || productName.length() < 3 || productName.length() > 50) {
             throw new BbangleException(BbangleErrorCode.INVALID_PRODUCT_INFO_NOTICE_NAME);

--- a/src/main/java/com/bbangle/bbangle/board/repository/BoardRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/BoardRepository.java
@@ -17,7 +17,7 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardQueryD
     @EntityGraph(attributePaths = {"store", "boardDetail", "boardStatistic"})
     Optional<Board> findById(Long boardId);
 
-    @EntityGraph(attributePaths = {"store", "productInfoNotice", "boardDetail", "products", "productImgs"})
+    @EntityGraph(attributePaths = {"store", "productInfoNotice", "boardDetail"})
     Optional<Board> findWithAllById(Long boardId);
 
     @EntityGraph(attributePaths = {"boardStatistic"})

--- a/src/main/java/com/bbangle/bbangle/board/repository/BoardRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/BoardRepository.java
@@ -17,6 +17,9 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardQueryD
     @EntityGraph(attributePaths = {"store", "boardDetail", "boardStatistic"})
     Optional<Board> findById(Long boardId);
 
+    @EntityGraph(attributePaths = {"store", "productInfoNotice", "boardDetail", "products", "productImgs"})
+    Optional<Board> findWithAllById(Long boardId);
+
     @EntityGraph(attributePaths = {"boardStatistic"})
     Page<Board> findByIsCrawlingTrueAndIsDeletedFalse(Pageable pageable);
 

--- a/src/main/java/com/bbangle/bbangle/board/seller/controller/SellerBoardController.java
+++ b/src/main/java/com/bbangle/bbangle/board/seller/controller/SellerBoardController.java
@@ -2,7 +2,7 @@ package com.bbangle.bbangle.board.seller.controller;
 
 import com.bbangle.bbangle.board.seller.controller.dto.request.CreateBoardRequest;
 import com.bbangle.bbangle.board.seller.controller.dto.request.ProductBoardRequest.ProductBoardSearchRequest;
-import com.bbangle.bbangle.board.seller.controller.dto.request.ProductBoardUpdateRequest;
+import com.bbangle.bbangle.board.seller.controller.dto.request.UpdateBoardRequest;
 import com.bbangle.bbangle.board.seller.controller.dto.response.SellerBoardResponse.SellerBoardSearchResponse;
 import com.bbangle.bbangle.board.seller.controller.swagger.SellerBoardApi;
 import com.bbangle.bbangle.board.seller.facade.SellerBoardFacade;
@@ -68,13 +68,15 @@ public class SellerBoardController implements SellerBoardApi {
         return responseService.getSingleResult(res);
     }
 
-    @PutMapping("/{boardId}")
-    public CommonResult changeProductBoard(
+    @PutMapping(value = "/{boardId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public SingleResult<BoardInfo> changeProductBoard(
+        @AuthenticationPrincipal Long sellerId,
         @PathVariable(name = "boardId") Long boardId,
-        @RequestParam(name = "storeId") Long storeId,
-        @Valid @RequestBody ProductBoardUpdateRequest request) {
-        // TODO: 비즈니스 로직 구현 예정
-        return responseService.getSingleResult(request);
+        @Valid @ModelAttribute UpdateBoardRequest request
+    ) {
+        return responseService.getSingleResult(
+            sellerBoardFacade.updateBoard(request.toCommand(sellerId, boardId))
+        );
     }
 
     @PostMapping("/{boardId}/copy")

--- a/src/main/java/com/bbangle/bbangle/board/seller/controller/dto/request/UpdateBoardRequest.java
+++ b/src/main/java/com/bbangle/bbangle/board/seller/controller/dto/request/UpdateBoardRequest.java
@@ -1,0 +1,60 @@
+package com.bbangle.bbangle.board.seller.controller.dto.request;
+
+import com.bbangle.bbangle.board.seller.facade.command.UpdateBoardFacadeCommand;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdateBoardRequest {
+
+    private String title;
+    private Boolean isFresh;
+    private String productionStartTime;
+    private Integer price;
+    private Integer discountValue;
+    private String discountType;
+    private String deliveryCondition;
+    private String deliveryCompany;
+    private Integer deliveryFee;
+    private Integer freeShippingConditions;
+    private List<UpdateProductRequest> products;
+    @Valid
+    private BoardDetailRequest boardDetailRequest;
+    private ProductInfoNoticeRequest productInfoNoticeRequest;
+    private MultipartFile thumbnailImgFile;
+    private String existingThumbnailUrl;
+    private List<MultipartFile> newSubImages;
+    private List<String> existingSubImageUrls;
+    private List<MultipartFile> boardDetailImages;
+
+    public UpdateBoardFacadeCommand toCommand(Long sellerId, Long boardId) {
+        return UpdateBoardFacadeCommand.builder()
+            .sellerId(sellerId)
+            .boardId(boardId)
+            .title(title)
+            .isFresh(isFresh)
+            .productionStartTime(productionStartTime)
+            .price(price)
+            .discountValue(discountValue)
+            .discountType(discountType)
+            .deliveryCondition(deliveryCondition)
+            .deliveryCompany(deliveryCompany)
+            .deliveryFee(deliveryFee)
+            .freeShippingConditions(freeShippingConditions)
+            .thumbnailImgFile(thumbnailImgFile)
+            .existingThumbnailUrl(existingThumbnailUrl)
+            .newSubImages(newSubImages)
+            .existingSubImageUrls(existingSubImageUrls)
+            .boardDetailImages(boardDetailImages)
+            .products(products)
+            .boardDetailRequest(boardDetailRequest)
+            .productInfoNoticeRequest(productInfoNoticeRequest)
+            .build();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/board/seller/controller/dto/request/UpdateProductRequest.java
+++ b/src/main/java/com/bbangle/bbangle/board/seller/controller/dto/request/UpdateProductRequest.java
@@ -1,0 +1,39 @@
+package com.bbangle.bbangle.board.seller.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "상품 수정 요청 DTO")
+public class UpdateProductRequest {
+
+    @Schema(description = "상품 ID (null이면 신규 상품)", example = "1")
+    private Long productId;
+
+    @Schema(description = "상품 카테고리")
+    private String category;
+
+    @Schema(description = "상품명", example = "비건 쿠키")
+    private String title;
+
+    @Schema(description = "성분 카테고리")
+    private DietaryTagsRequest dietaryTags;
+
+    @Schema(description = "게시글 가격에 추가되는 금액", example = "1000")
+    private int plusPriceWithBoardPrice;
+
+    @Schema(description = "재고 수량", example = "100")
+    private int stock;
+
+    @Schema(description = "주문 가능 요일 정보")
+    private AvailabilityRequest availability;
+
+    @Schema(description = "영양 정보")
+    private NutritionInfoRequest nutritionInfo;
+}

--- a/src/main/java/com/bbangle/bbangle/board/seller/controller/swagger/SellerBoardApi.java
+++ b/src/main/java/com/bbangle/bbangle/board/seller/controller/swagger/SellerBoardApi.java
@@ -2,7 +2,7 @@ package com.bbangle.bbangle.board.seller.controller.swagger;
 
 import com.bbangle.bbangle.board.seller.controller.dto.request.CreateBoardRequest;
 import com.bbangle.bbangle.board.seller.controller.dto.request.ProductBoardRequest.ProductBoardSearchRequest;
-import com.bbangle.bbangle.board.seller.controller.dto.request.ProductBoardUpdateRequest;
+import com.bbangle.bbangle.board.seller.controller.dto.request.UpdateBoardRequest;
 import com.bbangle.bbangle.board.seller.controller.dto.response.SellerBoardResponse.SellerBoardSearchResponse;
 import com.bbangle.bbangle.board.seller.service.info.BoardInfo;
 import com.bbangle.bbangle.common.dto.CommonResult;
@@ -104,31 +104,51 @@ public interface SellerBoardApi {
         @ParameterObject
         ProductBoardSearchRequest request);
 
-    @Operation(summary = "판매자 상품 게시글 수정", description = "상품 게시글을 수정합니다.")
-
+    @Operation(
+        summary = "판매자 상품 게시글 수정",
+        description = "상품 게시글을 수정합니다. multipart/form-data 형식으로 전송합니다. " +
+            "thumbnailImgFile이 없으면 existingThumbnailUrl로 기존 썸네일을 유지합니다. " +
+            "products[].productId가 null이면 신규 상품으로 추가됩니다."
+    )
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "상품 게시글 수정",
-            content = @Content(schema = @Schema(implementation = CommonResult.class),
-                examples = @ExampleObject(name = "successResponse",
+        @ApiResponse(
+            responseCode = "200",
+            description = "상품 게시글 수정 성공",
+            content = @Content(
+                schema = @Schema(implementation = SingleResult.class),
+                examples = @ExampleObject(
+                    name = "successResponse",
                     summary = "성공응답 예시",
                     value = """
                         {
                             "success": true,
                             "code": 0,
                             "message": "SUCCESS",
+                            "content": {
+                                "boardId": 1,
+                                "title": "수정된 상품명",
+                                "createdAt": "2024-01-01T00:00:00"
+                            }
                         }
-                        """))),
-        @ApiResponse(
-            responseCode = "400", description = "잘못된 요청 데이터",
-            content = @Content(schema = @Schema(implementation = GlobalControllerAdvice.class)
+                        """
+                )
             )
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "해당 게시글에 대한 접근 권한 없음",
+            content = @Content(schema = @Schema(implementation = GlobalControllerAdvice.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "게시글을 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = GlobalControllerAdvice.class))
         )
-    }
-    )
-    CommonResult changeProductBoard(
-        @Parameter(name = "storeId", description = "스토어 ID", example = "1") Long storeId,
-        @Parameter(name = "boardId", description = "게시글 ID", example = "1") Long boardId,
-        ProductBoardUpdateRequest request);
+    })
+    SingleResult<BoardInfo> changeProductBoard(
+        @Parameter(hidden = true) @AuthenticationPrincipal Long sellerId,
+        @Parameter(name = "boardId", description = "수정할 게시글 ID", example = "1") Long boardId,
+        @Valid @ModelAttribute UpdateBoardRequest request);
 
 
     @Operation(

--- a/src/main/java/com/bbangle/bbangle/board/seller/facade/SellerBoardFacade.java
+++ b/src/main/java/com/bbangle/bbangle/board/seller/facade/SellerBoardFacade.java
@@ -7,6 +7,8 @@ import com.bbangle.bbangle.board.seller.service.command.BoardDetailCommand;
 import com.bbangle.bbangle.board.seller.service.command.ProductImgCommand;
 import com.bbangle.bbangle.board.seller.service.info.BoardInfo;
 import com.bbangle.bbangle.common.service.HtmlContentProcessor;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.image.customer.service.S3Service;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.seller.service.SellerStoreService;
@@ -110,6 +112,9 @@ public class SellerBoardFacade {
                 uploadedUrls.add(thumbnailUrl);
             } else {
                 thumbnailUrl = command.existingThumbnailUrl();
+            }
+            if (thumbnailUrl == null) {
+                throw new BbangleException(BbangleErrorCode.MISSING_BOARD_THUMBNAIL);
             }
 
             List<ProductImgCommand> productImgCommands = buildProductImgCommands(

--- a/src/main/java/com/bbangle/bbangle/board/seller/facade/SellerBoardFacade.java
+++ b/src/main/java/com/bbangle/bbangle/board/seller/facade/SellerBoardFacade.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.board.seller.facade;
 
 import com.bbangle.bbangle.board.seller.facade.command.CreateBoardFacadeCommand;
+import com.bbangle.bbangle.board.seller.facade.command.UpdateBoardFacadeCommand;
 import com.bbangle.bbangle.board.seller.service.SellerBoardService;
 import com.bbangle.bbangle.board.seller.service.command.BoardDetailCommand;
 import com.bbangle.bbangle.board.seller.service.command.ProductImgCommand;
@@ -98,6 +99,64 @@ public class SellerBoardFacade {
         }
 
         return productImgCommands;
+    }
+
+    public BoardInfo updateBoard(UpdateBoardFacadeCommand command) {
+        List<String> uploadedUrls = new ArrayList<>();
+        try {
+            String thumbnailUrl;
+            if (command.thumbnailImgFile() != null) {
+                thumbnailUrl = s3Service.saveAndReturnWithCdn(BOARD_IMAGE_FOLDER, command.thumbnailImgFile());
+                uploadedUrls.add(thumbnailUrl);
+            } else {
+                thumbnailUrl = command.existingThumbnailUrl();
+            }
+
+            List<ProductImgCommand> productImgCommands = buildProductImgCommands(
+                thumbnailUrl,
+                command.newSubImages(),
+                command.existingSubImageUrls(),
+                uploadedUrls
+            );
+
+            BoardDetailCommand boardDetailCommand = processBoardDetailContent(
+                command.boardDetailRequest().getContent(),
+                command.boardDetailImages(),
+                uploadedUrls
+            );
+
+            return sellerBoardService.updateBoard(
+                command.toServiceCommand(productImgCommands, boardDetailCommand)
+            );
+        } catch (Exception e) {
+            rollbackUploadedImages(uploadedUrls);
+            throw e;
+        }
+    }
+
+    private List<ProductImgCommand> buildProductImgCommands(
+        String thumbnailUrl,
+        List<MultipartFile> newSubImages,
+        List<String> existingSubImageUrls,
+        List<String> uploadedUrls
+    ) {
+        List<ProductImgCommand> commands = new ArrayList<>();
+        commands.add(new ProductImgCommand(thumbnailUrl, 0));
+
+        int order = 1;
+        if (existingSubImageUrls != null) {
+            for (String url : existingSubImageUrls) {
+                commands.add(new ProductImgCommand(url, order++));
+            }
+        }
+        if (newSubImages != null) {
+            for (MultipartFile file : newSubImages) {
+                String url = s3Service.saveAndReturnWithCdn(BOARD_IMAGE_FOLDER, file);
+                uploadedUrls.add(url);
+                commands.add(new ProductImgCommand(url, order++));
+            }
+        }
+        return commands;
     }
 
     private void rollbackUploadedImages(List<String> uploadedUrls) {

--- a/src/main/java/com/bbangle/bbangle/board/seller/facade/command/UpdateBoardFacadeCommand.java
+++ b/src/main/java/com/bbangle/bbangle/board/seller/facade/command/UpdateBoardFacadeCommand.java
@@ -1,0 +1,126 @@
+package com.bbangle.bbangle.board.seller.facade.command;
+
+import com.bbangle.bbangle.board.domain.Nutrition;
+import com.bbangle.bbangle.board.seller.controller.dto.request.BoardDetailRequest;
+import com.bbangle.bbangle.board.seller.controller.dto.request.NutritionInfoRequest;
+import com.bbangle.bbangle.board.seller.controller.dto.request.ProductInfoNoticeRequest;
+import com.bbangle.bbangle.board.seller.controller.dto.request.UpdateProductRequest;
+import com.bbangle.bbangle.board.seller.service.command.BoardDetailCommand;
+import com.bbangle.bbangle.board.seller.service.command.ProductImgCommand;
+import com.bbangle.bbangle.board.seller.service.command.ProductInfoNoticeCommand;
+import com.bbangle.bbangle.board.seller.service.command.UpdateBoardServiceCommand;
+import com.bbangle.bbangle.board.seller.service.command.UpdateProductCommand;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import java.util.List;
+import lombok.Builder;
+import org.springframework.web.multipart.MultipartFile;
+
+@Builder
+public record UpdateBoardFacadeCommand(
+    Long sellerId,
+    Long boardId,
+    String title,
+    Boolean isFresh,
+    String productionStartTime,
+    Integer price,
+    Integer discountValue,
+    String discountType,
+    String deliveryCondition,
+    String deliveryCompany,
+    Integer freeShippingConditions,
+    Integer deliveryFee,
+    MultipartFile thumbnailImgFile,
+    String existingThumbnailUrl,
+    List<MultipartFile> newSubImages,
+    List<String> existingSubImageUrls,
+    List<MultipartFile> boardDetailImages,
+    BoardDetailRequest boardDetailRequest,
+    ProductInfoNoticeRequest productInfoNoticeRequest,
+    List<UpdateProductRequest> products
+) {
+
+    public UpdateBoardServiceCommand toServiceCommand(
+        List<ProductImgCommand> productImgCommands,
+        BoardDetailCommand boardDetailCommand
+    ) {
+        return UpdateBoardServiceCommand.builder()
+            .sellerId(sellerId)
+            .boardId(boardId)
+            .title(title)
+            .isFresh(isFresh)
+            .productionStartTime(productionStartTime)
+            .price(price)
+            .discountValue(discountValue)
+            .discountType(discountType)
+            .deliveryCondition(deliveryCondition)
+            .deliveryCompany(deliveryCompany)
+            .freeShippingConditions(freeShippingConditions)
+            .deliveryFee(deliveryFee)
+            .productImgs(productImgCommands)
+            .boardDetail(boardDetailCommand)
+            .productInfoNotice(toProductInfoNoticeCommand())
+            .products(toUpdateProductCommands())
+            .build();
+    }
+
+    private ProductInfoNoticeCommand toProductInfoNoticeCommand() {
+        return ProductInfoNoticeCommand.builder()
+            .productName(productInfoNoticeRequest.getProductName())
+            .foodType(productInfoNoticeRequest.getFoodType())
+            .manufacturer(productInfoNoticeRequest.getManufacturer())
+            .originLocation(productInfoNoticeRequest.getOriginLocation())
+            .manufactureDate(productInfoNoticeRequest.getManufactureDate())
+            .expirationDate(productInfoNoticeRequest.getExpirationDate())
+            .storageGuide(productInfoNoticeRequest.getStorageGuide())
+            .packagingQuantityUnit(productInfoNoticeRequest.getPackagingQuantityUnit())
+            .rawMaterialName(productInfoNoticeRequest.getRawMaterialName())
+            .nutritionInfo(productInfoNoticeRequest.getNutritionInfo())
+            .transgenic(productInfoNoticeRequest.getTransgenic())
+            .customerWarning(productInfoNoticeRequest.getCustomerWarning())
+            .importFood(productInfoNoticeRequest.getImportFood())
+            .build();
+    }
+
+    private List<UpdateProductCommand> toUpdateProductCommands() {
+        return products.stream()
+            .map(this::toUpdateProductCommand)
+            .toList();
+    }
+
+    private UpdateProductCommand toUpdateProductCommand(UpdateProductRequest req) {
+        if (req.getDietaryTags() == null || req.getAvailability() == null || req.getNutritionInfo() == null) {
+            throw new BbangleException(BbangleErrorCode.INVALID_PRODUCT_REQUEST);
+        }
+        NutritionInfoRequest ni = req.getNutritionInfo();
+        Nutrition nutrition = new Nutrition(
+            ni.getTotalWeight(),
+            ni.getServingSize(),
+            ni.getCarbohydrates(),
+            ni.getSugars(),
+            ni.getProtein(),
+            ni.getFat(),
+            ni.getCalories()
+        );
+        return UpdateProductCommand.builder()
+            .productId(req.getProductId())
+            .title(req.getTitle())
+            .category(req.getCategory())
+            .plusPriceWithBoardPrice(req.getPlusPriceWithBoardPrice())
+            .stock(req.getStock())
+            .glutenFreeTag(req.getDietaryTags().isGlutenFreeTag())
+            .highProteinTag(req.getDietaryTags().isHighProteinTag())
+            .sugarFreeTag(req.getDietaryTags().isSugarFreeTag())
+            .veganTag(req.getDietaryTags().isVeganTag())
+            .ketogenicTag(req.getDietaryTags().isKetogenicTag())
+            .monday(req.getAvailability().isMonday())
+            .tuesday(req.getAvailability().isTuesday())
+            .wednesday(req.getAvailability().isWednesday())
+            .thursday(req.getAvailability().isThursday())
+            .friday(req.getAvailability().isFriday())
+            .saturday(req.getAvailability().isSaturday())
+            .sunday(req.getAvailability().isSunday())
+            .nutrition(nutrition)
+            .build();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/board/seller/service/SellerBoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/seller/service/SellerBoardService.java
@@ -4,10 +4,20 @@ import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.domain.Product;
 import com.bbangle.bbangle.board.domain.ProductImg;
 import com.bbangle.bbangle.board.repository.BoardRepository;
+import com.bbangle.bbangle.board.repository.ProductImgRepository;
 import com.bbangle.bbangle.board.seller.service.command.CreateBoardServiceCommand;
 import com.bbangle.bbangle.board.seller.service.command.ProductImgCommand;
+import com.bbangle.bbangle.board.seller.service.command.UpdateBoardServiceCommand;
+import com.bbangle.bbangle.board.seller.service.command.UpdateProductCommand;
 import com.bbangle.bbangle.board.seller.service.info.BoardInfo;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class SellerBoardService {
 
     private final BoardRepository boardRepository;
+    private final ProductImgRepository productImgRepository;
+    private final SellerRepository sellerRepository;
 
     @Transactional
     public BoardInfo createBoard(CreateBoardServiceCommand command) {
@@ -52,6 +64,112 @@ public class SellerBoardService {
         boardRepository.save(board);
 
         return BoardInfo.from(board);
+    }
+
+    @Transactional
+    public BoardInfo updateBoard(UpdateBoardServiceCommand command) {
+        Board board = boardRepository.findWithAllById(command.boardId())
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.BOARD_NOT_FOUND));
+
+        validateOwnership(command.sellerId(), board);
+
+        board.update(
+            command.title(),
+            command.price(),
+            command.discountType(),
+            command.discountValue(),
+            command.deliveryFee(),
+            command.freeShippingConditions(),
+            command.isFresh(),
+            command.productionStartTime(),
+            command.deliveryCondition(),
+            command.deliveryCompany()
+        );
+
+        board.getProductInfoNotice().update(
+            command.productInfoNotice().productName(),
+            command.productInfoNotice().foodType(),
+            command.productInfoNotice().manufacturer(),
+            command.productInfoNotice().originLocation(),
+            command.productInfoNotice().manufactureDate(),
+            command.productInfoNotice().expirationDate(),
+            command.productInfoNotice().storageGuide(),
+            command.productInfoNotice().packagingQuantityUnit(),
+            command.productInfoNotice().rawMaterialName(),
+            command.productInfoNotice().nutritionInfo(),
+            command.productInfoNotice().transgenic(),
+            command.productInfoNotice().customerWarning(),
+            command.productInfoNotice().importFood()
+        );
+
+        board.getBoardDetail().update(command.boardDetail().content());
+
+        mergeProducts(board, command.products());
+
+        // dirty 상태(board, productInfoNotice, boardDetail, products) flush
+        // softDeleteByBoardIds의 clearAutomatically = true로 인해 EM이 clear되기 전에 반영해야 함
+        boardRepository.flush();
+
+        // 기존 ProductImg soft-delete 후 새 이미지 저장
+        productImgRepository.softDeleteByBoardIds(List.of(command.boardId()));
+        List<ProductImg> newProductImgs = command.productImgs().stream()
+            .map(ProductImgCommand::toProductImg)
+            .toList();
+        newProductImgs.forEach(img -> img.updateBoard(board));
+        productImgRepository.saveAll(newProductImgs);
+
+        return BoardInfo.from(board);
+    }
+
+    private void validateOwnership(Long sellerId, Board board) {
+        Long storeIdOfSeller = sellerRepository.findStoreIdBySellerId(sellerId);
+        if (storeIdOfSeller == null || !board.getStore().getId().equals(storeIdOfSeller)) {
+            throw new BbangleException(BbangleErrorCode.FORBIDDEN_BOARD_ACCESS);
+        }
+    }
+
+    private void mergeProducts(Board board, List<UpdateProductCommand> productCommands) {
+        Map<Long, Product> existingMap = board.getProducts().stream()
+            .filter(p -> !p.isDeleted())
+            .collect(Collectors.toMap(Product::getId, p -> p));
+
+        Set<Long> requestedIds = productCommands.stream()
+            .filter(cmd -> cmd.productId() != null)
+            .map(UpdateProductCommand::productId)
+            .collect(Collectors.toSet());
+
+        existingMap.values().stream()
+            .filter(p -> !requestedIds.contains(p.getId()))
+            .forEach(Product::delete);
+
+        List<Product> newProducts = new ArrayList<>();
+        for (UpdateProductCommand cmd : productCommands) {
+            if (cmd.productId() != null && existingMap.containsKey(cmd.productId())) {
+                existingMap.get(cmd.productId()).update(
+                    cmd.title(),
+                    cmd.plusPriceWithBoardPrice(),
+                    cmd.category(),
+                    cmd.stock(),
+                    cmd.glutenFreeTag(),
+                    cmd.highProteinTag(),
+                    cmd.sugarFreeTag(),
+                    cmd.veganTag(),
+                    cmd.ketogenicTag(),
+                    cmd.monday(),
+                    cmd.tuesday(),
+                    cmd.wednesday(),
+                    cmd.thursday(),
+                    cmd.friday(),
+                    cmd.saturday(),
+                    cmd.sunday(),
+                    cmd.nutrition()
+                );
+            } else {
+                newProducts.add(cmd.toNewProduct(board));
+            }
+        }
+
+        board.addProducts(newProducts);
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/board/seller/service/SellerBoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/seller/service/SellerBoardService.java
@@ -144,7 +144,9 @@ public class SellerBoardService {
 
         List<Product> newProducts = new ArrayList<>();
         for (UpdateProductCommand cmd : productCommands) {
-            if (cmd.productId() != null && existingMap.containsKey(cmd.productId())) {
+            if (cmd.productId() == null) {
+                newProducts.add(cmd.toNewProduct(board));
+            } else if (existingMap.containsKey(cmd.productId())) {
                 existingMap.get(cmd.productId()).update(
                     cmd.title(),
                     cmd.plusPriceWithBoardPrice(),
@@ -165,7 +167,7 @@ public class SellerBoardService {
                     cmd.nutrition()
                 );
             } else {
-                newProducts.add(cmd.toNewProduct(board));
+                throw new BbangleException(BbangleErrorCode.PRODUCT_NOT_FOUND);
             }
         }
 

--- a/src/main/java/com/bbangle/bbangle/board/seller/service/command/UpdateBoardServiceCommand.java
+++ b/src/main/java/com/bbangle/bbangle/board/seller/service/command/UpdateBoardServiceCommand.java
@@ -1,0 +1,25 @@
+package com.bbangle.bbangle.board.seller.service.command;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record UpdateBoardServiceCommand(
+    Long sellerId,
+    Long boardId,
+    String title,
+    Boolean isFresh,
+    String productionStartTime,
+    Integer price,
+    Integer discountValue,
+    String discountType,
+    String deliveryCondition,
+    String deliveryCompany,
+    Integer freeShippingConditions,
+    Integer deliveryFee,
+    List<ProductImgCommand> productImgs,
+    List<UpdateProductCommand> products,
+    BoardDetailCommand boardDetail,
+    ProductInfoNoticeCommand productInfoNotice
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/board/seller/service/command/UpdateProductCommand.java
+++ b/src/main/java/com/bbangle/bbangle/board/seller/service/command/UpdateProductCommand.java
@@ -1,0 +1,52 @@
+package com.bbangle.bbangle.board.seller.service.command;
+
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.Nutrition;
+import com.bbangle.bbangle.board.domain.Product;
+import lombok.Builder;
+
+@Builder
+public record UpdateProductCommand(
+    Long productId,
+    String title,
+    String category,
+    int plusPriceWithBoardPrice,
+    int stock,
+    boolean glutenFreeTag,
+    boolean highProteinTag,
+    boolean sugarFreeTag,
+    boolean veganTag,
+    boolean ketogenicTag,
+    boolean monday,
+    boolean tuesday,
+    boolean wednesday,
+    boolean thursday,
+    boolean friday,
+    boolean saturday,
+    boolean sunday,
+    Nutrition nutrition
+) {
+
+    public Product toNewProduct(Board board) {
+        return new Product(
+            board,
+            title,
+            plusPriceWithBoardPrice,
+            category,
+            stock,
+            glutenFreeTag,
+            highProteinTag,
+            sugarFreeTag,
+            veganTag,
+            ketogenicTag,
+            monday,
+            tuesday,
+            wednesday,
+            thursday,
+            friday,
+            saturday,
+            sunday,
+            nutrition
+        );
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -116,6 +116,8 @@ public enum BbangleErrorCode {
     ENCRYPTION_FAILED(-712, "암호화 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     DECRYPTION_FAILED(-713, "복호화 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ALREADY_REGISTER_STORE(-714, "이미 스토어를 등록한 판매자 계정입니다.", BAD_REQUEST),
+    FORBIDDEN_BOARD_ACCESS(-715, "해당 게시글에 대한 접근 권한이 없습니다.", FORBIDDEN),
+    PRODUCT_NOT_FOUND(-716, "존재하지 않는 상품입니다.", NOT_FOUND),
 
     // Store Error (721~740)
     INVALID_STORE(-721, "유효하지 않은 스토어 객체입니다.", BAD_REQUEST),

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -118,6 +118,7 @@ public enum BbangleErrorCode {
     ALREADY_REGISTER_STORE(-714, "이미 스토어를 등록한 판매자 계정입니다.", BAD_REQUEST),
     FORBIDDEN_BOARD_ACCESS(-715, "해당 게시글에 대한 접근 권한이 없습니다.", FORBIDDEN),
     PRODUCT_NOT_FOUND(-716, "존재하지 않는 상품입니다.", NOT_FOUND),
+    MISSING_BOARD_THUMBNAIL(-717, "썸네일 이미지는 필수입니다. 새 파일 또는 기존 URL을 제공해주세요.", BAD_REQUEST),
 
     // Store Error (721~740)
     INVALID_STORE(-721, "유효하지 않은 스토어 객체입니다.", BAD_REQUEST),

--- a/src/test/java/com/bbangle/bbangle/board/domain/BoardDetailTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/domain/BoardDetailTest.java
@@ -1,0 +1,47 @@
+package com.bbangle.bbangle.board.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[단위 테스트] BoardDetail 도메인")
+class BoardDetailTest {
+
+    @Nested
+    @DisplayName("update 메서드")
+    class Update {
+
+        @Test
+        @DisplayName("정상적인 입력으로 BoardDetail content를 수정한다")
+        void success() {
+            // given
+            BoardDetail boardDetail = BoardDetail.builder()
+                .content("<p>기존 상세 내용</p>")
+                .build();
+
+            // when
+            boardDetail.update("<p>수정된 상세 내용</p><img src=\"https://cdn.bbangle.com/img.png\">");
+
+            // then
+            assertThat(boardDetail.getContent())
+                .isEqualTo("<p>수정된 상세 내용</p><img src=\"https://cdn.bbangle.com/img.png\">");
+        }
+
+        @Test
+        @DisplayName("빈 문자열로 content를 수정한다")
+        void updateWithEmptyContent() {
+            // given
+            BoardDetail boardDetail = BoardDetail.builder()
+                .content("<p>기존 내용</p>")
+                .build();
+
+            // when
+            boardDetail.update("");
+
+            // then
+            assertThat(boardDetail.getContent()).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/board/domain/BoardTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/domain/BoardTest.java
@@ -185,6 +185,136 @@ class BoardTest {
     }
 
     @Nested
+    @DisplayName("update 메서드")
+    class Update {
+
+        private Board createDefaultBoard() {
+            return Board.sellerCreate(
+                store, "기존 게시글", 10000, "RATE", 10,
+                3000, 30000, false, "T_09_10", "NORMAL",
+                "CJ대한통운", productInfoNotice, boardDetail
+            );
+        }
+
+        @Test
+        @DisplayName("정상적인 입력으로 Board를 수정한다")
+        void success() {
+            // given
+            Board board = createDefaultBoard();
+
+            // when
+            board.update("수정된 게시글", 20000, "AMOUNT", 5000, 2500, 50000,
+                true, "T_07_08", "COLD", "우체국택배");
+
+            // then
+            assertThat(board.getTitle()).isEqualTo("수정된 게시글");
+            assertThat(board.getPrice()).isEqualTo(20000);
+            assertThat(board.getDiscountType()).isEqualTo(DiscountType.AMOUNT);
+            assertThat(board.getDiscountValue()).isEqualTo(5000);
+            assertThat(board.getDiscountPrice()).isEqualTo(15000);
+            assertThat(board.getDeliveryFee()).isEqualTo(2500);
+            assertThat(board.getFreeShippingConditions()).isEqualTo(50000);
+            assertThat(board.getIsFresh()).isTrue();
+            assertThat(board.getCourier()).isEqualTo("우체국택배");
+        }
+
+        @Test
+        @DisplayName("title이 blank이면 예외가 발생한다")
+        void failWhenTitleIsBlank() {
+            // given
+            Board board = createDefaultBoard();
+
+            // when & then
+            assertThatThrownBy(() -> board.update(
+                "  ", 10000, "RATE", 10, 3000, 30000,
+                false, "T_09_10", "NORMAL", "CJ대한통운"
+            ))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.INVALID_BOARD_TITLE);
+        }
+
+        @Test
+        @DisplayName("price가 음수이면 예외가 발생한다")
+        void failWhenPriceIsNegative() {
+            // given
+            Board board = createDefaultBoard();
+
+            // when & then
+            assertThatThrownBy(() -> board.update(
+                "수정된 게시글", -1, "RATE", 10, 3000, 30000,
+                false, "T_09_10", "NORMAL", "CJ대한통운"
+            ))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.INVALID_BOARD_PRICE);
+        }
+
+        @Test
+        @DisplayName("RATE 할인율이 100을 초과하면 예외가 발생한다")
+        void failWhenRateExceeds100() {
+            // given
+            Board board = createDefaultBoard();
+
+            // when & then
+            assertThatThrownBy(() -> board.update(
+                "수정된 게시글", 10000, "RATE", 101, 3000, 30000,
+                false, "T_09_10", "NORMAL", "CJ대한통운"
+            ))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.INVALID_BOARD_DISCOUNT);
+        }
+
+        @Test
+        @DisplayName("AMOUNT 할인금액이 가격을 초과하면 예외가 발생한다")
+        void failWhenAmountExceedsPrice() {
+            // given
+            Board board = createDefaultBoard();
+
+            // when & then
+            assertThatThrownBy(() -> board.update(
+                "수정된 게시글", 10000, "AMOUNT", 10001, 3000, 30000,
+                false, "T_09_10", "NORMAL", "CJ대한통운"
+            ))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.INVALID_BOARD_DISCOUNT);
+        }
+
+        @Test
+        @DisplayName("deliveryFee가 음수이면 예외가 발생한다")
+        void failWhenDeliveryFeeIsNegative() {
+            // given
+            Board board = createDefaultBoard();
+
+            // when & then
+            assertThatThrownBy(() -> board.update(
+                "수정된 게시글", 10000, "RATE", 10, -1, 30000,
+                false, "T_09_10", "NORMAL", "CJ대한통운"
+            ))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.INVALID_DELIVERY_FEE);
+        }
+
+        @Test
+        @DisplayName("RATE 타입으로 수정하면 discountRate와 discountPrice가 재계산된다")
+        void recalculatesDiscountWithRate() {
+            // given
+            Board board = createDefaultBoard();
+
+            // when
+            board.update("수정된 게시글", 20000, "RATE", 20, 3000, 30000,
+                false, "T_09_10", "NORMAL", "CJ대한통운");
+
+            // then
+            assertThat(board.getDiscountRate()).isEqualTo(20);
+            assertThat(board.getDiscountPrice()).isEqualTo(16000);
+        }
+    }
+
+    @Nested
     @DisplayName("할인가격 계산")
     class DiscountPriceCalculation {
 

--- a/src/test/java/com/bbangle/bbangle/board/domain/ProductInfoNoticeTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/domain/ProductInfoNoticeTest.java
@@ -1,0 +1,91 @@
+package com.bbangle.bbangle.board.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.board.domain.ProductInfoNoticeFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[단위 테스트] ProductInfoNotice 도메인")
+class ProductInfoNoticeTest {
+
+    @Nested
+    @DisplayName("update 메서드")
+    class Update {
+
+        @Test
+        @DisplayName("정상적인 입력으로 ProductInfoNotice를 수정한다")
+        void success() {
+            // given
+            ProductInfoNotice notice = ProductInfoNoticeFixture.defaultNotice();
+
+            // when
+            notice.update("수정된상품명", "과자류", "수정제조사", "수정소재지",
+                "2025-01-01", "2025-12-31", "냉장보관",
+                "1개", "밀가루, 설탕", "탄수화물 30g",
+                "해당없음", "알레르기 주의", "해당없음");
+
+            // then
+            assertThat(notice.getProductName()).isEqualTo("수정된상품명");
+            assertThat(notice.getFoodType()).isEqualTo("과자류");
+            assertThat(notice.getManufacturer()).isEqualTo("수정제조사");
+            assertThat(notice.getOriginLocation()).isEqualTo("수정소재지");
+            assertThat(notice.getManufactureDate()).isEqualTo("2025-01-01");
+            assertThat(notice.getExpirationDate()).isEqualTo("2025-12-31");
+            assertThat(notice.getStorageGuide()).isEqualTo("냉장보관");
+            assertThat(notice.getPackagingQuantityUnit()).isEqualTo("1개");
+            assertThat(notice.getRawMaterialName()).isEqualTo("밀가루, 설탕");
+            assertThat(notice.getNutritionInfo()).isEqualTo("탄수화물 30g");
+            assertThat(notice.getTransgenic()).isEqualTo("해당없음");
+            assertThat(notice.getCustomerWarning()).isEqualTo("알레르기 주의");
+            assertThat(notice.getImportFood()).isEqualTo("해당없음");
+        }
+
+        @Test
+        @DisplayName("productName이 null이면 예외가 발생한다")
+        void failWhenProductNameIsNull() {
+            // given
+            ProductInfoNotice notice = ProductInfoNoticeFixture.defaultNotice();
+
+            // when & then
+            assertThatThrownBy(() -> notice.update(null, null, null, null,
+                null, null, null, null, null, null, null, null, null))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.INVALID_PRODUCT_INFO_NOTICE_NAME);
+        }
+
+        @Test
+        @DisplayName("productName이 3자 미만이면 예외가 발생한다")
+        void failWhenProductNameTooShort() {
+            // given
+            ProductInfoNotice notice = ProductInfoNoticeFixture.defaultNotice();
+
+            // when & then
+            assertThatThrownBy(() -> notice.update("ab", null, null, null,
+                null, null, null, null, null, null, null, null, null))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.INVALID_PRODUCT_INFO_NOTICE_NAME);
+        }
+
+        @Test
+        @DisplayName("productName이 50자 초과이면 예외가 발생한다")
+        void failWhenProductNameTooLong() {
+            // given
+            ProductInfoNotice notice = ProductInfoNoticeFixture.defaultNotice();
+            String longName = "가".repeat(51);
+
+            // when & then
+            assertThatThrownBy(() -> notice.update(longName, null, null, null,
+                null, null, null, null, null, null, null, null, null))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.INVALID_PRODUCT_INFO_NOTICE_NAME);
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/board/domain/ProductTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/domain/ProductTest.java
@@ -152,7 +152,7 @@ class ProductTest {
 
             // then
             assertThat(product.getTitle()).isEqualTo("수정된상품");
-            assertThat(product.getPrice()).isEqualTo(board.getPrice() + 500);
+            assertThat(product.getPrice()).isEqualTo(500);
             assertThat(product.getCategory()).isEqualTo(Category.COOKIE);
             assertThat(product.getStock()).isEqualTo(20);
             assertThat(product.isSoldout()).isFalse();
@@ -229,18 +229,10 @@ class ProductTest {
         }
 
         @Test
-        @DisplayName("board price 변경 후 update 호출 시 price가 재계산된다")
-        void priceRecalculatedAfterBoardPriceChange() {
+        @DisplayName("update 호출 시 price는 plusPriceWithBoardPrice 값으로 저장된다")
+        void priceStoredAsPlusPriceWithBoardPrice() {
             // given
-            Board updatedBoard = BoardFixture.defaultBoard();
-            updatedBoard.update("게시글", 20000, "RATE", 0, 0, 0,
-                false, "T_09_10", "NORMAL", "CJ대한통운");
-            Product product = new Product(
-                updatedBoard, "기존상품", updatedBoard.getPrice(), "BREAD", 10,
-                false, false, false, false, false,
-                true, false, false, false, false, false, false,
-                nutrition
-            );
+            Product product = createDefaultProduct();
 
             // when
             product.update("기존상품", 1000, "BREAD", 10,
@@ -249,7 +241,7 @@ class ProductTest {
                 nutrition);
 
             // then
-            assertThat(product.getPrice()).isEqualTo(21000); // 20000 + 1000
+            assertThat(product.getPrice()).isEqualTo(1000);
         }
     }
 

--- a/src/test/java/com/bbangle/bbangle/board/domain/ProductTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/domain/ProductTest.java
@@ -122,6 +122,138 @@ class ProductTest {
     }
 
     @Nested
+    @DisplayName("update 메서드")
+    class Update {
+
+        private final Board board = BoardFixture.defaultBoard();
+        private final Nutrition nutrition = new Nutrition(100, 50, 30, 10, 5, 3, 200);
+
+        private Product createDefaultProduct() {
+            return new Product(
+                board, "기존상품", board.getPrice(), "BREAD", 10,
+                true, false, false, false, false,
+                true, false, false, false, false, false, false,
+                nutrition
+            );
+        }
+
+        @Test
+        @DisplayName("정상적인 입력으로 Product를 수정한다")
+        void success() {
+            // given
+            Product product = createDefaultProduct();
+            Nutrition newNutrition = new Nutrition(200, 100, 60, 20, 10, 6, 400);
+
+            // when
+            product.update("수정된상품", 500, "COOKIE", 20,
+                false, true, false, false, false,
+                false, true, false, false, false, false, false,
+                newNutrition);
+
+            // then
+            assertThat(product.getTitle()).isEqualTo("수정된상품");
+            assertThat(product.getPrice()).isEqualTo(board.getPrice() + 500);
+            assertThat(product.getCategory()).isEqualTo(Category.COOKIE);
+            assertThat(product.getStock()).isEqualTo(20);
+            assertThat(product.isSoldout()).isFalse();
+            assertThat(product.isGlutenFreeTag()).isFalse();
+            assertThat(product.isHighProteinTag()).isTrue();
+            assertThat(product.isTuesday()).isTrue();
+            assertThat(product.getNutrition()).isEqualTo(newNutrition);
+        }
+
+        @Test
+        @DisplayName("stock이 0으로 수정되면 soldout이 true가 된다")
+        void soldoutWhenStockBecomesZero() {
+            // given
+            Product product = createDefaultProduct();
+
+            // when
+            product.update("기존상품", 0, "BREAD", 0,
+                true, false, false, false, false,
+                true, false, false, false, false, false, false,
+                nutrition);
+
+            // then
+            assertThat(product.getStock()).isZero();
+            assertThat(product.isSoldout()).isTrue();
+        }
+
+        @Test
+        @DisplayName("title이 3자 미만이면 예외가 발생한다")
+        void failWhenTitleTooShort() {
+            // given
+            Product product = createDefaultProduct();
+
+            // when & then
+            assertThatThrownBy(() -> product.update("ab", 0, "BREAD", 10,
+                false, false, false, false, false,
+                true, false, false, false, false, false, false,
+                nutrition))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.INVALID_PRODUCT_NAME);
+        }
+
+        @Test
+        @DisplayName("title이 50자 초과이면 예외가 발생한다")
+        void failWhenTitleTooLong() {
+            // given
+            Product product = createDefaultProduct();
+            String longTitle = "가".repeat(51);
+
+            // when & then
+            assertThatThrownBy(() -> product.update(longTitle, 0, "BREAD", 10,
+                false, false, false, false, false,
+                true, false, false, false, false, false, false,
+                nutrition))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.INVALID_PRODUCT_NAME);
+        }
+
+        @Test
+        @DisplayName("배송 요일이 하나도 선택되지 않으면 예외가 발생한다")
+        void failWhenNoDeliveryDay() {
+            // given
+            Product product = createDefaultProduct();
+
+            // when & then
+            assertThatThrownBy(() -> product.update("기존상품", 0, "BREAD", 10,
+                false, false, false, false, false,
+                false, false, false, false, false, false, false,
+                nutrition))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.INVALID_PRODUCT_DELIVERY_DAY);
+        }
+
+        @Test
+        @DisplayName("board price 변경 후 update 호출 시 price가 재계산된다")
+        void priceRecalculatedAfterBoardPriceChange() {
+            // given
+            Board updatedBoard = BoardFixture.defaultBoard();
+            updatedBoard.update("게시글", 20000, "RATE", 0, 0, 0,
+                false, "T_09_10", "NORMAL", "CJ대한통운");
+            Product product = new Product(
+                updatedBoard, "기존상품", updatedBoard.getPrice(), "BREAD", 10,
+                false, false, false, false, false,
+                true, false, false, false, false, false, false,
+                nutrition
+            );
+
+            // when
+            product.update("기존상품", 1000, "BREAD", 10,
+                false, false, false, false, false,
+                true, false, false, false, false, false, false,
+                nutrition);
+
+            // then
+            assertThat(product.getPrice()).isEqualTo(21000); // 20000 + 1000
+        }
+    }
+
+    @Nested
     @DisplayName("getTags 메서드")
     class GetTags {
 

--- a/src/test/java/com/bbangle/bbangle/board/seller/facade/SellerBoardFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/seller/facade/SellerBoardFacadeIntegrationTest.java
@@ -16,11 +16,16 @@ import com.bbangle.bbangle.board.seller.controller.dto.request.DietaryTagsReques
 import com.bbangle.bbangle.board.seller.controller.dto.request.NutritionInfoRequest;
 import com.bbangle.bbangle.board.seller.controller.dto.request.ProductInfoNoticeRequest;
 import com.bbangle.bbangle.board.seller.controller.dto.request.ProductRequest;
+import com.bbangle.bbangle.board.seller.controller.dto.request.UpdateProductRequest;
 import com.bbangle.bbangle.board.seller.facade.command.CreateBoardFacadeCommand;
+import com.bbangle.bbangle.board.seller.facade.command.UpdateBoardFacadeCommand;
 import com.bbangle.bbangle.board.seller.service.info.BoardInfo;
 import com.bbangle.bbangle.config.S3IntegrationTestSupport;
 import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.repository.StoreRepository;
 import jakarta.persistence.EntityManager;
@@ -45,6 +50,9 @@ class SellerBoardFacadeIntegrationTest extends S3IntegrationTestSupport {
 
     @Autowired
     private StoreRepository storeRepository;
+
+    @Autowired
+    private SellerRepository sellerRepository;
 
     @Autowired
     private EntityManager em;
@@ -401,6 +409,171 @@ class SellerBoardFacadeIntegrationTest extends S3IntegrationTestSupport {
         }
     }
 
+    @Nested
+    @DisplayName("updateBoard() 테스트")
+    class UpdateBoardTest {
+
+        private Seller seller;
+        private Long boardId;
+        private String existingThumbnailUrl;
+
+        @BeforeEach
+        void setUp() {
+            seller = sellerRepository.saveAndFlush(SellerFixture.defaultSeller(store));
+
+            BoardInfo boardInfo = sellerBoardFacade.createBoard(createValidCommand(store.getId()));
+            boardId = boardInfo.boardId();
+
+            em.flush();
+            em.clear();
+
+            Board savedBoard = boardRepository.findById(boardId).orElseThrow();
+            existingThumbnailUrl = savedBoard.getThumbnail();
+        }
+
+        @DisplayName("정상적인 입력으로 Board 기본 정보가 수정된다.")
+        @Test
+        void givenValidCommand_whenUpdateBoard_thenBoardInfoUpdated() {
+            // given
+            UpdateBoardFacadeCommand command = buildUpdateCommand(seller.getId(), boardId)
+                .title("수정된 상품명")
+                .existingThumbnailUrl(existingThumbnailUrl)
+                .build();
+
+            // when
+            BoardInfo result = sellerBoardFacade.updateBoard(command);
+
+            // then
+            em.flush();
+            em.clear();
+            Board updatedBoard = boardRepository.findById(result.boardId()).orElseThrow();
+            assertThat(updatedBoard.getTitle()).isEqualTo("수정된 상품명");
+        }
+
+        @DisplayName("새 썸네일 파일을 제공하면 새 이미지 URL이 저장된다.")
+        @Test
+        void givenNewThumbnailFile_whenUpdateBoard_thenThumbnailUrlChanges() {
+            // given
+            MockMultipartFile newThumbnail = createMockImage("new-thumbnail.png");
+            UpdateBoardFacadeCommand command = buildUpdateCommand(seller.getId(), boardId)
+                .thumbnailImgFile(newThumbnail)
+                .existingThumbnailUrl(null)
+                .build();
+
+            // when
+            sellerBoardFacade.updateBoard(command);
+
+            // then
+            em.flush();
+            em.clear();
+            Board updatedBoard = boardRepository.findById(boardId).orElseThrow();
+            List<ProductImg> activeImgs = updatedBoard.getProductImgs().stream()
+                .filter(img -> !img.isDeleted())
+                .toList();
+            assertThat(activeImgs).hasSize(1);
+            assertThat(activeImgs.get(0).getUrl()).isNotEqualTo(existingThumbnailUrl);
+        }
+
+        @DisplayName("썸네일 파일을 제공하지 않으면 기존 썸네일 URL이 유지된다.")
+        @Test
+        void givenNoThumbnailFile_whenUpdateBoard_thenExistingThumbnailKept() {
+            // given
+            UpdateBoardFacadeCommand command = buildUpdateCommand(seller.getId(), boardId)
+                .thumbnailImgFile(null)
+                .existingThumbnailUrl(existingThumbnailUrl)
+                .build();
+
+            // when
+            sellerBoardFacade.updateBoard(command);
+
+            // then
+            em.flush();
+            em.clear();
+            Board updatedBoard = boardRepository.findById(boardId).orElseThrow();
+            List<ProductImg> activeImgs = updatedBoard.getProductImgs().stream()
+                .filter(img -> !img.isDeleted())
+                .toList();
+            assertThat(activeImgs.get(0).getUrl()).isEqualTo(existingThumbnailUrl);
+        }
+
+        @DisplayName("기존 서브 이미지 URL과 새 파일을 조합하면 모두 저장된다.")
+        @Test
+        void givenExistingAndNewSubImages_whenUpdateBoard_thenAllImagesSaved() {
+            // given
+            MockMultipartFile newSubImage = createMockImage("new-sub.png");
+            String existingSubUrl = "https://cdn.example.com/existing-sub.png";
+            UpdateBoardFacadeCommand command = buildUpdateCommand(seller.getId(), boardId)
+                .existingThumbnailUrl(existingThumbnailUrl)
+                .existingSubImageUrls(List.of(existingSubUrl))
+                .newSubImages(List.of(newSubImage))
+                .build();
+
+            // when
+            sellerBoardFacade.updateBoard(command);
+
+            // then
+            em.flush();
+            em.clear();
+            Board updatedBoard = boardRepository.findById(boardId).orElseThrow();
+            List<ProductImg> activeImgs = updatedBoard.getProductImgs().stream()
+                .filter(img -> !img.isDeleted())
+                .toList();
+            assertThat(activeImgs).hasSize(3); // thumbnail + existing sub + new upload
+        }
+
+        @DisplayName("다른 셀러로 수정 시도하면 예외가 발생한다.")
+        @Test
+        void givenWrongSeller_whenUpdateBoard_thenThrowsForbiddenException() {
+            // given
+            UpdateBoardFacadeCommand command = buildUpdateCommand(seller.getId() + 999, boardId)
+                .existingThumbnailUrl(existingThumbnailUrl)
+                .build();
+
+            // when & then
+            assertThatThrownBy(() -> sellerBoardFacade.updateBoard(command))
+                .isInstanceOf(BbangleException.class);
+        }
+
+        @DisplayName("존재하지 않는 boardId로 수정 시도하면 예외가 발생한다.")
+        @Test
+        void givenNonExistingBoardId_whenUpdateBoard_thenThrowsException() {
+            // given
+            UpdateBoardFacadeCommand command = buildUpdateCommand(seller.getId(), 999999L)
+                .existingThumbnailUrl(existingThumbnailUrl)
+                .build();
+
+            // when & then
+            assertThatThrownBy(() -> sellerBoardFacade.updateBoard(command))
+                .isInstanceOf(BbangleException.class);
+        }
+
+        private UpdateBoardFacadeCommand.UpdateBoardFacadeCommandBuilder buildUpdateCommand(
+            Long sellerId, Long boardId
+        ) {
+            return UpdateBoardFacadeCommand.builder()
+                .sellerId(sellerId)
+                .boardId(boardId)
+                .title("수정된 상품명")
+                .price(12000)
+                .discountType("RATE")
+                .discountValue(10)
+                .deliveryFee(3000)
+                .freeShippingConditions(30000)
+                .isFresh(false)
+                .productionStartTime("T_09_10")
+                .deliveryCondition("일반배송")
+                .deliveryCompany("CJ대한통운")
+                .thumbnailImgFile(null)
+                .existingThumbnailUrl(null)
+                .newSubImages(null)
+                .existingSubImageUrls(null)
+                .boardDetailImages(null)
+                .products(List.of(createUpdateProductRequest(null)))
+                .boardDetailRequest(new BoardDetailRequest("<p>수정된 상세설명</p>"))
+                .productInfoNoticeRequest(createProductInfoNoticeRequest());
+        }
+    }
+
     private CreateBoardFacadeCommand createValidCommand(Long storeId) {
         return CreateBoardFacadeCommand.builder()
             .sellerId(1L)
@@ -440,6 +613,19 @@ class SellerBoardFacadeIntegrationTest extends S3IntegrationTestSupport {
             new DietaryTagsRequest(true, false, true, false, false),
             0,
             100,
+            new AvailabilityRequest(true, true, true, true, true, false, false),
+            new NutritionInfoRequest(300, 50, 30, 5, 10, 8, 200)
+        );
+    }
+
+    private UpdateProductRequest createUpdateProductRequest(Long productId) {
+        return new UpdateProductRequest(
+            productId,
+            "BREAD",
+            "수정된 식빵",
+            new DietaryTagsRequest(true, false, true, false, false),
+            0,
+            80,
             new AvailabilityRequest(true, true, true, true, true, false, false),
             new NutritionInfoRequest(300, 50, 30, 5, 10, 8, 200)
         );

--- a/src/test/java/com/bbangle/bbangle/board/seller/service/SellerBoardServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/seller/service/SellerBoardServiceIntegrationTest.java
@@ -13,9 +13,15 @@ import com.bbangle.bbangle.board.seller.service.command.CreateBoardServiceComman
 import com.bbangle.bbangle.board.seller.service.command.ProductCommand;
 import com.bbangle.bbangle.board.seller.service.command.ProductImgCommand;
 import com.bbangle.bbangle.board.seller.service.command.ProductInfoNoticeCommand;
+import com.bbangle.bbangle.board.seller.service.command.UpdateBoardServiceCommand;
+import com.bbangle.bbangle.board.seller.service.command.UpdateProductCommand;
 import com.bbangle.bbangle.board.seller.service.info.BoardInfo;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.repository.StoreRepository;
 import jakarta.persistence.EntityManager;
@@ -43,6 +49,9 @@ class SellerBoardServiceIntegrationTest {
 
     @Autowired
     private StoreRepository storeRepository;
+
+    @Autowired
+    private SellerRepository sellerRepository;
 
     @Autowired
     private EntityManager em;
@@ -359,6 +368,293 @@ class SellerBoardServiceIntegrationTest {
             // when & then
             assertThatThrownBy(() -> sellerBoardService.createBoard(command))
                 .isInstanceOf(BbangleException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateBoard 메서드")
+    class UpdateBoard {
+
+        private Seller seller;
+        private Long boardId;
+
+        @BeforeEach
+        void setUpUpdateBoard() {
+            seller = sellerRepository.saveAndFlush(SellerFixture.defaultSeller(store));
+            BoardInfo created = sellerBoardService.createBoard(createValidCommand(store));
+            boardId = created.boardId();
+            em.flush();
+            em.clear();
+        }
+
+        @Test
+        @DisplayName("정상적인 입력으로 Board 기본 정보가 수정된다")
+        void success_updatesBasicBoardInfo() {
+            // given
+            UpdateBoardServiceCommand command = createValidUpdateCommand(seller.getId(), boardId);
+
+            // when
+            BoardInfo result = sellerBoardService.updateBoard(command);
+
+            // then
+            em.flush();
+            em.clear();
+
+            Board updatedBoard = boardRepository.findWithAllById(result.boardId()).orElseThrow();
+            assertThat(updatedBoard.getTitle()).isEqualTo("수정된 상품명");
+            assertThat(updatedBoard.getPrice()).isEqualTo(20000);
+            assertThat(updatedBoard.getDeliveryFee()).isEqualTo(2500);
+        }
+
+        @Test
+        @DisplayName("ProductInfoNotice가 수정된다")
+        void success_updatesProductInfoNotice() {
+            // given
+            UpdateBoardServiceCommand command = createValidUpdateCommand(seller.getId(), boardId);
+
+            // when
+            sellerBoardService.updateBoard(command);
+
+            // then
+            em.flush();
+            em.clear();
+
+            Board updatedBoard = boardRepository.findWithAllById(boardId).orElseThrow();
+            assertThat(updatedBoard.getProductInfoNotice().getProductName()).isEqualTo("수정된 상품명");
+            assertThat(updatedBoard.getProductInfoNotice().getManufacturer()).isEqualTo("수정 제조사");
+        }
+
+        @Test
+        @DisplayName("BoardDetail content가 수정된다")
+        void success_updatesBoardDetail() {
+            // given
+            UpdateBoardServiceCommand command = createValidUpdateCommand(seller.getId(), boardId);
+
+            // when
+            sellerBoardService.updateBoard(command);
+
+            // then
+            em.flush();
+            em.clear();
+
+            Board updatedBoard = boardRepository.findWithAllById(boardId).orElseThrow();
+            assertThat(updatedBoard.getBoardDetail().getContent()).isEqualTo("<p>수정된 상세내용</p>");
+        }
+
+        @Test
+        @DisplayName("기존 ProductImg가 soft-delete되고 새 이미지로 교체된다")
+        void success_replacesProductImgs() {
+            // given
+            UpdateBoardServiceCommand command = UpdateBoardServiceCommand.builder()
+                .sellerId(seller.getId())
+                .boardId(boardId)
+                .title("수정된 상품명")
+                .price(20000)
+                .discountType("RATE")
+                .discountValue(0)
+                .deliveryFee(2500)
+                .freeShippingConditions(50000)
+                .isFresh(true)
+                .productionStartTime("T_09_10")
+                .deliveryCondition("COLD")
+                .deliveryCompany("우체국택배")
+                .productImgs(List.of(
+                    new ProductImgCommand("https://cdn.example.com/new-thumbnail.jpg", 0),
+                    new ProductImgCommand("https://cdn.example.com/new-sub.jpg", 1)
+                ))
+                .products(List.of(createUpdateProductCommand(null)))
+                .boardDetail(new BoardDetailCommand("<p>수정된 상세내용</p>"))
+                .productInfoNotice(createUpdateNoticeCommand())
+                .build();
+
+            // when
+            sellerBoardService.updateBoard(command);
+
+            // then
+            em.flush();
+            em.clear();
+
+            Board updatedBoard = boardRepository.findWithAllById(boardId).orElseThrow();
+            List<ProductImg> activeImgs = updatedBoard.getProductImgs().stream()
+                .filter(img -> !img.isDeleted())
+                .toList();
+            assertThat(activeImgs).hasSize(2);
+            assertThat(activeImgs).extracting(ProductImg::getUrl)
+                .contains("https://cdn.example.com/new-thumbnail.jpg");
+        }
+
+        @Test
+        @DisplayName("요청에 없는 기존 Product가 soft-delete된다")
+        void success_softDeletesRemovedProduct() {
+            // given - 기존 board에 product가 1개 있는 상태에서 products를 빈 목록으로 수정
+            UpdateBoardServiceCommand command = UpdateBoardServiceCommand.builder()
+                .sellerId(seller.getId())
+                .boardId(boardId)
+                .title("수정된 상품명")
+                .price(20000)
+                .discountType("RATE")
+                .discountValue(0)
+                .deliveryFee(2500)
+                .freeShippingConditions(50000)
+                .isFresh(true)
+                .productionStartTime("T_09_10")
+                .deliveryCondition("COLD")
+                .deliveryCompany("우체국택배")
+                .productImgs(List.of(
+                    new ProductImgCommand("https://cdn.example.com/thumbnail.jpg", 0)
+                ))
+                .products(List.of())
+                .boardDetail(new BoardDetailCommand("<p>수정된 상세내용</p>"))
+                .productInfoNotice(createUpdateNoticeCommand())
+                .build();
+
+            // when
+            sellerBoardService.updateBoard(command);
+
+            // then
+            em.flush();
+            em.clear();
+
+            Board updatedBoard = boardRepository.findWithAllById(boardId).orElseThrow();
+            long activeProducts = updatedBoard.getProducts().stream()
+                .filter(p -> !p.isDeleted())
+                .count();
+            assertThat(activeProducts).isZero();
+        }
+
+        @Test
+        @DisplayName("신규 Product가 추가된다")
+        void success_addsNewProduct() {
+            // given
+            UpdateBoardServiceCommand command = UpdateBoardServiceCommand.builder()
+                .sellerId(seller.getId())
+                .boardId(boardId)
+                .title("수정된 상품명")
+                .price(20000)
+                .discountType("RATE")
+                .discountValue(0)
+                .deliveryFee(2500)
+                .freeShippingConditions(50000)
+                .isFresh(true)
+                .productionStartTime("T_09_10")
+                .deliveryCondition("COLD")
+                .deliveryCompany("우체국택배")
+                .productImgs(List.of(
+                    new ProductImgCommand("https://cdn.example.com/thumbnail.jpg", 0)
+                ))
+                .products(List.of(
+                    createUpdateProductCommand(null),
+                    createUpdateProductCommand(null)
+                ))
+                .boardDetail(new BoardDetailCommand("<p>수정된 상세내용</p>"))
+                .productInfoNotice(createUpdateNoticeCommand())
+                .build();
+
+            // when
+            sellerBoardService.updateBoard(command);
+
+            // then
+            em.flush();
+            em.clear();
+
+            Board updatedBoard = boardRepository.findWithAllById(boardId).orElseThrow();
+            long activeProducts = updatedBoard.getProducts().stream()
+                .filter(p -> !p.isDeleted())
+                .count();
+            assertThat(activeProducts).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("다른 셀러의 Board를 수정하면 FORBIDDEN_BOARD_ACCESS 예외가 발생한다")
+        void fail_whenNotOwner_throwsForbiddenException() {
+            // given
+            Store anotherStore = storeRepository.saveAndFlush(StoreFixture.defaultStore());
+            Seller anotherSeller = sellerRepository.saveAndFlush(
+                SellerFixture.defaultSeller(anotherStore));
+            UpdateBoardServiceCommand command = createValidUpdateCommand(anotherSeller.getId(), boardId);
+
+            // when & then
+            assertThatThrownBy(() -> sellerBoardService.updateBoard(command))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.FORBIDDEN_BOARD_ACCESS);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 boardId로 수정하면 BOARD_NOT_FOUND 예외가 발생한다")
+        void fail_whenBoardNotFound_throwsException() {
+            // given
+            UpdateBoardServiceCommand command = createValidUpdateCommand(seller.getId(), 999999L);
+
+            // when & then
+            assertThatThrownBy(() -> sellerBoardService.updateBoard(command))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.BOARD_NOT_FOUND);
+        }
+
+        private UpdateBoardServiceCommand createValidUpdateCommand(Long sellerId, Long boardId) {
+            return UpdateBoardServiceCommand.builder()
+                .sellerId(sellerId)
+                .boardId(boardId)
+                .title("수정된 상품명")
+                .price(20000)
+                .discountType("RATE")
+                .discountValue(0)
+                .deliveryFee(2500)
+                .freeShippingConditions(50000)
+                .isFresh(true)
+                .productionStartTime("T_09_10")
+                .deliveryCondition("COLD")
+                .deliveryCompany("우체국택배")
+                .productImgs(List.of(
+                    new ProductImgCommand("https://cdn.example.com/new-thumbnail.jpg", 0)
+                ))
+                .products(List.of(createUpdateProductCommand(null)))
+                .boardDetail(new BoardDetailCommand("<p>수정된 상세내용</p>"))
+                .productInfoNotice(createUpdateNoticeCommand())
+                .build();
+        }
+
+        private UpdateProductCommand createUpdateProductCommand(Long productId) {
+            return UpdateProductCommand.builder()
+                .productId(productId)
+                .title("수정된 상품옵션")
+                .category("BREAD")
+                .plusPriceWithBoardPrice(0)
+                .stock(50)
+                .glutenFreeTag(true)
+                .highProteinTag(false)
+                .sugarFreeTag(false)
+                .veganTag(false)
+                .ketogenicTag(false)
+                .monday(true)
+                .tuesday(true)
+                .wednesday(false)
+                .thursday(false)
+                .friday(false)
+                .saturday(false)
+                .sunday(false)
+                .nutrition(new Nutrition(200, 50, 25, 5, 8, 6, 150))
+                .build();
+        }
+
+        private ProductInfoNoticeCommand createUpdateNoticeCommand() {
+            return ProductInfoNoticeCommand.builder()
+                .productName("수정된 상품명")
+                .foodType("빵류")
+                .manufacturer("수정 제조사")
+                .originLocation("부산광역시")
+                .manufactureDate("제조일자 별도 표기")
+                .expirationDate("제조일로부터 3일")
+                .storageGuide("냉장보관")
+                .packagingQuantityUnit("1개")
+                .rawMaterialName("밀가루, 설탕")
+                .nutritionInfo("별도 표기")
+                .transgenic("해당없음")
+                .customerWarning("알레르기 주의")
+                .importFood("해당없음")
+                .build();
         }
     }
 


### PR DESCRIPTION
## History                 
- 관련이슈: #602 
                                                                                                                                                                            
 ## 🚀 Major Changes & Explanations                     
  - `PUT /api/v1/sellers/boards/{boardId}` 엔드포인트 추가                                                                                             
  - `Board.update()`, `Product.update()`, `ProductInfoNotice.update()`, `BoardDetail.update()` 도메인 메서드 추가                                      
  - `SellerBoardService.updateBoard()`: 소유권 검증, Product 병합 전략(유지/수정/삭제/추가), ProductImg soft-delete 후 재저장 구현
  - `SellerBoardFacade.updateBoard()`: S3 이미지 업로드(썸네일 교체/유지, 서브이미지 조합) 및 실패 시 롤백 처리
  - `UpdateBoardRequest`: multipart/form-data 기반 수정 요청 DTO 추가 (`thumbnailImgFile` nullable로 기존 썸네일 유지 지원)
  - `UpdateProductRequest`: `productId` nullable로 기존 상품 수정 / 신규 상품 추가 구분
  - `BbangleErrorCode`에 `FORBIDDEN_BOARD_ACCESS(-715)`, `PRODUCT_NOT_FOUND(-716)` 추가

  ## 📷 Test Image

  ## 💡 ETC
  - `ProductBoardUpdateRequest` 제거 (기존 미구현 placeholder DTO)
  - `BoardRepository.findWithAllById()` EntityGraph 추가 (`store`, `productInfoNotice`, `boardDetail`) — `MultipleBagFetchException` 방지를 위해
  `products`, `productImgs`는 lazy loading으로 처리
  - `@Modifying(clearAutomatically = true)` 실행 전 `boardRepository.flush()` 명시 호출로 dirty state 유실 이슈 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 판매자가 게시글을 통합 수정 가능: 제목·가격·할인·배송·생산정보 등 및 상품, 상세정보, 상품정보고시 동시 업데이트
  * 섬네일 교체 또는 기존 섬네일 유지, 서브 이미지 추가/병합/교체 지원; 멀티파트 업로드 처리

* **Bug Fixes**
  * 권한 없는 게시글 접근 차단 (FORBIDDEN_BOARD_ACCESS)
  * 존재하지 않는 상품 요청에 대한 오류 처리 추가 (PRODUCT_NOT_FOUND)
  * 섬네일 누락 시 오류 처리 추가 (MISSING_BOARD_THUMBNAIL)

* **Tests**
  * 업데이트 흐름 관련 단위·통합 테스트 추가 및 검증 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->