### PR TITLE
[Refactore] OAuth2 인증 완료 후 판매자 JWT 발급 API 네이밍 수정

### DIFF
--- a/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
+++ b/src/main/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping(SellerApiPath.PREFIX + "/oauth2")
+@RequestMapping(SellerApiPath.PREFIX + "/oauth")
 public class SellerOauthController implements SellerOauthApi {
 
     private final ResponseService responseService;

--- a/src/main/java/com/bbangle/bbangle/config/security/PublicApiPath.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/PublicApiPath.java
@@ -16,7 +16,7 @@ public class PublicApiPath {
         "/api/v1/stores/**",
         "/api/v1/health/**",
         "/api/v1/push/**",
-        SellerApiPath.PREFIX + "/oauth2/tokens",
+        SellerApiPath.PREFIX + "/oauth/tokens",
         PublicApiPath.AUTH_PREFIX + "/**"
     };
 

--- a/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/auth/seller/controller/SellerOauthControllerTest.java
@@ -86,7 +86,7 @@ class SellerOauthControllerTest {
         given(oAuth2SellerFacade.generateToken(code)).willReturn(dto);
 
         // when & then
-        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/tokens")
+        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth/tokens")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(jsonDataEncoder.encode(new GenerateTokenRequest(code)))
             )
@@ -105,7 +105,7 @@ class SellerOauthControllerTest {
     @Test
     @DisplayName("임시 코드가 없으면 400 에러를 반환한다.")
     void failure_sellerToken_400() throws Exception {
-        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/tokens")
+        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth/tokens")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(jsonDataEncoder.encode(new GenerateTokenRequest("")))
             )
@@ -123,7 +123,7 @@ class SellerOauthControllerTest {
             .willThrow(new BbangleException(BbangleErrorCode._UNAUTHORIZED));
 
         // when & then
-        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth2/tokens")
+        mockMvc.perform(post(SellerApiPath.PREFIX + "/oauth/tokens")
                     .contentType(MediaType.APPLICATION_JSON)
                 .content(jsonDataEncoder.encode(new GenerateTokenRequest(code)))
             )


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

- 연관된 이슈 : #613 
- [Notion 개발 일정](https://www.notion.so/sideproject-unione/1-_-_JWT-API-314622e86d3d80398d6cd9887c2239d5?source=copy_link)
- [API 명세서](https://www.notion.so/sideproject-unione/JWT-2d6622e86d3d806ab1f4d76c3a6e82a8?v=2c6622e86d3d8157890d000cc857bdd2&source=copy_link) 

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

- (판매자) JWT 발급 API 네이밍 수정
  - oauth2 -> oauth 

|기능|변경 전 API|변경 된 API|
|-----|------------|------------|
|(판매자) JWT 발급 API|/api/v1/seller/oauth2/tokens|/api/v1/seller/oauth/tokens|

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->
- JWT 발급은 OAuth2 플로우에 포함된다 생각되어 oauth로 정하였습니다.