### PR TITLE
[Refactor] Auth 관련 API 네이밍 수정

### DIFF
--- a/src/main/java/com/bbangle/bbangle/auth/oauth/client/controller/OAuthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/oauth/client/controller/OAuthController.java
@@ -1,0 +1,73 @@
+package com.bbangle.bbangle.auth.oauth.client.controller;
+
+import static com.bbangle.bbangle.util.CookieUtils.createCookie;
+
+import com.bbangle.bbangle.auth.oauth.OauthServerType;
+import com.bbangle.bbangle.auth.oauth.client.controller.swagger.OAuthApi;
+import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO.ProfileType;
+import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO.UserType;
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
+import com.bbangle.bbangle.auth.oauth.client.facade.OAuthFacade;
+import com.bbangle.bbangle.auth.oauth.client.service.OAuthService;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/oauth")
+public class OAuthController implements OAuthApi {
+
+    private final ResponseService responseService;
+    private final OAuthFacade oAuthFacade;
+    private final OAuthService oAuthService;
+
+    @Override
+    @GetMapping("/authorization/{oauthServerType}")
+    public void login(
+        @PathVariable OauthServerType oauthServerType,
+        UserType userType,
+        ProfileType profileType
+    ) {}
+
+    @Override
+    @PostMapping("/reissue")
+    public CommonResult reissueToken(
+        @CookieValue(value = "refreshToken", required = false)
+        String refreshToken,
+        HttpServletResponse response
+    ) {
+        if (refreshToken == null) throw new BbangleException(BbangleErrorCode._UNAUTHORIZED);
+
+        TokenResponse dto = oAuthFacade.reissueToken(refreshToken);
+        response.setHeader("Authorization", "Bearer " + dto.accessToken());
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(dto.refreshToken(), Duration.ofDays(14)).toString());
+
+        return responseService.getSuccessResult();
+    }
+
+    @Override
+    @DeleteMapping("/logout")
+    public CommonResult logout(
+        @CookieValue(value = "refreshToken", required = false)
+        String refreshToken,
+        HttpServletResponse response
+    ) {
+        if (refreshToken != null) oAuthService.deleteRefreshToken(refreshToken);
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie("", Duration.ofMillis(1)).toString());
+
+        return responseService.getSuccessResult();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/auth/oauth/client/controller/OAuthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/oauth/client/controller/OAuthController.java
@@ -12,6 +12,7 @@ import com.bbangle.bbangle.auth.oauth.client.service.OAuthService;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.PublicApiPath;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import jakarta.servlet.http.HttpServletResponse;
@@ -54,7 +55,7 @@ public class OAuthController implements OAuthApi {
 
         TokenResponse dto = oAuthFacade.reissueToken(refreshToken);
         response.setHeader("Authorization", "Bearer " + dto.accessToken());
-        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(dto.refreshToken(), Duration.ofDays(14)).toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(dto.refreshToken(), TokenProvider.REFRESH_TOKEN_DURATION).toString());
 
         return responseService.getSuccessResult();
     }

--- a/src/main/java/com/bbangle/bbangle/auth/oauth/client/controller/OAuthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/oauth/client/controller/OAuthController.java
@@ -11,6 +11,7 @@ import com.bbangle.bbangle.auth.oauth.client.facade.OAuthFacade;
 import com.bbangle.bbangle.auth.oauth.client.service.OAuthService;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.PublicApiPath;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import jakarta.servlet.http.HttpServletResponse;
@@ -27,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v1/oauth")
+@RequestMapping("")
 public class OAuthController implements OAuthApi {
 
     private final ResponseService responseService;
@@ -35,7 +36,7 @@ public class OAuthController implements OAuthApi {
     private final OAuthService oAuthService;
 
     @Override
-    @GetMapping("/authorization/{oauthServerType}")
+    @GetMapping(PublicApiPath.OAUTH_PREFIX + "/{oauthServerType}")
     public void login(
         @PathVariable OauthServerType oauthServerType,
         UserType userType,
@@ -43,7 +44,7 @@ public class OAuthController implements OAuthApi {
     ) {}
 
     @Override
-    @PostMapping("/reissue")
+    @PostMapping(PublicApiPath.AUTH_PREFIX + "/reissue")
     public CommonResult reissueToken(
         @CookieValue(value = "refreshToken", required = false)
         String refreshToken,
@@ -59,14 +60,14 @@ public class OAuthController implements OAuthApi {
     }
 
     @Override
-    @DeleteMapping("/logout")
+    @DeleteMapping(PublicApiPath.AUTH_PREFIX + "/logout")
     public CommonResult logout(
         @CookieValue(value = "refreshToken", required = false)
         String refreshToken,
         HttpServletResponse response
     ) {
         if (refreshToken != null) oAuthService.deleteRefreshToken(refreshToken);
-        response.addHeader(HttpHeaders.SET_COOKIE, createCookie("", Duration.ofMillis(1)).toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie("", Duration.ZERO).toString());
 
         return responseService.getSuccessResult();
     }

--- a/src/main/java/com/bbangle/bbangle/auth/oauth/client/controller/swagger/OAuthApi.java
+++ b/src/main/java/com/bbangle/bbangle/auth/oauth/client/controller/swagger/OAuthApi.java
@@ -1,0 +1,131 @@
+package com.bbangle.bbangle.auth.oauth.client.controller.swagger;
+
+import com.bbangle.bbangle.auth.oauth.OauthServerType;
+import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO.ProfileType;
+import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO.UserType;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "OAuth Login", description = "OAuth 관련 API")
+public interface OAuthApi {
+
+    @Operation(
+        summary = "OAuth 로그인 (Redirect)",
+        description = """
+        ### OAuth2 로그인 시작 (Customer & Seller)
+
+        이 엔드포인트는 OAuth2 인증을 시작합니다.
+        브라우저에서 접근 시 OAuth2 Provider 로그인 페이지로 이동합니다.
+        Customer OAuth2 로그인은 아직 지원하지 않습니다.
+
+        ---
+        ### 🔗 OAuth2 로그인 시작 URL - AJAX 호출이 아닌 Redirect를 사용하셔야합니다.
+        - `GET /api/v1/oauth/authorization/{OauthServerType}?user={UserType}&profile={ProfileType}`
+        - **OauthServerType**은 반드시 **소문자**로 작성하셔야합니다.
+        - **user** 파라미터는 **필수**입니다.
+        - **profile** 파라미터는 prod가 기본값으로 설정되어있습니다.
+
+        ---
+        ### ✅ 로그인 성공 시
+        - Redirect URL: `/callback/social?generateToken=1234-abcdefg-567890-hij`
+        - 동작:
+          1. OAuth2 인증 성공
+          2. 임시 코드 (generateToken) 발급
+          3. 프론트엔드로 리다이렉트
+          4. 프론트엔드의 콜백 페이지에서 임시 코드(generateToken)를 다시 서버로 전송
+
+        ---
+        ### ❌ 로그인 실패 시
+        - Redirect URL: `/callback/social?error={errorCode}&code={code}`
+        - 예시:
+          - `/callback/social?error=NOT_SUPPORTED_SERVER&code=-744`
+          - `/callback/social?error=INTERNAL_SERVER_ERROR&code=-999`
+
+        ---
+        ⚠️ 주의사항
+        - JSON 응답을 반환하지 않습니다.
+        - Swagger **Try it out**으로 실행하지 마세요.
+        - 임시 코드는 URL의 쿼리 파라미터를 통해 전송됩니다.
+        - 리다이렉트로 OAuth2 과정을 진행하셔야합니다.
+        """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "302",
+            description = """
+        ### ✅ 로그인 성공 시
+        - Redirect URL: `/callback/social?generateToken=1234-abcdefg-567890-hij`
+        - 콜백 페이지에서 generateToken을 추출한 다음 Token 발급 API를 호출하시면 됩니다.
+
+        ---
+        ### ❌ 로그인 실패 시
+        - Redirect URL: `/callback/social?error={errorCode}&code={code}`
+
+        ### ⚠️ 에러 코드 표
+        | Error Code | Code | 설명 |
+        |-----------|------|------|
+        |NOT_SUPPORTED_SERVER|-744|지원하지 않는 OAuth2 로그인 서버입니다.|
+        |MISSING_NAME_NICKNAME|-745|이름과 닉네임이 전부 비공개 상태입니다.|
+        |INVALID_OAUTH_PARAMS|-748|유효하지 않은 파라미터입니다.|
+        |_NOT_SUPPORTED_YET|-993|아직 지원하지 않는 기능입니다.|
+        |INTERNAL_SERVER_ERROR|-999|서버 내부 에러입니다. (ex : DB Down)|
+        |UNKNOWN_ERROR|null|에러 코드 표에 작성된 Error Code 이외의 기타 예외 상황|
+        """
+        )
+    })
+    void login(
+        @Parameter(description = "Oauth 서비스 종류", example = "KAKAO, GOOGLE")
+        @PathVariable
+        OauthServerType oauthServerType,
+        @Parameter(description = "로그인 할 계정 종류 - 대소문자 무시", example = "customer, seller")
+        @RequestParam("user")
+        UserType userType,
+        @Parameter(description = "요청한 프론트 환경 - 대소문자 무시, 기본값 = prod", example = "local, prod")
+        @RequestParam(value = "profile", required = false, defaultValue = "prod")
+        ProfileType profileType
+    );
+
+    @Operation(
+        summary = "Access Token 재발급",
+        description = """
+        ### Access Token을 재발급 하고 Refresh Token을 갱신
+
+        ---
+        ## ⚠️ 주의사항
+        - 서버로 요청을 보낼 때 Refresh Token을 **Cookie**에 담아서 전송해야합니다.
+        - 이 때, Cookie의 Key를 **refreshToken**으로 설정해야합니다.
+        """
+    )
+    CommonResult reissueToken(
+        @Parameter(description = "Refresh Token")
+        @CookieValue(value = "refreshToken", required = false)
+        String refreshToken,
+        HttpServletResponse response
+    );
+
+    @Operation(
+        summary = "로그아웃",
+        description = """
+        ### Refresh Token과 쿠키를 삭제하고 로그아웃 처리
+
+        ---
+        ## ⚠️ 주의사항
+        - 서버로 요청을 보낼 때 Refresh Token을 **Cookie**에 담아서 전송해야합니다.
+        - 이 때, Cookie의 Key를 **refreshToken**으로 설정해야합니다.
+        """
+    )
+    CommonResult logout(
+        @Parameter(description = "Refresh Token")
+        @CookieValue(value = "refreshToken", required = false)
+        String refreshToken,
+        HttpServletResponse response
+    );
+}

--- a/src/main/java/com/bbangle/bbangle/auth/oauth/client/facade/OAuthFacade.java
+++ b/src/main/java/com/bbangle/bbangle/auth/oauth/client/facade/OAuthFacade.java
@@ -1,0 +1,32 @@
+package com.bbangle.bbangle.auth.oauth.client.facade;
+
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenClaimsDTO;
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
+import com.bbangle.bbangle.auth.oauth.client.service.OAuthService;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthFacade {
+
+    private final OAuthService oAuthService;
+    private final TokenProvider tokenProvider;
+
+    public TokenResponse reissueToken(String refreshToken) {
+
+        TokenClaimsDTO claims = tokenProvider.parseRefreshToken(refreshToken);
+
+        oAuthService.refreshTokenValidate(refreshToken);
+        oAuthService.deleteRefreshToken(refreshToken);
+
+        String newRefreshToken = oAuthService.generateRefreshToken(claims.id(), claims.role());
+        String newAccessToken = oAuthService.generateAccessToken(claims.id(), claims.role());
+
+        return TokenResponse.builder()
+            .refreshToken(newRefreshToken)
+            .accessToken(newAccessToken)
+            .build();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/auth/oauth/client/service/OAuthService.java
+++ b/src/main/java/com/bbangle/bbangle/auth/oauth/client/service/OAuthService.java
@@ -1,0 +1,59 @@
+package com.bbangle.bbangle.auth.oauth.client.service;
+
+import com.bbangle.bbangle.auth.domain.RefreshToken;
+import com.bbangle.bbangle.common.redis.repository.RefreshTokenRepository;
+import com.bbangle.bbangle.common.role.Role;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+
+    public static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(14);
+    public static final Duration ACCESS_TOKEN_DURATION = Duration.ofHours(3);
+
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public String generateRefreshToken(Long userId, Role role) {
+        String refreshToken = tokenProvider.generateToken(userId, role, REFRESH_TOKEN_DURATION);
+
+        RefreshToken token = refreshTokenRepository
+            .findByUserIdAndUserRole(userId, role)
+            .orElseGet(() -> RefreshToken.create(
+                userId,
+                role,
+                refreshToken
+            ));
+
+        token.update(refreshToken);
+
+        refreshTokenRepository.save(token);
+
+        return refreshToken;
+    }
+
+    public String generateAccessToken(Long userId, Role role) {
+        return tokenProvider.generateToken(userId, role, ACCESS_TOKEN_DURATION);
+    }
+
+    @Transactional(readOnly = true)
+    public void refreshTokenValidate(String refreshToken) {
+        refreshTokenRepository.findByRefreshToken(refreshToken)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode._UNAUTHORIZED));
+    }
+
+    @Transactional
+    public void deleteRefreshToken(String refreshToken) {
+        refreshTokenRepository.deleteByRefreshToken(refreshToken);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/auth/oauth/client/service/OAuthService.java
+++ b/src/main/java/com/bbangle/bbangle/auth/oauth/client/service/OAuthService.java
@@ -6,7 +6,6 @@ import com.bbangle.bbangle.common.role.Role;
 import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,15 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OAuthService {
 
-    public static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(14);
-    public static final Duration ACCESS_TOKEN_DURATION = Duration.ofHours(3);
-
     private final TokenProvider tokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     public String generateRefreshToken(Long userId, Role role) {
-        String refreshToken = tokenProvider.generateToken(userId, role, REFRESH_TOKEN_DURATION);
+        String refreshToken = tokenProvider.generateToken(userId, role, TokenProvider.REFRESH_TOKEN_DURATION);
 
         refreshTokenRepository.findByUserIdAndUserRole(userId, role)
             .ifPresentOrElse(
@@ -39,7 +35,7 @@ public class OAuthService {
     }
 
     public String generateAccessToken(Long userId, Role role) {
-        return tokenProvider.generateToken(userId, role, ACCESS_TOKEN_DURATION);
+        return tokenProvider.generateToken(userId, role, TokenProvider.ACCESS_TOKEN_DURATION);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/bbangle/bbangle/auth/oauth/client/service/OAuthService.java
+++ b/src/main/java/com/bbangle/bbangle/auth/oauth/client/service/OAuthService.java
@@ -27,17 +27,13 @@ public class OAuthService {
     public String generateRefreshToken(Long userId, Role role) {
         String refreshToken = tokenProvider.generateToken(userId, role, REFRESH_TOKEN_DURATION);
 
-        RefreshToken token = refreshTokenRepository
-            .findByUserIdAndUserRole(userId, role)
-            .orElseGet(() -> RefreshToken.create(
-                userId,
-                role,
-                refreshToken
-            ));
-
-        token.update(refreshToken);
-
-        refreshTokenRepository.save(token);
+        refreshTokenRepository.findByUserIdAndUserRole(userId, role)
+            .ifPresentOrElse(
+                existing -> existing.update(refreshToken),
+                () -> refreshTokenRepository.save(
+                    RefreshToken.create(userId, role, refreshToken)
+                )
+            );
 
         return refreshToken;
     }

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
@@ -10,9 +10,9 @@ import com.bbangle.bbangle.auth.seller.facade.dto.GenerateTokenDTO;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.SellerApiPath;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,7 +37,7 @@ public class SellerOauthController implements SellerOauthApi {
         GenerateTokenDTO dto = oAuth2SellerFacade.generateToken(request.generateToken());
 
         response.setHeader("Authorization", "Bearer " + dto.accessToken());
-        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(dto.refreshToken(), Duration.ofDays(14)).toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(dto.refreshToken(), TokenProvider.REFRESH_TOKEN_DURATION).toString());
 
         return responseService.getSingleResult(
             GenerateTokenResponse.builder()

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
@@ -1,31 +1,20 @@
 package com.bbangle.bbangle.auth.seller.controller;
 
-import com.bbangle.bbangle.auth.oauth.OauthServerType;
-import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO.ProfileType;
-import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO.UserType;
-import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
+import static com.bbangle.bbangle.util.CookieUtils.createCookie;
+
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenRequest;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.swagger.SellerOauthApi;
 import com.bbangle.bbangle.auth.seller.facade.OAuth2SellerFacade;
 import com.bbangle.bbangle.auth.seller.facade.dto.GenerateTokenDTO;
-import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
-import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.SellerApiPath;
-import com.bbangle.bbangle.exception.BbangleErrorCode;
-import com.bbangle.bbangle.exception.BbangleException;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,15 +27,6 @@ public class SellerOauthController implements SellerOauthApi {
 
     private final ResponseService responseService;
     private final OAuth2SellerFacade oAuth2SellerFacade;
-    private final OAuthSellerService oAuthSellerService;
-
-    @Override
-    @GetMapping("/authorization/{oauthServerType}")
-    public void sellerLogin(
-        @PathVariable OauthServerType oauthServerType,
-        UserType userType,
-        ProfileType profileType
-    ) {}
 
     @Override
     @PostMapping("/tokens")
@@ -65,46 +45,5 @@ public class SellerOauthController implements SellerOauthApi {
                 .status(dto.status())
                 .build()
         );
-    }
-
-    // TODO : reissue, logout API 이동
-    @Override
-    @PostMapping("/reissue")
-    public CommonResult reissueToken(
-        @CookieValue(value = "refreshToken", required = false)
-        String refreshToken,
-        HttpServletResponse response
-    ) {
-        if (refreshToken == null) throw new BbangleException(BbangleErrorCode._UNAUTHORIZED);
-
-        TokenResponse dto = oAuth2SellerFacade.reissueToken(refreshToken);
-        response.setHeader("Authorization", "Bearer " + dto.accessToken());
-        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(dto.refreshToken(), Duration.ofDays(14)).toString());
-
-        return responseService.getSuccessResult();
-    }
-
-    @Override
-    @DeleteMapping("/logout")
-    public CommonResult logout(
-        @CookieValue(value = "refreshToken", required = false)
-        String refreshToken,
-        HttpServletResponse response
-    ) {
-        if (refreshToken != null) oAuthSellerService.deleteRefreshToken(refreshToken);
-        response.addHeader(HttpHeaders.SET_COOKIE, createCookie("", Duration.ofMillis(1)).toString());
-
-        return responseService.getSuccessResult();
-    }
-
-    private ResponseCookie createCookie(String value, Duration duration) {
-        return ResponseCookie.from("refreshToken", value)
-            .httpOnly(true)
-            // TODO : 로컬에서 사용할 때는 주석처리
-            .secure(true)
-            .path("/")
-            .maxAge(duration)
-            .sameSite("Strict")
-            .build();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/swagger/SellerOauthApi.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/swagger/SellerOauthApi.java
@@ -1,101 +1,16 @@
 package com.bbangle.bbangle.auth.seller.controller.swagger;
 
-import com.bbangle.bbangle.auth.oauth.OauthServerType;
-import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO.ProfileType;
-import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO.UserType;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenRequest;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
-import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Seller Oauth Login", description = "(판매자) 로그인 Oauth API")
 public interface SellerOauthApi {
-
-    @Operation(
-        summary = "판매자 Oauth 로그인 (Redirect)",
-        description = """
-        ### OAuth2 로그인 시작 (Admin)
-
-        이 엔드포인트는 OAuth2 인증을 시작합니다.
-        브라우저에서 접근 시 OAuth2 Provider 로그인 페이지로 이동합니다.
-
-        ---
-        ### 🔗 OAuth2 로그인 시작 URL - AJAX 호출이 아닌 Redirect를 사용하셔야합니다.
-        - `GET /api/v1/seller/oauth2/authorization/{OauthServerType}?user={UserType}&profile={ProfileType}`
-        - **OauthServerType**은 반드시 **소문자**로 작성하셔야합니다.
-        - **user** 파라미터는 필수입니다.
-        - profile 파라미터는 prod가 기본값으로 설정되어있습니다.
-
-        ---
-        ### ✅ 로그인 성공 시
-        - Redirect URL: `/callback/social?generateToken=1234-abcdefg-567890-hij`
-        - 동작:
-          1. OAuth2 인증 성공
-          2. 임시 코드 (generateToken) 발급
-          3. 프론트엔드로 리다이렉트
-          4. 프론트엔드의 콜백 페이지에서 임시 코드(generateToken)를 다시 서버로 전송
-
-        ---
-        ### ❌ 로그인 실패 시
-        - Redirect URL: `/callback/social?error={errorCode}&code={code}`
-        - 예시:
-          - `/callback/social?error=NOT_SUPPORTED_SERVER&code=-744`
-          - `/callback/social?error=INTERNAL_SERVER_ERROR&code=-999`
-
-        ---
-        ⚠️ 주의사항
-        - JSON 응답을 반환하지 않습니다.
-        - Swagger **Try it out**으로 실행하지 마세요.
-        - 임시 코드는 URL의 쿼리 파라미터를 통해 전송됩니다.
-        - 리다이렉트로 OAuth2 과정을 진행하셔야합니다.
-        """
-    )
-    @ApiResponses({
-        @ApiResponse(
-            responseCode = "302",
-            description = """
-        ### ✅ 로그인 성공 시
-        - Redirect URL: `/callback/social?generateToken=1234-abcdefg-567890-hij`
-        - 콜백 페이지에서 generateToken을 추출한 다음 Token 발급 API를 호출하시면 됩니다.
-
-        ---
-        ### ❌ 로그인 실패 시
-        - Redirect URL: `/callback/social?error={errorCode}&code={code}`
-
-        ### ⚠️ 에러 코드 표
-        | Error Code | Code | 설명 |
-        |-----------|------|------|
-        |NOT_SUPPORTED_SERVER|-744|지원하지 않는 OAuth2 로그인 서버입니다.|
-        |MISSING_NAME_NICKNAME|-745|이름과 닉네임이 전부 비공개 상태입니다.|
-        |INVALID_OAUTH_PARAMS|-748|유효하지 않은 파라미터입니다.|
-        |_NOT_SUPPORTED_YET|-993|아직 지원하지 않는 기능입니다.|
-        |INTERNAL_SERVER_ERROR|-999|서버 내부 에러입니다. (ex : DB Down)|
-        |UNKNOWN_ERROR|null|에러 코드 표에 작성된 Error Code 이외의 기타 예외 상황|
-        """
-        )
-    })
-    void sellerLogin(
-        @Parameter(description = "Oauth 서비스 종류", example = "KAKAO, GOOGLE")
-        @PathVariable
-        OauthServerType oauthServerType,
-        @Parameter(description = "로그인 할 계정 종류 - 대소문자 무시", example = "customer, seller")
-        @RequestParam("user")
-        UserType userType,
-        @Parameter(description = "요청한 프론트 환경 - 대소문자 무시, 기본값 = prod", example = "local, prod")
-        @RequestParam(value = "profile", required = false, defaultValue = "prod")
-        ProfileType profileType
-    );
 
     @Operation(
         summary = "판매자 Token 발급 및 계정 상태 조회",
@@ -114,42 +29,6 @@ public interface SellerOauthApi {
     )
     SingleResult<GenerateTokenResponse> sellerToken(
         @RequestBody @Valid GenerateTokenRequest request,
-        HttpServletResponse response
-    );
-
-    @Operation(
-        summary = "판매자 토큰 재발급",
-        description = """
-        ### 판매자의 Access Token을 재발급 하고 Refresh Token을 갱신
-
-        ---
-        ## ⚠️ 주의사항
-        - 서버로 요청을 보낼 때 Refresh Token을 **Cookie**에 담아서 전송해야합니다.
-        - 이 때, Cookie의 Key를 **refreshToken**으로 설정해야합니다.
-        """
-    )
-    CommonResult reissueToken(
-        @Parameter(description = "Refresh Token")
-        @CookieValue(value = "refreshToken", required = false)
-        String refreshToken,
-        HttpServletResponse response
-    );
-
-    @Operation(
-        summary = "판매자 로그아웃",
-        description = """
-        ### 판매자의 Refresh Token과 쿠키를 삭제하고 로그아웃 처리
-
-        ---
-        ## ⚠️ 주의사항
-        - 서버로 요청을 보낼 때 Refresh Token을 **Cookie**에 담아서 전송해야합니다.
-        - 이 때, Cookie의 Key를 **refreshToken**으로 설정해야합니다.
-        """
-    )
-    CommonResult logout(
-        @Parameter(description = "Refresh Token")
-        @CookieValue(value = "refreshToken", required = false)
-        String refreshToken,
         HttpServletResponse response
     );
 }

--- a/src/main/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacade.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacade.java
@@ -1,11 +1,9 @@
 package com.bbangle.bbangle.auth.seller.facade;
 
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO;
-import com.bbangle.bbangle.auth.oauth.client.dto.TokenClaimsDTO;
-import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
+import com.bbangle.bbangle.auth.oauth.client.service.OAuthService;
 import com.bbangle.bbangle.auth.seller.facade.dto.GenerateTokenDTO;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
-import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.seller.service.SellerService;
 import com.bbangle.bbangle.seller.seller.service.command.SellerCreateCommand;
@@ -19,10 +17,8 @@ public class OAuth2SellerFacade {
 
     // OAuth 작업과 관련된 Service 레이어
     private final OAuthSellerService oAuthSellerService;
-
     private final SellerService sellerService;
-
-    private final TokenProvider tokenProvider;
+    private final OAuthService oAuthService;
 
     public Seller login(SellerCreateCommand response) {
         try {
@@ -43,8 +39,8 @@ public class OAuth2SellerFacade {
     public GenerateTokenDTO generateToken(String code) {
 
         OAuth2DTO.InfoDTO sellerInfo = oAuthSellerService.getSellerInfoFromRedis(code);
-        String refreshToken = oAuthSellerService.generateRefreshToken(sellerInfo.id(), sellerInfo.role());
-        String accessToken = oAuthSellerService.generateAccessToken(sellerInfo.id(), sellerInfo.role());
+        String refreshToken = oAuthService.generateRefreshToken(sellerInfo.id(), sellerInfo.role());
+        String accessToken = oAuthService.generateAccessToken(sellerInfo.id(), sellerInfo.role());
 
         return GenerateTokenDTO.of(
             refreshToken,
@@ -52,21 +48,5 @@ public class OAuth2SellerFacade {
             sellerInfo.id(),
             sellerInfo.status()
         );
-    }
-
-    public TokenResponse reissueToken(String refreshToken) {
-
-        TokenClaimsDTO claims = tokenProvider.parseRefreshToken(refreshToken);
-
-        oAuthSellerService.refreshTokenValidate(refreshToken);
-        oAuthSellerService.deleteRefreshToken(refreshToken);
-
-        String newRefreshToken = oAuthSellerService.generateRefreshToken(claims.id(), claims.role());
-        String newAccessToken = oAuthSellerService.generateAccessToken(claims.id(), claims.role());
-
-        return TokenResponse.builder()
-            .refreshToken(newRefreshToken)
-            .accessToken(newAccessToken)
-            .build();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerService.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerService.java
@@ -1,18 +1,12 @@
 package com.bbangle.bbangle.auth.seller.service;
 
-import com.bbangle.bbangle.auth.domain.RefreshToken;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO;
 import com.bbangle.bbangle.common.redis.repository.RedisRepository;
-import com.bbangle.bbangle.common.redis.repository.RefreshTokenRepository;
-import com.bbangle.bbangle.common.role.Role;
-import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -20,12 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class OAuthSellerService {
 
     public static final String OAUTH_CODE_NAMESPACE = "oauth2:code";
-    public static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(14);
-    public static final Duration ACCESS_TOKEN_DURATION = Duration.ofHours(3);
 
     private final RedisRepository redisRepository;
-    private final TokenProvider tokenProvider;
-    private final RefreshTokenRepository refreshTokenRepository;
 
     public OAuth2DTO.InfoDTO getSellerInfoFromRedis(String code) {
         OAuth2DTO.InfoDTO sellerInfo;
@@ -39,38 +29,5 @@ public class OAuthSellerService {
         if (sellerInfo == null) throw new BbangleException(BbangleErrorCode._UNAUTHORIZED);
 
         return sellerInfo;
-    }
-
-    @Transactional
-    public String generateRefreshToken(Long sellerId, Role role) {
-        String refreshToken = tokenProvider.generateToken(sellerId, role, REFRESH_TOKEN_DURATION);
-
-        RefreshToken token = refreshTokenRepository
-            .findByUserIdAndUserRole(sellerId, role)
-            .orElseGet(() -> RefreshToken.create(
-                sellerId,
-                role,
-                refreshToken
-            ));
-
-        token.update(refreshToken);
-
-        refreshTokenRepository.save(token);
-
-        return refreshToken;
-    }
-
-    public String generateAccessToken(Long sellerId, Role role) {
-        return tokenProvider.generateToken(sellerId, role, ACCESS_TOKEN_DURATION);
-    }
-
-    public void refreshTokenValidate(String refreshToken) {
-        refreshTokenRepository.findByRefreshToken(refreshToken)
-            .orElseThrow(() -> new BbangleException(BbangleErrorCode._UNAUTHORIZED));
-    }
-
-    @Transactional
-    public void deleteRefreshToken(String refreshToken) {
-        refreshTokenRepository.deleteByRefreshToken(refreshToken);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/config/security/OAuth2SecurityConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/OAuth2SecurityConfig.java
@@ -37,7 +37,7 @@ public class OAuth2SecurityConfig {
     ) throws Exception {
         http
             .securityMatcher(
-                SellerApiPath.PREFIX + "/oauth2/**",
+                "/api/v1/oauth/authorization/**",
                 "/login/oauth2/**"
             )
             .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/bbangle/bbangle/config/security/PublicApiPath.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/PublicApiPath.java
@@ -13,9 +13,7 @@ public class PublicApiPath {
         "/api/v1/stores/**",
         "/api/v1/health/**",
         "/api/v1/push/**",
-        SellerApiPath.PREFIX + "/oauth2/tokens",
-        SellerApiPath.PREFIX + "/oauth2/reissue",
-        SellerApiPath.PREFIX + "/oauth2/logout"
+        SellerApiPath.PREFIX + "/oauth2/tokens"
     };
 
     public static final String[] GET_ONLY = {

--- a/src/main/java/com/bbangle/bbangle/config/security/PublicApiPath.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/PublicApiPath.java
@@ -2,6 +2,9 @@ package com.bbangle.bbangle.config.security;
 
 public class PublicApiPath {
 
+    public static final String OAUTH_PREFIX = "/api/v1/oauth/authorization";
+    public static final String AUTH_PREFIX = "/api/v1/auth";
+
     public static final String[] ANY_METHOD = {
         "/api/v1/token",
         AdminApiPath.PREFIX + "/login",
@@ -13,7 +16,8 @@ public class PublicApiPath {
         "/api/v1/stores/**",
         "/api/v1/health/**",
         "/api/v1/push/**",
-        SellerApiPath.PREFIX + "/oauth2/tokens"
+        SellerApiPath.PREFIX + "/oauth2/tokens",
+        PublicApiPath.AUTH_PREFIX + "/**"
     };
 
     public static final String[] GET_ONLY = {

--- a/src/main/java/com/bbangle/bbangle/config/security/auth/CustomOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/auth/CustomOAuth2AuthorizationRequestResolver.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.config.security.auth;
 
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO;
+import com.bbangle.bbangle.config.security.PublicApiPath;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -17,7 +18,7 @@ public class CustomOAuth2AuthorizationRequestResolver implements OAuth2Authoriza
         ClientRegistrationRepository clientRegistrationRepository
     ) {
         this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
-            clientRegistrationRepository, "/api/v1/oauth/authorization"
+            clientRegistrationRepository, PublicApiPath.OAUTH_PREFIX
         );
     }
 

--- a/src/main/java/com/bbangle/bbangle/config/security/auth/CustomOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/auth/CustomOAuth2AuthorizationRequestResolver.java
@@ -1,7 +1,6 @@
 package com.bbangle.bbangle.config.security.auth;
 
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO;
-import com.bbangle.bbangle.config.security.SellerApiPath;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -18,8 +17,7 @@ public class CustomOAuth2AuthorizationRequestResolver implements OAuth2Authoriza
         ClientRegistrationRepository clientRegistrationRepository
     ) {
         this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
-            // TODO : OAuth 로그인 URL 변경하기
-            clientRegistrationRepository, SellerApiPath.PREFIX + "/oauth2/authorization"
+            clientRegistrationRepository, "/api/v1/oauth/authorization"
         );
     }
 

--- a/src/main/java/com/bbangle/bbangle/config/security/auth/OAuth2ClientValidationFilter.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/auth/OAuth2ClientValidationFilter.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.config.security.auth;
 
 import com.bbangle.bbangle.auth.oauth.client.OAuth2StateParser;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO;
+import com.bbangle.bbangle.config.security.PublicApiPath;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.OAuth2Exception;
 import jakarta.servlet.FilterChain;
@@ -47,7 +48,7 @@ public class OAuth2ClientValidationFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
 
         // OAuth2 로그인 요청일 경우 검증
-        if (uri.contains("/oauth/authorization/")) {
+        if (uri.contains(PublicApiPath.OAUTH_PREFIX)) {
             // 현재 서버의 프로파일이 Prod일 경우 profile 파라미터의 값을 prod로 고정
             // profile 파라미터의 값이 부적절할 경우 prod로 고정
             request = wrapRequestDefaultParams(request);

--- a/src/main/java/com/bbangle/bbangle/config/security/auth/OAuth2ClientValidationFilter.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/auth/OAuth2ClientValidationFilter.java
@@ -47,7 +47,7 @@ public class OAuth2ClientValidationFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
 
         // OAuth2 로그인 요청일 경우 검증
-        if (uri.contains("/oauth2/authorization/")) {
+        if (uri.contains("/oauth/authorization/")) {
             // 현재 서버의 프로파일이 Prod일 경우 profile 파라미터의 값을 prod로 고정
             // profile 파라미터의 값이 부적절할 경우 prod로 고정
             request = wrapRequestDefaultParams(request);

--- a/src/main/java/com/bbangle/bbangle/config/security/jwt/TokenProvider.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/jwt/TokenProvider.java
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class TokenProvider {
+    public static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(14);
+    public static final Duration ACCESS_TOKEN_DURATION = Duration.ofHours(3);
     private static final String USER_KEY = "id";
     private static final String ROLE_KEY = "role";
     private final JwtProperties jwtProperties;

--- a/src/main/java/com/bbangle/bbangle/util/CookieUtils.java
+++ b/src/main/java/com/bbangle/bbangle/util/CookieUtils.java
@@ -1,17 +1,19 @@
 package com.bbangle.bbangle.util;
 
 import java.time.Duration;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.springframework.http.ResponseCookie;
 
 /**
  * 쿠키 유틸 클래스
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CookieUtils {
 
     public static ResponseCookie createCookie(String value, Duration duration) {
         return ResponseCookie.from("refreshToken", value)
             .httpOnly(true)
-            // TODO : 로컬에서 사용할 때는 주석처리
             .secure(true)
             .path("/")
             .maxAge(duration)

--- a/src/main/java/com/bbangle/bbangle/util/CookieUtils.java
+++ b/src/main/java/com/bbangle/bbangle/util/CookieUtils.java
@@ -1,0 +1,21 @@
+package com.bbangle.bbangle.util;
+
+import java.time.Duration;
+import org.springframework.http.ResponseCookie;
+
+/**
+ * 쿠키 유틸 클래스
+ */
+public class CookieUtils {
+
+    public static ResponseCookie createCookie(String value, Duration duration) {
+        return ResponseCookie.from("refreshToken", value)
+            .httpOnly(true)
+            // TODO : 로컬에서 사용할 때는 주석처리
+            .secure(true)
+            .path("/")
+            .maxAge(duration)
+            .sameSite("Strict")
+            .build();
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/auth/oauth/client/controller/OAuthControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/oauth/client/controller/OAuthControllerTest.java
@@ -1,0 +1,131 @@
+package com.bbangle.bbangle.auth.oauth.client.controller;
+
+import static com.bbangle.bbangle.common.service.ResponseService.CommonResponse.SUCCESS;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
+import com.bbangle.bbangle.auth.oauth.client.facade.OAuthFacade;
+import com.bbangle.bbangle.auth.oauth.client.service.OAuthService;
+import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.JsonDataEncoder;
+import com.bbangle.bbangle.config.security.SecurityConfig;
+import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.oauth.CookieFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("[컨트롤러 테스트] OAuthController")
+@Import({
+    TestSlackAdaptorConfig.class,
+    JsonDataEncoder.class,
+    TokenProvider.class,
+    TestJwtPropertiesConfig.class,
+    ResponseService.class,
+    SecurityConfig.class
+})
+@WebMvcTest(controllers = OAuthController.class)
+@ActiveProfiles("test")
+class OAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OAuthFacade facade;
+
+    @MockBean
+    private OAuthService service;
+
+    @SpyBean
+    private ResponseService responseService;
+
+    @Test
+    @DisplayName("Refresh Token 쿠키가 존재하면 토큰을 재발급한다.")
+    void success_reissueToken() throws Exception {
+
+        // given
+        String refreshToken = "validRefreshToken";
+
+        TokenResponse tokenResponse = TokenResponse.builder()
+            .refreshToken("newRefreshToken")
+            .accessToken("newAccessToken")
+            .build();
+
+        given(facade.reissueToken(refreshToken)).willReturn(tokenResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/oauth/reissue")
+                .cookie(CookieFixture.defaultCookie(refreshToken)))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Authorization", "Bearer newAccessToken"))
+            .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=newRefreshToken")))
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()));
+
+        then(responseService).should(times(1)).getSuccessResult();
+    }
+
+    @Test
+    @DisplayName("Refresh Token 쿠키가 없으면 401을 반환한다.")
+    void failure_reissueToken_notExistCookie() throws Exception {
+
+        // when & then
+        mockMvc.perform(post("/api/v1/oauth/reissue"))
+            .andExpect(status().isUnauthorized());
+
+        // 쿠키가 없을 경우 OAuth2SellerFacade는 호출조차 하지 않음
+        then(facade).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 유효하지 않을 경우 401을 반환한다.")
+    void failure_reissueToken_invalidRefreshToken() throws Exception {
+
+        // given
+        String refreshToken = "invalidRefreshToken";
+
+        given(facade.reissueToken(refreshToken))
+            .willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/oauth/reissue")
+                .cookie(CookieFixture.defaultCookie(refreshToken)))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그아웃 시 항상 만료된 쿠키를 반환한다.")
+    void logout() throws Exception {
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/oauth/logout")
+                .cookie(CookieFixture.defaultCookie()))
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=")))
+            .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Max-Age=0")))
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()));
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/auth/oauth/client/controller/OAuthControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/oauth/client/controller/OAuthControllerTest.java
@@ -17,6 +17,7 @@ import com.bbangle.bbangle.auth.oauth.client.service.OAuthService;
 import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.JsonDataEncoder;
+import com.bbangle.bbangle.config.security.PublicApiPath;
 import com.bbangle.bbangle.config.security.SecurityConfig;
 import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
 import com.bbangle.bbangle.config.security.jwt.TokenProvider;
@@ -74,7 +75,7 @@ class OAuthControllerTest {
         given(facade.reissueToken(refreshToken)).willReturn(tokenResponse);
 
         // when & then
-        mockMvc.perform(post("/api/v1/oauth/reissue")
+        mockMvc.perform(post(PublicApiPath.AUTH_PREFIX + "/reissue")
                 .cookie(CookieFixture.defaultCookie(refreshToken)))
             .andExpect(status().isOk())
             .andExpect(header().string("Authorization", "Bearer newAccessToken"))
@@ -91,10 +92,10 @@ class OAuthControllerTest {
     void failure_reissueToken_notExistCookie() throws Exception {
 
         // when & then
-        mockMvc.perform(post("/api/v1/oauth/reissue"))
+        mockMvc.perform(post(PublicApiPath.AUTH_PREFIX + "/reissue"))
             .andExpect(status().isUnauthorized());
 
-        // 쿠키가 없을 경우 OAuth2SellerFacade는 호출조차 하지 않음
+        // 쿠키가 없을 경우 OAuthFacade는 호출조차 하지 않음
         then(facade).shouldHaveNoInteractions();
     }
 
@@ -109,7 +110,7 @@ class OAuthControllerTest {
             .willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED));
 
         // when & then
-        mockMvc.perform(post("/api/v1/oauth/reissue")
+        mockMvc.perform(post(PublicApiPath.AUTH_PREFIX + "/reissue")
                 .cookie(CookieFixture.defaultCookie(refreshToken)))
             .andExpect(status().isUnauthorized());
     }
@@ -119,7 +120,7 @@ class OAuthControllerTest {
     void logout() throws Exception {
 
         // when & then
-        mockMvc.perform(delete("/api/v1/oauth/logout")
+        mockMvc.perform(delete(PublicApiPath.AUTH_PREFIX + "/logout")
                 .cookie(CookieFixture.defaultCookie()))
             .andExpect(status().isOk())
             .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=")))
@@ -127,5 +128,7 @@ class OAuthControllerTest {
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
             .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()));
+
+        then(service).should(times(1)).deleteRefreshToken("refreshToken");
     }
 }

--- a/src/test/java/com/bbangle/bbangle/auth/oauth/client/facade/OAuthFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/oauth/client/facade/OAuthFacadeIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.bbangle.bbangle.auth.oauth.client.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bbangle.bbangle.auth.domain.RefreshToken;
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
+import com.bbangle.bbangle.common.redis.repository.RefreshTokenRepository;
+import com.bbangle.bbangle.common.role.Role;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[통합테스트] OAuthFacade")
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class OAuthFacadeIntegrationTest {
+
+    @Autowired
+    OAuthFacade facade;
+
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    TokenProvider tokenProvider;
+
+    @Test
+    @DisplayName("Refresh Token이 유효하면 토큰을 재발급한다.")
+    void success_reissueToken() {
+
+        // given
+        Long sellerId = 1L;
+        Role role = Role.ROLE_SELLER;
+        String refreshToken = tokenProvider.generateToken(sellerId, role, Duration.ofDays(14));
+
+        RefreshToken entity = RefreshToken.create(sellerId, role, refreshToken);
+        RefreshToken oldToken = refreshTokenRepository.saveAndFlush(entity);
+
+        // when
+        TokenResponse result = facade.reissueToken(refreshToken);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.accessToken()).isNotNull();
+        assertThat(result.refreshToken()).isNotNull();
+
+        RefreshToken updated = refreshTokenRepository.findByUserIdAndUserRole(sellerId, role).orElseThrow();
+        assertThat(oldToken.getId()).isNotEqualTo(updated.getId());
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 DB에 없으면 예외 발생")
+    void failure_reissueToken_notExist() {
+
+        // given
+        Long sellerId = 1L;
+        Role role = Role.ROLE_SELLER;
+        String refreshToken = tokenProvider.generateToken(sellerId, role, Duration.ofDays(14));
+
+        // when & then
+        assertThatThrownBy(() -> facade.reissueToken(refreshToken))
+            .isInstanceOf(BbangleException.class)
+            .satisfies(e -> {
+                BbangleException ex = (BbangleException) e;
+                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
+            });
+    }
+
+}

--- a/src/test/java/com/bbangle/bbangle/auth/oauth/client/facade/OAuthFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/oauth/client/facade/OAuthFacadeUnitTest.java
@@ -1,0 +1,124 @@
+package com.bbangle.bbangle.auth.oauth.client.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenClaimsDTO;
+import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
+import com.bbangle.bbangle.auth.oauth.client.service.OAuthService;
+import com.bbangle.bbangle.common.role.Role;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[단위테스트] OAuthFacade")
+@ExtendWith(MockitoExtension.class)
+class OAuthFacadeUnitTest {
+
+    @InjectMocks
+    private OAuthFacade facade;
+
+    @Mock
+    private OAuthService service;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Test
+    @DisplayName("Refresh Token이 유효하면 토큰을 재발급한다.")
+    void success_reissueToken() {
+
+        // given
+        String refreshToken = "validRefreshToken";
+        TokenClaimsDTO tokenClaimsDTO = TokenClaimsDTO.builder()
+            .id(1L)
+            .role(Role.ROLE_SELLER)
+            .build();
+
+        given(tokenProvider.parseRefreshToken(refreshToken)).willReturn(tokenClaimsDTO);
+
+        willDoNothing().given(service).refreshTokenValidate(refreshToken);
+        willDoNothing().given(service).deleteRefreshToken(refreshToken);
+
+        given(service.generateRefreshToken(1L, Role.ROLE_SELLER)).willReturn("newRefreshToken");
+        given(service.generateAccessToken(1L, Role.ROLE_SELLER)).willReturn("newAccessToken");
+
+        // when
+        TokenResponse response = facade.reissueToken(refreshToken);
+
+        // then
+        assertThat(response.refreshToken()).isEqualTo("newRefreshToken");
+        assertThat(response.accessToken()).isEqualTo("newAccessToken");
+
+        InOrder inOrder = inOrder(tokenProvider, service);
+        inOrder.verify(tokenProvider).parseRefreshToken(refreshToken);
+        inOrder.verify(service).refreshTokenValidate(refreshToken);
+        inOrder.verify(service).deleteRefreshToken(refreshToken);
+        inOrder.verify(service).generateRefreshToken(1L, Role.ROLE_SELLER);
+        inOrder.verify(service).generateAccessToken(1L, Role.ROLE_SELLER);
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 만료되면 예외 발생")
+    void failure_reissueToken_expired() {
+
+        // given
+        String refreshToken = "expiredRefreshToken";
+
+        given(tokenProvider.parseRefreshToken(refreshToken)).willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED));
+
+        // when & then
+        assertThatThrownBy(() -> facade.reissueToken(refreshToken))
+            .isInstanceOf(BbangleException.class)
+            .satisfies(e -> {
+                BbangleException ex = (BbangleException) e;
+                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
+            });
+
+        verify(service, never()).refreshTokenValidate(refreshToken);
+        verify(service, never()).deleteRefreshToken(any());
+        verify(service, never()).generateRefreshToken(any(), any());
+        verify(service, never()).generateAccessToken(any(), any());
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 DB에 없으면 예외 발생")
+    void failure_reissueToken_notExist() {
+
+        // given
+        String refreshToken = "invalidRefreshToken";
+        TokenClaimsDTO tokenClaimsDTO = TokenClaimsDTO.builder()
+            .id(1L)
+            .role(Role.ROLE_SELLER)
+            .build();
+
+        given(tokenProvider.parseRefreshToken(refreshToken)).willReturn(tokenClaimsDTO);
+        willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED)).given(service).refreshTokenValidate(refreshToken);
+
+        // when & then
+        assertThatThrownBy(() -> facade.reissueToken(refreshToken))
+            .isInstanceOf(BbangleException.class)
+            .satisfies(e -> {
+                BbangleException ex = (BbangleException) e;
+                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
+            });
+
+        verify(service, never()).deleteRefreshToken(any());
+        verify(service, never()).generateRefreshToken(any(), any());
+        verify(service, never()).generateAccessToken(any(), any());
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/auth/oauth/client/service/OAuthServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/oauth/client/service/OAuthServiceIntegrationTest.java
@@ -1,0 +1,156 @@
+package com.bbangle.bbangle.auth.oauth.client.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.bbangle.bbangle.auth.domain.RefreshToken;
+import com.bbangle.bbangle.common.redis.repository.RefreshTokenRepository;
+import com.bbangle.bbangle.common.role.Role;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[통합테스트] OAuthService")
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class OAuthServiceIntegrationTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    private OAuthService service;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @Nested
+    @DisplayName("generateRefreshToken() Test")
+    class GenerateRefreshTokenTest {
+
+        @Test
+        @DisplayName("Refresh Token을 생성하고 DB에 저장한다.")
+        void create() {
+
+            // given
+            given(tokenProvider.generateToken(any(), any(), any())).willReturn("refreshToken");
+
+            // when
+            String token = service.generateRefreshToken(1L, Role.ROLE_SELLER);
+            em.flush();
+            em.clear();
+
+            // then
+            assertThat(token).isEqualTo("refreshToken");
+
+            RefreshToken saved = refreshTokenRepository
+                .findByUserIdAndUserRole(1L, Role.ROLE_SELLER)
+                .orElseThrow();
+
+            assertThat(saved.getRefreshToken()).isEqualTo("refreshToken");
+        }
+
+        @Test
+        @DisplayName("Refresh Token을 생성하고 DB에 업데이트한다.")
+        void update() {
+
+            // given
+            RefreshToken existing = RefreshToken.create(
+                1L,
+                Role.ROLE_SELLER,
+                "oldToken"
+            );
+            refreshTokenRepository.save(existing);
+
+            given(tokenProvider.generateToken(any(), any(), any())).willReturn("newToken");
+
+            // when
+            service.generateRefreshToken(1L, Role.ROLE_SELLER);
+            em.flush();
+            em.clear();
+
+            // then
+            RefreshToken updated = refreshTokenRepository
+                .findByUserIdAndUserRole(1L, Role.ROLE_SELLER)
+                .orElseThrow();
+
+            assertThat(updated.getRefreshToken()).isEqualTo("newToken");
+        }
+    }
+
+    @Nested
+    @DisplayName("refreshTokenValidate() Test")
+    class RefreshTokenValidateTest {
+
+        @Test
+        @DisplayName("DB에 Refresh Token이 존재하면 통과한다.")
+        void existToken() {
+
+            // given
+            String refreshToken = "validRefreshToken";
+            RefreshToken existing = RefreshToken.create(1L, Role.ROLE_SELLER, refreshToken);
+            refreshTokenRepository.save(existing);
+
+            // when & then
+            assertDoesNotThrow(() -> service.refreshTokenValidate(refreshToken));
+        }
+
+        @Test
+        @DisplayName("DB에 Refresh Token이 없으면 UNAUTHORIZED 예외")
+        void notExistToken() {
+
+            // given
+            String refreshToken = "invalidRefreshToken";
+
+            // when & then
+            assertThatThrownBy(() -> service.refreshTokenValidate(refreshToken))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
+                });
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteRefreshToken() Test")
+    class DeleteRefreshTokenTest {
+
+        @Test
+        @DisplayName("로그아웃 시 DB의 Refresh Token을 삭제한다.")
+        void deleteRefreshToken() {
+
+            // given
+            String refreshToken = "refreshToken";
+            RefreshToken exist = RefreshToken.create(
+                1L,
+                Role.ROLE_SELLER,
+                refreshToken
+            );
+            refreshTokenRepository.save(exist);
+
+            // when
+            service.deleteRefreshToken(refreshToken);
+
+            // then
+            assertThat(refreshTokenRepository.findByUserIdAndUserRole(1L, Role.ROLE_SELLER)).isEmpty();
+            assertThat(refreshTokenRepository.findByRefreshToken(refreshToken)).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/auth/oauth/client/service/OAuthServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/oauth/client/service/OAuthServiceUnitTest.java
@@ -1,0 +1,153 @@
+package com.bbangle.bbangle.auth.oauth.client.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.bbangle.bbangle.auth.domain.RefreshToken;
+import com.bbangle.bbangle.common.redis.repository.RefreshTokenRepository;
+import com.bbangle.bbangle.common.role.Role;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[단위테스트] OAuthService")
+@ExtendWith(MockitoExtension.class)
+class OAuthServiceUnitTest {
+
+    @InjectMocks
+    private OAuthService service;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Nested
+    @DisplayName("generateRefreshToken() Test")
+    class GenerateRefreshTokenTest {
+
+        @Test
+        @DisplayName("Refresh Token을 생성하고 DB에 저장한다.")
+        void success_create() {
+
+            // given
+            given(tokenProvider.generateToken(any(), any(), any())).willReturn("refreshToken");
+
+            given(refreshTokenRepository.findByUserIdAndUserRole(1L, Role.ROLE_SELLER))
+                .willReturn(Optional.empty());
+
+            // when
+            String token = service.generateRefreshToken(1L, Role.ROLE_SELLER);
+
+            // then
+            assertThat(token).isEqualTo("refreshToken");
+            verify(refreshTokenRepository).save(any(RefreshToken.class));
+        }
+
+        @Test
+        @DisplayName("Refresh Token을 생성하고 DB에 업데이트한다.")
+        void success_update() {
+
+            // given
+            RefreshToken existing = RefreshToken.create(1L, Role.ROLE_SELLER, "oldToken");
+
+            given(tokenProvider.generateToken(any(), any(), any())).willReturn("newToken");
+
+            given(refreshTokenRepository.findByUserIdAndUserRole(1L, Role.ROLE_SELLER))
+                .willReturn(Optional.of(existing));
+
+            // when
+            String token = service.generateRefreshToken(1L, Role.ROLE_SELLER);
+
+            // then
+            assertThat(token).isEqualTo("newToken");
+            verify(refreshTokenRepository).save(any(RefreshToken.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("generateAccessToken() Test")
+    class GenerateAccessTokenTest {
+
+        @Test
+        @DisplayName("Access Token을 생성한다.")
+        void success() {
+
+            // given
+            given(tokenProvider.generateToken(any(), any(), any())).willReturn("accessToken");
+
+            // when
+            String token = service.generateAccessToken(1L, Role.ROLE_SELLER);
+
+            // then
+            assertThat(token).isEqualTo("accessToken");
+        }
+    }
+
+    @Nested
+    @DisplayName("refreshTokenValidate() Test")
+    class RefreshTokenValidateTest {
+
+        @Test
+        @DisplayName("DB에 Refresh Token이 존재하면 통과한다.")
+        void existToken() {
+
+            // given
+            String refreshToken = "validRefreshToken";
+            RefreshToken existing = RefreshToken.create(1L, Role.ROLE_SELLER, "refreshToken");
+            given(refreshTokenRepository.findByRefreshToken(any())).willReturn(Optional.of(existing));
+
+            // when & then
+            assertDoesNotThrow(() -> service.refreshTokenValidate(refreshToken));
+        }
+
+        @Test
+        @DisplayName("DB에 Refresh Token이 없을 경우 UNAUTHORIZED 예외")
+        void notExistToken() {
+
+            // given
+            String refreshToken = "invalidRefreshToken";
+            given(refreshTokenRepository.findByRefreshToken(refreshToken)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> service.refreshTokenValidate(refreshToken))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
+                });
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteRefreshToken() Test")
+    class DeleteRefreshTokenTest {
+
+        @Test
+        @DisplayName("DB에 존재하는 Refresh Token을 삭제한다.")
+        void deleteRefreshToken() {
+
+            // given
+            String refreshToken = "refreshToken";
+
+            // when
+            service.deleteRefreshToken(refreshToken);
+
+            // then
+            verify(refreshTokenRepository).deleteByRefreshToken(refreshToken);
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/auth/oauth/client/service/OAuthServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/oauth/client/service/OAuthServiceUnitTest.java
@@ -74,7 +74,6 @@ class OAuthServiceUnitTest {
 
             // then
             assertThat(token).isEqualTo("newToken");
-            verify(refreshTokenRepository).save(any(RefreshToken.class));
         }
     }
 
@@ -108,7 +107,7 @@ class OAuthServiceUnitTest {
             // given
             String refreshToken = "validRefreshToken";
             RefreshToken existing = RefreshToken.create(1L, Role.ROLE_SELLER, "refreshToken");
-            given(refreshTokenRepository.findByRefreshToken(any())).willReturn(Optional.of(existing));
+            given(refreshTokenRepository.findByRefreshToken(refreshToken)).willReturn(Optional.of(existing));
 
             // when & then
             assertDoesNotThrow(() -> service.refreshTokenValidate(refreshToken));

--- a/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
@@ -5,13 +5,11 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenRequest;
 import com.bbangle.bbangle.auth.seller.controller.dto.GenerateTokenResponse;
 import com.bbangle.bbangle.auth.seller.facade.OAuth2SellerFacade;
@@ -27,7 +25,6 @@ import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
-import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -131,80 +128,5 @@ class SellerOauthControllerTest {
                 .content(jsonDataEncoder.encode(new GenerateTokenRequest(code)))
             )
             .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    @DisplayName("Refresh Token 쿠키가 존재하면 토큰을 재발급한다.")
-    void success_reissueToken() throws Exception {
-
-        // given
-        String refreshToken = "validRefreshToken";
-        Cookie cookie = new Cookie("refreshToken", refreshToken);
-
-        TokenResponse tokenResponse = TokenResponse.builder()
-            .refreshToken("newRefreshToken")
-            .accessToken("newAccessToken")
-            .build();
-
-        given(oAuth2SellerFacade.reissueToken(refreshToken)).willReturn(tokenResponse);
-
-        // when & then
-        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/reissue")
-            .cookie(cookie))
-            .andExpect(status().isOk())
-            .andExpect(header().string("Authorization", "Bearer newAccessToken"))
-            .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=newRefreshToken")))
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
-            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()));
-
-        then(responseService).should(times(1)).getSuccessResult();
-    }
-
-    @Test
-    @DisplayName("Refresh Token 쿠키가 없으면 401을 반환한다.")
-    void failure_reissueToken_notExistCookie() throws Exception {
-
-        // when & then
-        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/reissue"))
-            .andExpect(status().isUnauthorized());
-
-        // 쿠키가 없을 경우 oAuth2SellerFacade는 호출조차 하지 않음
-        then(oAuth2SellerFacade).shouldHaveNoInteractions();
-    }
-
-    @Test
-    @DisplayName("Refresh Token이 유효하지 않을 경우 401을 반환한다.")
-    void failure_reissueToken_invalidRefreshToken() throws Exception {
-
-        // given
-        String refreshToken = "invalidRefreshToken";
-        Cookie cookie = new Cookie("refreshToken", refreshToken);
-
-        given(oAuth2SellerFacade.reissueToken(refreshToken))
-            .willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED));
-
-        // when & then
-        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/reissue")
-                .cookie(cookie))
-            .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    @DisplayName("로그아웃 시 항상 만료된 쿠키를 반환한다.")
-    void logout() throws Exception {
-
-        // given
-        Cookie cookie = new Cookie("refreshToken", "refreshToken");
-
-        // when & then
-        mockMvc.perform(delete(SellerApiPath.PREFIX + "/oauth2/logout")
-            .cookie(cookie))
-            .andExpect(status().isOk())
-            .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("refreshToken=")))
-            .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Max-Age=0")))
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
-            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()));
     }
 }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeIntegrationTest.java
@@ -6,13 +6,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.bbangle.bbangle.auth.domain.RefreshToken;
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO;
-import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
 import com.bbangle.bbangle.auth.seller.facade.dto.GenerateTokenDTO;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
 import com.bbangle.bbangle.common.redis.repository.RedisRepository;
 import com.bbangle.bbangle.common.redis.repository.RefreshTokenRepository;
 import com.bbangle.bbangle.common.role.Role;
-import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.domain.Seller;
@@ -56,9 +54,6 @@ class OAuth2SellerFacadeIntegrationTest {
 
     @Autowired
     EntityManager em;
-
-    @Autowired
-    TokenProvider tokenProvider;
 
     @Test
     @DisplayName("판매자 계정이 없으면 새로 생성한다.")
@@ -218,48 +213,6 @@ class OAuth2SellerFacadeIntegrationTest {
 
         // when & then
         assertThatThrownBy(() -> oAuth2SellerFacade.generateToken(code))
-            .isInstanceOf(BbangleException.class)
-            .satisfies(e -> {
-                BbangleException ex = (BbangleException) e;
-                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
-            });
-    }
-
-    @Test
-    @DisplayName("Refresh Token이 유효하면 토큰을 재발급한다.")
-    void success_reissueToken() {
-
-        // given
-        Long sellerId = 1L;
-        Role role = Role.ROLE_SELLER;
-        String refreshToken = tokenProvider.generateToken(sellerId, role, Duration.ofDays(14));
-
-        RefreshToken entity = RefreshToken.create(sellerId, role, refreshToken);
-        RefreshToken oldToken = refreshTokenRepository.save(entity);
-
-        // when
-        TokenResponse result = oAuth2SellerFacade.reissueToken(refreshToken);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.accessToken()).isNotNull();
-        assertThat(result.refreshToken()).isNotNull();
-
-        RefreshToken updated = refreshTokenRepository.findByUserIdAndUserRole(sellerId, role).orElseThrow();
-        assertThat(oldToken.getId()).isNotEqualTo(updated.getId());
-    }
-
-    @Test
-    @DisplayName("Refresh Token이 DB에 없으면 예외 발생")
-    void failure_reissueToken_notExist() {
-
-        // given
-        Long sellerId = 1L;
-        Role role = Role.ROLE_SELLER;
-        String refreshToken = tokenProvider.generateToken(sellerId, role, Duration.ofDays(14));
-
-        // when & then
-        assertThatThrownBy(() -> oAuth2SellerFacade.reissueToken(refreshToken))
             .isInstanceOf(BbangleException.class)
             .satisfies(e -> {
                 BbangleException ex = (BbangleException) e;

--- a/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/facade/OAuth2SellerFacadeUnitTest.java
@@ -4,20 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO;
-import com.bbangle.bbangle.auth.oauth.client.dto.TokenClaimsDTO;
-import com.bbangle.bbangle.auth.oauth.client.dto.TokenResponse;
+import com.bbangle.bbangle.auth.oauth.client.service.OAuthService;
 import com.bbangle.bbangle.auth.seller.facade.dto.GenerateTokenDTO;
 import com.bbangle.bbangle.auth.seller.service.OAuthSellerService;
 import com.bbangle.bbangle.common.role.Role;
-import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.domain.Seller;
@@ -51,7 +47,7 @@ class OAuth2SellerFacadeUnitTest {
     private OAuthSellerService oAuthSellerService;
 
     @Mock
-    private TokenProvider tokenProvider;
+    private OAuthService oAuthService;
 
     @Test
     @DisplayName("판매자 계정이 없으면 새로 생성한다.")
@@ -159,8 +155,8 @@ class OAuth2SellerFacadeUnitTest {
             .build();
 
         given(oAuthSellerService.getSellerInfoFromRedis(code)).willReturn(sellerInfo);
-        given(oAuthSellerService.generateRefreshToken(1L, Role.ROLE_SELLER)).willReturn("refreshToken");
-        given(oAuthSellerService.generateAccessToken(1L, Role.ROLE_SELLER)).willReturn("accessToken");
+        given(oAuthService.generateRefreshToken(1L, Role.ROLE_SELLER)).willReturn("refreshToken");
+        given(oAuthService.generateAccessToken(1L, Role.ROLE_SELLER)).willReturn("accessToken");
 
         // when
         GenerateTokenDTO response = oAuth2SellerFacade.generateToken(code);
@@ -172,8 +168,8 @@ class OAuth2SellerFacadeUnitTest {
         assertThat(response.status()).isEqualTo(CertificationStatus.NEW);
 
         verify(oAuthSellerService).getSellerInfoFromRedis(code);
-        verify(oAuthSellerService).generateRefreshToken(1L, Role.ROLE_SELLER);
-        verify(oAuthSellerService).generateAccessToken(1L, Role.ROLE_SELLER);
+        verify(oAuthService).generateRefreshToken(1L, Role.ROLE_SELLER);
+        verify(oAuthService).generateAccessToken(1L, Role.ROLE_SELLER);
     }
 
     @Test
@@ -187,89 +183,5 @@ class OAuth2SellerFacadeUnitTest {
         // when & then
         assertThatThrownBy(() -> oAuth2SellerFacade.generateToken("code"))
             .isInstanceOf(BbangleException.class);
-    }
-
-    @Test
-    @DisplayName("Refresh Token이 유효하면 토큰을 재발급한다.")
-    void success_reissueToken() {
-
-        // given
-        String refreshToken = "validRefreshToken";
-        TokenClaimsDTO tokenClaimsDTO = TokenClaimsDTO.builder()
-            .id(1L)
-            .role(Role.ROLE_SELLER)
-            .build();
-
-        given(tokenProvider.parseRefreshToken(refreshToken)).willReturn(tokenClaimsDTO);
-
-        willDoNothing().given(oAuthSellerService).refreshTokenValidate(refreshToken);
-        willDoNothing().given(oAuthSellerService).deleteRefreshToken(refreshToken);
-
-        given(oAuthSellerService.generateRefreshToken(1L, Role.ROLE_SELLER)).willReturn("newRefreshToken");
-        given(oAuthSellerService.generateAccessToken(1L, Role.ROLE_SELLER)).willReturn("newAccessToken");
-
-        // when
-        TokenResponse response = oAuth2SellerFacade.reissueToken(refreshToken);
-
-        // then
-        assertThat(response.refreshToken()).isEqualTo("newRefreshToken");
-        assertThat(response.accessToken()).isEqualTo("newAccessToken");
-
-        InOrder inOrder = inOrder(tokenProvider, oAuthSellerService);
-        inOrder.verify(tokenProvider).parseRefreshToken(refreshToken);
-        inOrder.verify(oAuthSellerService).refreshTokenValidate(refreshToken);
-        inOrder.verify(oAuthSellerService).deleteRefreshToken(refreshToken);
-        inOrder.verify(oAuthSellerService).generateRefreshToken(1L, Role.ROLE_SELLER);
-        inOrder.verify(oAuthSellerService).generateAccessToken(1L, Role.ROLE_SELLER);
-    }
-
-    @Test
-    @DisplayName("Refresh Token이 만료되면 예외 발생")
-    void failure_reissueToken_expired() {
-
-        // given
-        String refreshToken = "expiredRefreshToken";
-
-        given(tokenProvider.parseRefreshToken(refreshToken)).willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED));
-
-        // when & then
-        assertThatThrownBy(() -> oAuth2SellerFacade.reissueToken(refreshToken))
-            .isInstanceOf(BbangleException.class)
-            .satisfies(e -> {
-                BbangleException ex = (BbangleException) e;
-                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
-            });
-
-        verify(oAuthSellerService, never()).refreshTokenValidate(refreshToken);
-        verify(oAuthSellerService, never()).deleteRefreshToken(any());
-        verify(oAuthSellerService, never()).generateRefreshToken(any(), any());
-        verify(oAuthSellerService, never()).generateAccessToken(any(), any());
-    }
-
-    @Test
-    @DisplayName("Refresh Token이 DB에 없으면 예외 발생")
-    void failure_reissueToken_notExist() {
-
-        // given
-        String refreshToken = "invalidRefreshToken";
-        TokenClaimsDTO tokenClaimsDTO = TokenClaimsDTO.builder()
-            .id(1L)
-            .role(Role.ROLE_SELLER)
-            .build();
-
-        given(tokenProvider.parseRefreshToken(refreshToken)).willReturn(tokenClaimsDTO);
-        willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED)).given(oAuthSellerService).refreshTokenValidate(refreshToken);
-
-        // when & then
-        assertThatThrownBy(() -> oAuth2SellerFacade.reissueToken(refreshToken))
-            .isInstanceOf(BbangleException.class)
-            .satisfies(e -> {
-                BbangleException ex = (BbangleException) e;
-                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
-            });
-
-        verify(oAuthSellerService, never()).deleteRefreshToken(any());
-        verify(oAuthSellerService, never()).generateRefreshToken(any(), any());
-        verify(oAuthSellerService, never()).generateAccessToken(any(), any());
     }
 }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceIntegrationTest.java
@@ -2,26 +2,18 @@ package com.bbangle.bbangle.auth.seller.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 
-import com.bbangle.bbangle.auth.domain.RefreshToken;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO;
 import com.bbangle.bbangle.common.redis.repository.RedisRepository;
-import com.bbangle.bbangle.common.redis.repository.RefreshTokenRepository;
 import com.bbangle.bbangle.common.role.Role;
-import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
-import jakarta.persistence.EntityManager;
 import java.time.Duration;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,19 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 class OAuthSellerServiceIntegrationTest {
 
     @Autowired
-    EntityManager em;
-
-    @Autowired
     private OAuthSellerService service;
 
     @Autowired
     private RedisRepository redisRepository;
-
-    @Autowired
-    private RefreshTokenRepository refreshTokenRepository;
-
-    @MockBean
-    private TokenProvider tokenProvider;
 
     @Test
     @DisplayName("Redis에 저장된 SellerInfo를 조회하고 즉시 삭제한다.")
@@ -79,104 +62,5 @@ class OAuthSellerServiceIntegrationTest {
         assertThatThrownBy(() -> service.getSellerInfoFromRedis("code"))
             .isInstanceOf(BbangleException.class)
             .hasMessage(BbangleErrorCode._UNAUTHORIZED.getMessage());
-    }
-
-    @Test
-    @DisplayName("Refresh Token을 생성하고 DB에 저장한다.")
-    void generateRefreshToken_create() {
-
-        // given
-        given(tokenProvider.generateToken(any(), any(), any())).willReturn("refreshToken");
-
-        // when
-        String token = service.generateRefreshToken(1L, Role.ROLE_SELLER);
-        em.flush();
-        em.clear();
-
-        // then
-        assertThat(token).isEqualTo("refreshToken");
-
-        RefreshToken saved = refreshTokenRepository
-            .findByUserIdAndUserRole(1L, Role.ROLE_SELLER)
-            .orElseThrow();
-
-        assertThat(saved.getRefreshToken()).isEqualTo("refreshToken");
-    }
-
-    @Test
-    @DisplayName("Refresh Token을 생성하고 DB에 업데이트한다.")
-    void generateRefreshToken_update() {
-
-        // given
-        RefreshToken existing = RefreshToken.create(
-            1L,
-            Role.ROLE_SELLER,
-            "oldToken"
-        );
-        refreshTokenRepository.save(existing);
-
-        given(tokenProvider.generateToken(any(), any(), any())).willReturn("newToken");
-
-        // when
-        service.generateRefreshToken(1L, Role.ROLE_SELLER);
-        em.flush();
-        em.clear();
-
-        // then
-        RefreshToken updated = refreshTokenRepository
-            .findByUserIdAndUserRole(1L, Role.ROLE_SELLER)
-            .orElseThrow();
-
-        assertThat(updated.getRefreshToken()).isEqualTo("newToken");
-    }
-
-    @Test
-    @DisplayName("DB에 Refresh Token이 존재하면 통과한다.")
-    void refreshTokenValidate_existToken() {
-
-        // given
-        String refreshToken = "validRefreshToken";
-        RefreshToken existing = RefreshToken.create(1L, Role.ROLE_SELLER, refreshToken);
-        refreshTokenRepository.save(existing);
-
-        // when & then
-        assertDoesNotThrow(() -> service.refreshTokenValidate(refreshToken));
-    }
-
-    @Test
-    @DisplayName("DB에 Refresh Token이 없으면 UNAUTHORIZED 예외")
-    void refreshTokenValidate_notExistToken() {
-
-        // given
-        String refreshToken = "invalidRefreshToken";
-
-        // when & then
-        assertThatThrownBy(() -> service.refreshTokenValidate(refreshToken))
-            .isInstanceOf(BbangleException.class)
-            .satisfies(e -> {
-                BbangleException ex = (BbangleException) e;
-                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
-            });
-    }
-
-    @Test
-    @DisplayName("로그아웃 시 DB의 Refresh Token을 삭제한다.")
-    void deleteRefreshToken() {
-
-        // given
-        String refreshToken = "refreshToken";
-        RefreshToken exist = RefreshToken.create(
-            1L,
-            Role.ROLE_SELLER,
-            refreshToken
-        );
-        refreshTokenRepository.save(exist);
-
-        // when
-        service.deleteRefreshToken(refreshToken);
-
-        // then
-        assertThat(refreshTokenRepository.findByUserIdAndUserRole(1L, Role.ROLE_SELLER)).isEmpty();
-        assertThat(refreshTokenRepository.findByRefreshToken(refreshToken)).isEmpty();
     }
 }

--- a/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/service/OAuthSellerServiceUnitTest.java
@@ -2,21 +2,13 @@ package com.bbangle.bbangle.auth.seller.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 
-import com.bbangle.bbangle.auth.domain.RefreshToken;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO;
 import com.bbangle.bbangle.common.redis.repository.RedisRepository;
-import com.bbangle.bbangle.common.redis.repository.RefreshTokenRepository;
 import com.bbangle.bbangle.common.role.Role;
-import com.bbangle.bbangle.config.security.jwt.TokenProvider;
-import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,15 +26,6 @@ class OAuthSellerServiceUnitTest {
     @Mock
     private RedisRepository redisRepository;
 
-    @Mock
-    private TokenProvider tokenProvider;
-
-    @Mock
-    private RefreshTokenRepository refreshTokenRepository;
-
-    // --------------------
-    // getSellerInfoFromRedis Test
-    // --------------------
     @Test
     @DisplayName("Redis에 저장된 SellerInfo를 조회하고 즉시 삭제한다.")
     void success_getSellerInfoFromRedis() {
@@ -87,110 +70,5 @@ class OAuthSellerServiceUnitTest {
         // when & then
         assertThatThrownBy(() -> service.getSellerInfoFromRedis("code"))
             .isInstanceOf(BbangleException.class);
-    }
-
-    // --------------------
-    // generateRefreshToken Test
-    // --------------------
-    @Test
-    @DisplayName("Refresh Token을 생성하고 DB에 저장한다.")
-    void success_generateRefreshToken_create() {
-
-        // given
-        given(tokenProvider.generateToken(any(), any(), any())).willReturn("refreshToken");
-
-        given(refreshTokenRepository.findByUserIdAndUserRole(1L, Role.ROLE_SELLER))
-            .willReturn(Optional.empty());
-
-        // when
-        String token = service.generateRefreshToken(1L, Role.ROLE_SELLER);
-
-        // then
-        assertThat(token).isEqualTo("refreshToken");
-        verify(refreshTokenRepository).save(any(RefreshToken.class));
-    }
-
-    @Test
-    @DisplayName("Refresh Token을 생성하고 DB에 업데이트한다.")
-    void success_generateRefreshToken_update() {
-
-        // given
-        RefreshToken existing = RefreshToken.create(1L, Role.ROLE_SELLER, "oldToken");
-
-        given(tokenProvider.generateToken(any(), any(), any())).willReturn("newToken");
-
-        given(refreshTokenRepository.findByUserIdAndUserRole(1L, Role.ROLE_SELLER))
-            .willReturn(Optional.of(existing));
-
-        // when
-        String token = service.generateRefreshToken(1L, Role.ROLE_SELLER);
-
-        // then
-        assertThat(token).isEqualTo("newToken");
-        verify(refreshTokenRepository).save(any(RefreshToken.class));
-    }
-
-    // --------------------
-    // generateRefreshToken Test
-    // --------------------
-    @Test
-    @DisplayName("Access Token을 생성한다.")
-    void success_generateAccessToken() {
-
-        // given
-        given(tokenProvider.generateToken(any(), any(), any())).willReturn("accessToken");
-
-        // when
-        String token = service.generateAccessToken(1L, Role.ROLE_SELLER);
-
-        // then
-        assertThat(token).isEqualTo("accessToken");
-    }
-
-    // --------------------
-    // refreshTokenValidate Test
-    // --------------------
-    @Test
-    @DisplayName("DB에 Refresh Token이 존재하면 통과한다.")
-    void refreshTokenValidate_existToken() {
-
-        // given
-        String refreshToken = "validRefreshToken";
-        RefreshToken existing = RefreshToken.create(1L, Role.ROLE_SELLER, "refreshToken");
-        given(refreshTokenRepository.findByRefreshToken(any())).willReturn(Optional.of(existing));
-
-        // when & then
-        assertDoesNotThrow(() -> service.refreshTokenValidate(refreshToken));
-    }
-
-    @Test
-    @DisplayName("DB에 Refresh Token이 없을 경우 UNAUTHORIZED 예외")
-    void refreshTokenValidate_notExistToken() {
-
-        // given
-        String refreshToken = "invalidRefreshToken";
-        given(refreshTokenRepository.findByRefreshToken(refreshToken)).willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> service.refreshTokenValidate(refreshToken))
-            .isInstanceOf(BbangleException.class)
-            .satisfies(e -> {
-                BbangleException ex = (BbangleException) e;
-                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._UNAUTHORIZED);
-            });
-    }
-
-    @Test
-    @DisplayName("DB에 존재하는 Refresh Token을 삭제한다.")
-    void deleteRefreshToken() {
-
-        // given
-        String refreshToken = "refreshToken";
-
-        // when
-        service.deleteRefreshToken(refreshToken);
-
-        // then
-        verify(refreshTokenRepository).deleteByRefreshToken(refreshToken);
     }
 }

--- a/src/test/java/com/bbangle/bbangle/claim/repository/ClaimRepositoryDataJpaTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/repository/ClaimRepositoryDataJpaTest.java
@@ -149,21 +149,6 @@ class ClaimRepositoryDataJpaTest {
         }
 
         @Test
-        @DisplayName("같은 store의 다른 seller도 true를 반환한다")
-        void given_samestoreWithDifferentSeller_when_exists_then_returnTrue() {
-            // given
-            Seller anotherSeller = sellerRepository.save(SellerFixture.defaultSeller(store));
-            em.flush();
-            em.clear();
-
-            // when
-            boolean result = claimRepository.existsClaimRequestBySeller(returnRequest.getId(), anotherSeller.getId());
-
-            // then
-            assertThat(result).isTrue();
-        }
-
-        @Test
         @DisplayName("존재하지 않는 seller id로 조회하면 false를 반환한다")
         void given_nonExistentSellerId_when_exists_then_returnFalse() {
             // given

--- a/src/test/java/com/bbangle/bbangle/config/security/auth/OAuth2ClientValidationFilterUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/config/security/auth/OAuth2ClientValidationFilterUnitTest.java
@@ -68,7 +68,7 @@ class OAuth2ClientValidationFilterUnitTest {
     void redirect_client_not_found() throws Exception {
 
         // given
-        request.setRequestURI("/oauth2/authorization/test");
+        request.setRequestURI("/oauth/authorization/test");
         request.addHeader("Referer", "test");
 
         given(clientRegistrationRepository.findByRegistrationId("test")).willReturn(null);
@@ -98,7 +98,7 @@ class OAuth2ClientValidationFilterUnitTest {
     void redirect_invalid_oauth_params() throws Exception {
 
         // given
-        request.setRequestURI("/oauth2/authorization/test");
+        request.setRequestURI("/oauth/authorization/test");
         request.setParameter("user", "INVALID"); // dto.valid() false 유도
         request.addHeader("Referer", "test");
 
@@ -133,7 +133,7 @@ class OAuth2ClientValidationFilterUnitTest {
     void pass_client_exists() throws Exception {
 
         // given
-        request.setRequestURI("/oauth2/authorization/test");
+        request.setRequestURI("/oauth/authorization/test");
         request.setParameter("user", UserType.CUSTOMER.toString());
 
         ClientRegistration clientRegistration = mock(ClientRegistration.class);
@@ -157,7 +157,7 @@ class OAuth2ClientValidationFilterUnitTest {
     void oauth2_profileParam_default_wrapping() throws Exception {
 
         // given
-        request.setRequestURI("/oauth2/authorization/test");
+        request.setRequestURI("/oauth/authorization/test");
         request.setParameter("user", UserType.CUSTOMER.toString());
 
         ClientRegistration clientRegistration = mock(ClientRegistration.class);

--- a/src/test/java/com/bbangle/bbangle/config/security/auth/OAuth2ClientValidationFilterUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/config/security/auth/OAuth2ClientValidationFilterUnitTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import com.bbangle.bbangle.auth.oauth.client.OAuth2StateParser;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO;
 import com.bbangle.bbangle.auth.oauth.client.dto.OAuth2DTO.UserType;
+import com.bbangle.bbangle.config.security.PublicApiPath;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.OAuth2Exception;
 import jakarta.servlet.FilterChain;
@@ -68,7 +69,7 @@ class OAuth2ClientValidationFilterUnitTest {
     void redirect_client_not_found() throws Exception {
 
         // given
-        request.setRequestURI("/oauth/authorization/test");
+        request.setRequestURI(PublicApiPath.OAUTH_PREFIX + "/test");
         request.addHeader("Referer", "test");
 
         given(clientRegistrationRepository.findByRegistrationId("test")).willReturn(null);
@@ -98,7 +99,7 @@ class OAuth2ClientValidationFilterUnitTest {
     void redirect_invalid_oauth_params() throws Exception {
 
         // given
-        request.setRequestURI("/oauth/authorization/test");
+        request.setRequestURI(PublicApiPath.OAUTH_PREFIX + "/test");
         request.setParameter("user", "INVALID"); // dto.valid() false 유도
         request.addHeader("Referer", "test");
 
@@ -133,7 +134,7 @@ class OAuth2ClientValidationFilterUnitTest {
     void pass_client_exists() throws Exception {
 
         // given
-        request.setRequestURI("/oauth/authorization/test");
+        request.setRequestURI(PublicApiPath.OAUTH_PREFIX + "/test");
         request.setParameter("user", UserType.CUSTOMER.toString());
 
         ClientRegistration clientRegistration = mock(ClientRegistration.class);
@@ -157,7 +158,7 @@ class OAuth2ClientValidationFilterUnitTest {
     void oauth2_profileParam_default_wrapping() throws Exception {
 
         // given
-        request.setRequestURI("/oauth/authorization/test");
+        request.setRequestURI(PublicApiPath.OAUTH_PREFIX + "/test");
         request.setParameter("user", UserType.CUSTOMER.toString());
 
         ClientRegistration clientRegistration = mock(ClientRegistration.class);
@@ -185,7 +186,7 @@ class OAuth2ClientValidationFilterUnitTest {
     void pass_non_oauth2_request() throws Exception {
 
         // given
-        request.setRequestURI("/api/test");
+        request.setRequestURI("/api/v1/test");
 
         // when
         filter.doFilter(request, response, filterChain);

--- a/src/test/java/com/bbangle/bbangle/fixture/oauth/CookieFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/oauth/CookieFixture.java
@@ -1,0 +1,16 @@
+package com.bbangle.bbangle.fixture.oauth;
+
+import jakarta.servlet.http.Cookie;
+
+public final class CookieFixture {
+
+    private CookieFixture() {}
+
+    public static Cookie defaultCookie() {
+        return new Cookie("refreshToken", "refreshToken");
+    }
+
+    public static Cookie defaultCookie(String value) {
+        return new Cookie("refreshToken", value);
+    }
+}


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

- 연관된 이슈 : #606 
- [Notion 개발 일정](https://www.notion.so/sideproject-unione/1-_-_OAuth2-API-310622e86d3d806d8f97ea9a78328195?source=copy_link) 
- [API 명세서 - Kakao 로그인](https://www.notion.so/sideproject-unione/2d6622e86d3d80069dffc0297ed1a0d3?v=2c6622e86d3d8157890d000cc857bdd2&source=copy_link)
- [API 명세서 - Google 로그인](https://www.notion.so/sideproject-unione/2d6622e86d3d808bb76ced676b846ad6?v=2c6622e86d3d8157890d000cc857bdd2&source=copy_link)  
- [API 명세서 - 로그아웃](https://www.notion.so/sideproject-unione/2f2622e86d3d806fbd0ce4919396d735?source=copy_link)
- [API 명세서 - 토큰 재발급](https://www.notion.so/sideproject-unione/2ee622e86d3d8077b3c3df69610fb22c?source=copy_link)

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

- OAuth2 로그인 및 Token 관련 API를 Customer와 Seller 둘 다 사용해야 하므로 API 네이밍을 변경하였습니다.
- /seller/oauth2 > /oauth

|기능|변경 전|변경 후|
|-----|-------|--------|
|Kakao 로그인|/api/v1/seller/oauth2/authorization/kakao|/api/v1/oauth/authorization/kakao|
|Google 로그인|/api/v1/seller/oauth2/authorization/google|/api/v1/oauth/authorization/google|
|토큰 재발급|/api/v1/seller/oauth2/reissue|/api/v1/auth/reissue|
|로그아웃|/api/v1/seller/oauth2/logout|/api/v1/auth/logout|

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
- 일단, OAuth2 API는 /oauth로 설정하였고 토큰 관련은 /auth로 설정하였습니다.
  - API Prefix 전부 /oauth로 통일할지 구분할지 생각중인데 어떻게 생각하시나요?
- Store와 Seller의 연관관계를 1:1로 변경하면서 이와 관련된 테스트코드를 제거하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth 인증 엔드포인트 추가: 로그인, 토큰 재발급, 로그아웃 제공
  * 토큰 재발급 시 Authorization 헤더 갱신 및 리프레시 토큰 쿠키 자동 설정/갱신

* **Refactor**
  * 토큰 생성·검증 로직 중앙화로 흐름 단순화 및 일관성 향상
  * 판매자용 OAuth 흐름 일부 정리 및 책임 분리

* **Tests**
  * OAuth 인증 및 토큰 흐름에 대한 단위·통합 테스트 대폭 추가/갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->