### PR TITLE
[Test] SellerOrderService 단위 테스트 실패 오류 수정 및 검증 로직 최신화

### DIFF
--- a/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceUnitTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 import com.bbangle.bbangle.common.page.BbanglePageResponse;
+import com.bbangle.bbangle.delivery.domain.Shipping;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
@@ -17,6 +18,7 @@ import com.bbangle.bbangle.fixture.payment.domain.PaymentFixture;
 import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
 import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderDelivery;
 import com.bbangle.bbangle.order.domain.OrderItem;
 import com.bbangle.bbangle.order.domain.model.CompletedOrderSearchType;
 import com.bbangle.bbangle.order.domain.model.CourierCompany;
@@ -27,8 +29,12 @@ import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.order.repository.OrderRepository;
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
+import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.ShipmentModifyResponse;
+import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.ShipmentRegisterResponse;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderConfirmCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderSearchCommand;
+import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentModifyCommand;
+import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentRegisterCommand;
 import com.bbangle.bbangle.payment.domain.Payment;
 import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
@@ -39,6 +45,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -67,276 +74,589 @@ class SellerOrderServiceUnitTest {
     @Mock
     private SellerRepository sellerRepository;
 
-    @DisplayName("주문이 존재하지 않으면 ORDER_NOT_FOUND 예외가 발생한다.")
-    @Test
-    void givenNonExistingOrderId_whenConfirmOrder_thenThrowsException() {
-        // given
-        Long orderId = 999L;
-        OrderConfirmCommand command = OrderConfirmCommand.builder()
-            .sellerId(1L) // 지금은 검증 안 해도 command 형태 맞추려고 넣어둠
-            .orderId(orderId)
-            .orderItemIds(List.of(1L, 2L))
-            .build();
-
-        given(orderRepository.findById(orderId)).willReturn(Optional.empty());
-
-        // when
-        BbangleException result = assertThrows(BbangleException.class,
-            () -> sut.confirmOrder(command));
-
-        // then
-        then(orderRepository).should(times(1)).findById(orderId);
-        assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_NOT_FOUND);
-    }
-
-    @DisplayName("결제 완료(PAYMENT_COMPLETED)인 주문상품만 발주확인(ORDER_CONFIRMED)되고, 나머지는 부분 성공으로 스킵된다.")
-    @Test
-    void givenMixedOrderItems_whenConfirmOrder_thenConfirmOnlyPaymentCompleted() {
-        // given
-        Long orderId = 1L;
-
-        Order order = OrderFixture.createDefaultOrder();
-        ReflectionTestUtils.setField(order, "id", orderId);
-
-        OrderItem okItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.PAYMENT_COMPLETED);
-        ReflectionTestUtils.setField(okItem, "id", 10L);
-        ReflectionTestUtils.setField(okItem, "order", order);
-
-        OrderItem skipItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.ORDER_CONFIRMED);
-        ReflectionTestUtils.setField(skipItem, "id", 11L);
-        ReflectionTestUtils.setField(skipItem, "order", order);
-
-        OrderConfirmCommand command = OrderConfirmCommand.builder()
-            .sellerId(1L)
-            .orderId(orderId)
-            .orderItemIds(List.of(10L, 11L))
-            .build();
-
-        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
-        given(sellerRepository.findStoreIdBySellerId(1L)).willReturn(1L);
-        given(orderItemRepository.countOwnedOrderItems(orderId, List.of(10L, 11L), 1L))
-            .willReturn(2L);
-        given(orderItemRepository.findByOrderIdAndIdIn(orderId, List.of(10L, 11L)))
-            .willReturn(List.of(okItem, skipItem));
-
-        // when
-        OrderConfirmResponse result = sut.confirmOrder(command);
-
-        // then
-        then(orderRepository).should(times(1)).findById(orderId);
-        then(orderItemRepository).should(times(1)).findByOrderIdAndIdIn(orderId, List.of(10L, 11L));
-
-        // 응답 검증: PAYMENT_COMPLETED였던 것만 포함
-        assertThat(result).isNotNull();
-        assertThat(result.content().orderId()).isEqualTo(orderId);
-        assertThat(result.content().confirmedOrderItemIds())
-            .asList()
-            .containsExactly(10L);
-
-        // 상태 변경 검증
-        assertThat(okItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED);
-        assertThat(skipItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED); // 원래부터 confirmed였으면 그대로
-    }
-
-    @DisplayName("주문 검색 시 Page 객체로 올바르게 반환되는지 확인")
-    @Test
-    void givenOrderSearchRequest_whenOrderSearch_thenReturnsPageWithCorrectData() {
-        // given
-        Long orderId = 1L;
-        String orderNumber = "ORDER-2025-01-01-00001";
-        Integer totalAmount = 50000;
-        String buyerName = "홍길동";
-
-        Store boardStore = StoreFixture.defaultStore();
-        ReflectionTestUtils.setField(boardStore, "id", 2L);
-        var board = BoardFixture.defaultBoardWithStore(boardStore, "카카오커피");
-        var product = ProductFixture.create(board, "카카오커피");
-
-        Order order = OrderFixture.createOrderWithNumber(orderNumber)
-            .toBuilder()
-            .totalAmount(totalAmount)
-            .buyerName(buyerName)
-            .build();
-        ReflectionTestUtils.setField(order, "id", orderId);
-
-        OrderItem orderItem = OrderItemFixture.createOrderItemWithProduct(product);
-        ReflectionTestUtils.setField(orderItem, "id", 10L);
-        order.addOrderItem(orderItem);
-
+    private Seller sellerWithStore(Long storeId) {
         Store store = StoreFixture.defaultStore();
-        ReflectionTestUtils.setField(store, "id", 1L);
+        ReflectionTestUtils.setField(store, "id", storeId);
+        return SellerFixture.createDefaultSeller(store);
+    }
 
-        Seller seller = SellerFixture.createDefaultSeller(store);
-        ReflectionTestUtils.setField(seller, "id", 1L);
-        ReflectionTestUtils.setField(order, "seller", seller);
+    @Nested
+    @DisplayName("발주 확인 (confirmOrder)")
+    class ConfirmOrderTest {
 
-        Payment payment = PaymentFixture.createDefaultPayment(order);
-        ReflectionTestUtils.setField(order, "payment", payment);
+        @DisplayName("주문이 존재하지 않으면 ORDER_NOT_FOUND 예외가 발생한다.")
+        @Test
+        void givenNonExistingOrderId_whenConfirmOrder_thenThrowsException() {
+            // given
+            Long orderId = 999L;
+            OrderConfirmCommand command = OrderConfirmCommand.builder()
+                .sellerId(1L)
+                .orderId(orderId)
+                .orderItemIds(List.of(1L, 2L))
+                .build();
 
-        PageRequest pageable = PageRequest.of(0, 10);
-        BbanglePageResponse<Order> orderPage = new BbanglePageResponse<>(
-            List.of(order),
-            0,
-            10,
-            1,
-            1L);
+            given(orderRepository.findById(orderId)).willReturn(Optional.empty());
 
-        OrderSearchCommand command = OrderSearchCommand.builder()
-            .sellerId(1L)
-            .orderDeliveryStatus(null)
-            .searchType(CompletedOrderSearchType.ORDER_NUMBER)
-            .searchCondition(null)
-            .page(pageable)
-            .build();
+            // when
+            BbangleException result = assertThrows(BbangleException.class,
+                () -> sut.confirmOrder(command));
 
-        given(orderRepository.searchOrderList(command)).willReturn(orderPage);
-        given(orderDeliveryRepository.findLatestByOrderItemIds(List.of(10L)))
-            .willReturn(Collections.emptyList());
-
-        // when
-        BbanglePageResponse<OrderResponse.OrderSearchResponse> result = sut.orderSearch(command);
-
-        log.info("=== OrderSearchResponse (JSON) ===");
-        if (!result.content().isEmpty()) {
-            try {
-                ObjectMapper objectMapper = new ObjectMapper();
-                String json = objectMapper.writerWithDefaultPrettyPrinter()
-                    .writeValueAsString(result.content().get(0));
-                log.info(json);
-            } catch (Exception e) {
-                log.error("Failed to serialize OrderSearchResponse to JSON", e);
-            }
+            // then
+            then(orderRepository).should(times(1)).findById(orderId);
+            assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_NOT_FOUND);
         }
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.totalElements()).isEqualTo(1L);
-        assertThat(result.content()).asList().hasSize(1);
+        @DisplayName("결제 완료(PAYMENT_COMPLETED)인 주문상품만 발주확인(ORDER_CONFIRMED)되고, 나머지는 failedIds로 반환된다.")
+        @Test
+        void givenMixedOrderItems_whenConfirmOrder_thenConfirmOnlyPaymentCompleted() {
+            // given
+            Long orderId = 1L;
 
-        OrderResponse.OrderSearchResponse response = result.content().get(0);
+            Order order = OrderFixture.createDefaultOrder();
+            ReflectionTestUtils.setField(order, "id", orderId);
 
-        // 기본 정보 검증
-        assertThat(response.orderNumber()).isEqualTo(orderNumber);
-        assertThat(response.totalOrderPrice()).isEqualTo(totalAmount.toString());
-        assertThat(response.recipientName()).isEqualTo(buyerName);
+            OrderItem okItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.PAYMENT_COMPLETED);
+            ReflectionTestUtils.setField(okItem, "id", 10L);
 
-        // 주문 상품 정보 검증
-        assertThat(response.orderItems()).isNotNull().asList().hasSize(1);
+            OrderItem skipItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.ORDER_CONFIRMED);
+            ReflectionTestUtils.setField(skipItem, "id", 11L);
 
-        var orderItemList = response.orderItems().get(0);
-        assertThat(orderItemList.orderNumber()).isEqualTo(orderNumber);
-        assertThat(orderItemList.orderStatus()).isEqualTo(OrderStatus.PAYMENT_COMPLETED);
-        assertThat(orderItemList.orderItemInfo().itemName()).isEqualTo("카카오커피");
-        assertThat(orderItemList.orderItemInfo().quantity()).isEqualTo(2);
-        assertThat(orderItemList.orderItemInfo().unitPrice()).isEqualTo(25000L);
-        assertThat(orderItemList.orderItemInfo().totalPrice()).isEqualTo(50000L);
+            Seller seller = sellerWithStore(1L);
 
-        // 배송 정보 검증 (OrderItem에 OrderDelivery 없으므로 기본값 - 이제 품목 수준)
-        assertThat(orderItemList.orderDeliveryStatus()).isEqualTo(OrderDeliveryStatus.PREPARING);
-        assertThat(orderItemList.courierCompany()).isEqualTo(CourierCompany.NONE);
-        assertThat(orderItemList.trackingNumber()).isEqualTo("-");
+            OrderConfirmCommand command = OrderConfirmCommand.builder()
+                .sellerId(1L)
+                .orderId(orderId)
+                .orderItemIds(List.of(10L, 11L))
+                .build();
 
-        // 판매자 정보 검증
-        assertThat(response.sellerId()).isEqualTo(1L);
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(sellerRepository.findByIdWithStore(1L)).willReturn(Optional.of(seller));
+            given(orderItemRepository.findByOrderIdAndIdIn(orderId, List.of(10L, 11L)))
+                .willReturn(List.of(okItem, skipItem));
+            given(orderItemRepository.countOwnedOrderItems(orderId, List.of(10L, 11L), 1L))
+                .willReturn(2L);
 
-        // 결제 정보 검증
-        assertThat(response.paymentInfo()).isNotNull();
+            // when
+            OrderConfirmResponse result = sut.confirmOrder(command);
+
+            // then
+            then(orderRepository).should(times(1)).findById(orderId);
+            then(orderItemRepository).should(times(1)).findByOrderIdAndIdIn(orderId, List.of(10L, 11L));
+
+            assertThat(result).isNotNull();
+            assertThat(result.content().orderId()).isEqualTo(orderId);
+            assertThat(result.content().confirmedOrderItemIds()).containsExactly(10L);
+            assertThat(result.content().failedOrderItemIds()).containsExactly(11L);
+
+            assertThat(okItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED);
+            assertThat(skipItem.getOrderStatus()).isEqualTo(OrderStatus.ORDER_CONFIRMED); // 변경 없음
+        }
     }
 
-    @DisplayName("OrderItem이 없는 주문은 스킵되고 나머지는 정상 조회된다")
-    @Test
-    void givenOrdersWithMissingOrderItem_whenOrderSearch_thenSkipsInvalidOrders() {
-        // given
-        Store boardStore = StoreFixture.defaultStore();
-        ReflectionTestUtils.setField(boardStore, "id", 2L);
-        var board = BoardFixture.defaultBoardWithStore(boardStore, "카카오커피");
-        var product = ProductFixture.create(board, "카카오커피");
+    @Nested
+    @DisplayName("운송장 입력 (registerShipment)")
+    class RegisterShipmentTest {
 
-        // 정상 주문 (OrderItem 있음)
-        Order validOrder = OrderFixture.createDefaultOrder();
-        ReflectionTestUtils.setField(validOrder, "id", 1L);
-        OrderItem validOrderItem = OrderItemFixture.createOrderItemWithProduct(product);
-        ReflectionTestUtils.setField(validOrderItem, "id", 10L);
-        validOrder.addOrderItem(validOrderItem);
-        Payment validPayment = PaymentFixture.createDefaultPayment(validOrder);
-        ReflectionTestUtils.setField(validOrder, "payment", validPayment);
+        @DisplayName("ORDER_CONFIRMED 상태의 주문상품에 운송장을 등록하면 SHIPPED로 전환되고 성공 목록에 포함된다.")
+        @Test
+        void givenOrderConfirmedItem_whenRegisterShipment_thenItemBecomesShippedAndSuccess() {
+            // given
+            Long orderId = 1L;
+            Long sellerId = 1L;
+            Long orderItemId = 10L;
 
-        // 비정상 주문 (OrderItem 없음)
-        Order invalidOrder = OrderFixture.createDefaultOrder();
-        ReflectionTestUtils.setField(invalidOrder, "id", 2L);
-        // OrderItem을 추가하지 않음
-        Payment invalidPayment = PaymentFixture.createDefaultPayment(invalidOrder);
-        ReflectionTestUtils.setField(invalidOrder, "payment", invalidPayment);
+            Order order = OrderFixture.createDefaultOrder();
+            ReflectionTestUtils.setField(order, "id", orderId);
 
-        BbanglePageResponse<Order> orderPage = new BbanglePageResponse<>(
-            List.of(validOrder, invalidOrder),
-            0, 10, 1, 2L
-        );
+            OrderItem orderItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.ORDER_CONFIRMED);
+            ReflectionTestUtils.setField(orderItem, "id", orderItemId);
+            ReflectionTestUtils.setField(orderItem, "order", order);
 
-        OrderSearchCommand command = OrderSearchCommand.builder()
-            .sellerId(1L)
-            .orderDeliveryStatus(null)
-            .searchType(CompletedOrderSearchType.ORDER_NUMBER)
-            .page(PageRequest.of(0, 10))
-            .build();
+            Seller seller = sellerWithStore(1L);
 
-        given(orderRepository.searchOrderList(command)).willReturn(orderPage);
-        given(orderDeliveryRepository.findLatestByOrderItemIds(List.of(10L)))
-            .willReturn(Collections.emptyList());
+            ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
+                .sellerId(sellerId)
+                .orderId(orderId)
+                .orderItemIds(List.of(orderItemId))
+                .courierName("CJ대한통운")
+                .trackingNumber("1234567890")
+                .build();
 
-        // when
-        BbanglePageResponse<OrderResponse.OrderSearchResponse> result = sut.orderSearch(command);
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(sellerRepository.findByIdWithStore(sellerId)).willReturn(Optional.of(seller));
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(orderItemId)))
+                .willReturn(List.of(orderItem));
+            given(orderItemRepository.countOwnedOrderItems(orderId, List.of(orderItemId), 1L))
+                .willReturn(1L);
+            given(orderDeliveryRepository.findByOrderItemIdIn(List.of(orderItemId)))
+                .willReturn(Collections.emptyList()); // 기존 배송 정보 없음 → 신규 생성
 
-        // then
-        assertThat(result.content()).asList().hasSize(1);  // 정상 주문 1개만
-        assertThat(result.content().get(0).orderNumber()).isEqualTo(validOrder.getOrderNumber());
+            // when
+            ShipmentRegisterResponse result = sut.registerShipment(command);
+
+            // then
+            assertThat(result.content().orderId()).isEqualTo(orderId);
+            assertThat(result.content().successOrderItemIds()).containsExactly(orderItemId);
+            assertThat(result.content().failedOrderItemIds()).isEmpty();
+            assertThat(result.content().summary().successCount()).isEqualTo(1);
+            assertThat(result.content().summary().failCount()).isEqualTo(0);
+            assertThat(result.content().courierName()).isEqualTo("CJ대한통운");
+            assertThat(result.content().trackingNumber()).isEqualTo("1234567890");
+            assertThat(result.content().shippedAt()).isNotNull();
+            // 주문상품 상태 전환 검증
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.SHIPPED);
+        }
+
+        @DisplayName("운송장 등록 대상 주문이 존재하지 않으면 ORDER_NOT_FOUND 예외가 발생한다.")
+        @Test
+        void givenNonExistingOrder_whenRegisterShipment_thenThrowsOrderNotFoundException() {
+            // given
+            ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
+                .sellerId(1L)
+                .orderId(999L)
+                .orderItemIds(List.of(1L))
+                .courierName("CJ대한통운")
+                .trackingNumber("1234567890")
+                .build();
+
+            given(orderRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when
+            BbangleException result = assertThrows(BbangleException.class,
+                () -> sut.registerShipment(command));
+
+            // then
+            assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_NOT_FOUND);
+        }
+
+        @DisplayName("ORDER_CONFIRMED/IN_PRODUCTION 이 아닌 주문상품은 운송장 등록이 실패하여 failedOrderItemIds에 포함된다.")
+        @Test
+        void givenInvalidStatusItem_whenRegisterShipment_thenItemFailsWithOrderInvalidStatus() {
+            // given
+            Long orderId = 1L;
+            Long sellerId = 1L;
+            Long orderItemId = 10L;
+
+            Order order = OrderFixture.createDefaultOrder();
+            ReflectionTestUtils.setField(order, "id", orderId);
+
+            // PAYMENT_COMPLETED 상태 → shipOrder() 호출 시 ORDER_INVALID_STATUS 예외 → failedIds
+            OrderItem orderItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.PAYMENT_COMPLETED);
+            ReflectionTestUtils.setField(orderItem, "id", orderItemId);
+            ReflectionTestUtils.setField(orderItem, "order", order);
+
+            Seller seller = sellerWithStore(1L);
+
+            ShipmentRegisterCommand command = ShipmentRegisterCommand.builder()
+                .sellerId(sellerId)
+                .orderId(orderId)
+                .orderItemIds(List.of(orderItemId))
+                .courierName("CJ대한통운")
+                .trackingNumber("1234567890")
+                .build();
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(sellerRepository.findByIdWithStore(sellerId)).willReturn(Optional.of(seller));
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(orderItemId)))
+                .willReturn(List.of(orderItem));
+            given(orderItemRepository.countOwnedOrderItems(orderId, List.of(orderItemId), 1L))
+                .willReturn(1L);
+            given(orderDeliveryRepository.findByOrderItemIdIn(List.of(orderItemId)))
+                .willReturn(Collections.emptyList());
+
+            // when
+            ShipmentRegisterResponse result = sut.registerShipment(command);
+
+            // then: ORDER_INVALID_STATUS로 내부 처리 → 서비스 예외 없이 failedIds에 포함
+            assertThat(result.content().successOrderItemIds()).isEmpty();
+            assertThat(result.content().failedOrderItemIds()).containsExactly(orderItemId);
+            assertThat(result.content().summary().failCount()).isEqualTo(1);
+            // 상태 변경 없음
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.PAYMENT_COMPLETED);
+        }
     }
 
-    @DisplayName("Payment가 없는 주문은 스킵되고 나머지는 정상 조회된다")
-    @Test
-    void givenOrdersWithMissingPayment_whenOrderSearch_thenSkipsInvalidOrders() {
-        // given
-        Store boardStore = StoreFixture.defaultStore();
-        ReflectionTestUtils.setField(boardStore, "id", 2L);
-        var board = BoardFixture.defaultBoardWithStore(boardStore, "카카오커피");
-        var product = ProductFixture.create(board, "카카오커피");
+    @Nested
+    @DisplayName("운송장 수정 (modifyShipment)")
+    class ModifyShipmentTest {
 
-        // 정상 주문 (Payment 있음)
-        Order validOrder = OrderFixture.createDefaultOrder();
-        ReflectionTestUtils.setField(validOrder, "id", 1L);
-        OrderItem validOrderItem = OrderItemFixture.createOrderItemWithProduct(product);
-        ReflectionTestUtils.setField(validOrderItem, "id", 10L);
-        validOrder.addOrderItem(validOrderItem);
-        Payment validPayment = PaymentFixture.createDefaultPayment(validOrder);
-        ReflectionTestUtils.setField(validOrder, "payment", validPayment);
+        @DisplayName("PREPARING 상태의 배송 정보는 운송장 수정이 성공한다.")
+        @Test
+        void givenPreparingDelivery_whenModifyShipment_thenShipmentInfoUpdated() {
+            // given
+            Long orderId = 1L;
+            Long sellerId = 1L;
+            Long orderItemId = 10L;
 
-        // 비정상 주문 (Payment 없음)
-        Order invalidOrder = OrderFixture.createDefaultOrder();
-        ReflectionTestUtils.setField(invalidOrder, "id", 2L);
-        OrderItem invalidOrderItem = OrderItemFixture.createOrderItemWithProduct(product);
-        ReflectionTestUtils.setField(invalidOrderItem, "id", 11L);
-        invalidOrder.addOrderItem(invalidOrderItem);
-        // Payment를 설정하지 않음 (null)
+            Order order = OrderFixture.createDefaultOrder();
+            ReflectionTestUtils.setField(order, "id", orderId);
 
-        BbanglePageResponse<Order> orderPage = new BbanglePageResponse<>(
-            List.of(validOrder, invalidOrder),
-            0, 10, 1, 2L
-        );
+            OrderItem orderItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.SHIPPED);
+            ReflectionTestUtils.setField(orderItem, "id", orderItemId);
+            ReflectionTestUtils.setField(orderItem, "order", order);
 
-        OrderSearchCommand command = OrderSearchCommand.builder()
-            .sellerId(1L)
-            .page(PageRequest.of(0, 10))
-            .build();
+            Seller seller = sellerWithStore(1L);
 
-        given(orderRepository.searchOrderList(command)).willReturn(orderPage);
-        given(orderDeliveryRepository.findLatestByOrderItemIds(List.of(10L, 11L)))
-            .willReturn(Collections.emptyList());
+            // PREPARING 상태 → 수정 허용 (MODIFIABLE_STATUSES: NONE, PREPARING, PICKING_UP)
+            OrderDelivery delivery = OrderDelivery.create(null, null,
+                Shipping.of("기존택배사", "0000000000"),
+                OrderDeliveryStatus.PREPARING,
+                orderItem);
+            ReflectionTestUtils.setField(delivery, "id", 100L);
 
-        // when
-        BbanglePageResponse<OrderResponse.OrderSearchResponse> result = sut.orderSearch(command);
+            ShipmentModifyCommand command = ShipmentModifyCommand.builder()
+                .sellerId(sellerId)
+                .orderId(orderId)
+                .orderItemIds(List.of(orderItemId))
+                .courierName("한진택배")
+                .trackingNumber("9876543210")
+                .build();
 
-        // then
-        assertThat(result.content()).asList().hasSize(1);
-        assertThat(result.content().get(0).orderNumber()).isEqualTo(validOrder.getOrderNumber());
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(sellerRepository.findByIdWithStore(sellerId)).willReturn(Optional.of(seller));
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(orderItemId)))
+                .willReturn(List.of(orderItem));
+            given(orderItemRepository.countOwnedOrderItems(orderId, List.of(orderItemId), 1L))
+                .willReturn(1L);
+            given(orderDeliveryRepository.findByOrderItemIdIn(List.of(orderItemId)))
+                .willReturn(List.of(delivery));
+
+            // when
+            ShipmentModifyResponse result = sut.modifyShipment(command);
+
+            // then
+            assertThat(result.content().orderId()).isEqualTo(orderId);
+            assertThat(result.content().successOrderItemIds()).containsExactly(orderItemId);
+            assertThat(result.content().failedOrderItemIds()).isEmpty();
+            assertThat(result.content().courierName()).isEqualTo("한진택배");
+            assertThat(result.content().trackingNumber()).isEqualTo("9876543210");
+            // 실제 Shipping 필드 변경 여부 검증
+            assertThat(delivery.getShipping().getCourierName()).isEqualTo("한진택배");
+            assertThat(delivery.getShipping().getTrackingNumber()).isEqualTo("9876543210");
+        }
+
+        @DisplayName("배송 정보(OrderDelivery)가 없는 주문상품은 운송장 수정이 실패하여 failedOrderItemIds에 포함된다.")
+        @Test
+        void givenNoExistingDelivery_whenModifyShipment_thenItemFailsWithDeliveryNotFound() {
+            // given
+            Long orderId = 1L;
+            Long sellerId = 1L;
+            Long orderItemId = 10L;
+
+            Order order = OrderFixture.createDefaultOrder();
+            ReflectionTestUtils.setField(order, "id", orderId);
+
+            OrderItem orderItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.SHIPPED);
+            ReflectionTestUtils.setField(orderItem, "id", orderItemId);
+            ReflectionTestUtils.setField(orderItem, "order", order);
+
+            Seller seller = sellerWithStore(1L);
+
+            ShipmentModifyCommand command = ShipmentModifyCommand.builder()
+                .sellerId(sellerId)
+                .orderId(orderId)
+                .orderItemIds(List.of(orderItemId))
+                .courierName("한진택배")
+                .trackingNumber("9876543210")
+                .build();
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(sellerRepository.findByIdWithStore(sellerId)).willReturn(Optional.of(seller));
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(orderItemId)))
+                .willReturn(List.of(orderItem));
+            given(orderItemRepository.countOwnedOrderItems(orderId, List.of(orderItemId), 1L))
+                .willReturn(1L);
+            // 배송 정보 없음 → deliveryMap.get(orderItemId) == null → DELIVERY_NOT_FOUND
+            given(orderDeliveryRepository.findByOrderItemIdIn(List.of(orderItemId)))
+                .willReturn(Collections.emptyList());
+
+            // when
+            ShipmentModifyResponse result = sut.modifyShipment(command);
+
+            // then: DELIVERY_NOT_FOUND(-784) 예외를 내부에서 catch → failedIds에 포함
+            assertThat(result.content().successOrderItemIds()).isEmpty();
+            assertThat(result.content().failedOrderItemIds()).containsExactly(orderItemId);
+            assertThat(result.content().summary().failCount()).isEqualTo(1);
+        }
+
+        @DisplayName("DELIVERING 이후 상태의 배송 정보는 운송장 수정 시 DELIVERY_MODIFY_NOT_ALLOWED(-785)로 인해 failedOrderItemIds에 포함된다.")
+        @Test
+        void givenDeliveringDelivery_whenModifyShipment_thenItemFailsWithModifyNotAllowed() {
+            // given
+            Long orderId = 1L;
+            Long sellerId = 1L;
+            Long orderItemId = 10L;
+
+            Order order = OrderFixture.createDefaultOrder();
+            ReflectionTestUtils.setField(order, "id", orderId);
+
+            OrderItem orderItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.SHIPPED);
+            ReflectionTestUtils.setField(orderItem, "id", orderItemId);
+            ReflectionTestUtils.setField(orderItem, "order", order);
+
+            Seller seller = sellerWithStore(1L);
+
+            // DELIVERING 상태 → MODIFIABLE_STATUSES(NONE, PREPARING, PICKING_UP) 외 → 수정 불가
+            OrderDelivery delivery = OrderDelivery.create(null, null,
+                Shipping.of("CJ대한통운", "1234567890"),
+                OrderDeliveryStatus.DELIVERING,
+                orderItem);
+            ReflectionTestUtils.setField(delivery, "id", 100L);
+
+            ShipmentModifyCommand command = ShipmentModifyCommand.builder()
+                .sellerId(sellerId)
+                .orderId(orderId)
+                .orderItemIds(List.of(orderItemId))
+                .courierName("한진택배")
+                .trackingNumber("9999999999")
+                .build();
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(sellerRepository.findByIdWithStore(sellerId)).willReturn(Optional.of(seller));
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(orderItemId)))
+                .willReturn(List.of(orderItem));
+            given(orderItemRepository.countOwnedOrderItems(orderId, List.of(orderItemId), 1L))
+                .willReturn(1L);
+            given(orderDeliveryRepository.findByOrderItemIdIn(List.of(orderItemId)))
+                .willReturn(List.of(delivery));
+
+            // when
+            ShipmentModifyResponse result = sut.modifyShipment(command);
+
+            // then: DELIVERY_MODIFY_NOT_ALLOWED(-785) → failedIds에 포함
+            assertThat(result.content().successOrderItemIds()).isEmpty();
+            assertThat(result.content().failedOrderItemIds()).containsExactly(orderItemId);
+            assertThat(result.content().summary().failCount()).isEqualTo(1);
+            // 운송장 정보 변경 없음
+            assertThat(delivery.getShipping().getCourierName()).isEqualTo("CJ대한통운");
+            assertThat(delivery.getShipping().getTrackingNumber()).isEqualTo("1234567890");
+        }
+
+        @DisplayName("운송장 수정 대상 주문이 존재하지 않으면 ORDER_NOT_FOUND 예외가 발생한다.")
+        @Test
+        void givenNonExistingOrder_whenModifyShipment_thenThrowsOrderNotFoundException() {
+            // given
+            ShipmentModifyCommand command = ShipmentModifyCommand.builder()
+                .sellerId(1L)
+                .orderId(999L)
+                .orderItemIds(List.of(1L))
+                .courierName("한진택배")
+                .trackingNumber("9876543210")
+                .build();
+
+            given(orderRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when
+            BbangleException result = assertThrows(BbangleException.class,
+                () -> sut.modifyShipment(command));
+
+            // then
+            assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 검색 (orderSearch)")
+    class OrderSearchTest {
+
+        @DisplayName("주문 검색 시 Page 객체로 올바르게 반환되는지 확인")
+        @Test
+        void givenOrderSearchRequest_whenOrderSearch_thenReturnsPageWithCorrectData() {
+            // given
+            Long orderId = 1L;
+            String orderNumber = "ORDER-2025-01-01-00001";
+            Integer totalAmount = 50000;
+            String buyerName = "홍길동";
+
+            Store boardStore = StoreFixture.defaultStore();
+            ReflectionTestUtils.setField(boardStore, "id", 2L);
+            var board = BoardFixture.defaultBoardWithStore(boardStore, "카카오커피");
+            var product = ProductFixture.create(board, "카카오커피");
+
+            Order order = OrderFixture.createOrderWithNumber(orderNumber)
+                .toBuilder()
+                .totalAmount(totalAmount)
+                .buyerName(buyerName)
+                .build();
+            ReflectionTestUtils.setField(order, "id", orderId);
+
+            OrderItem orderItem = OrderItemFixture.createOrderItemWithProduct(product);
+            ReflectionTestUtils.setField(orderItem, "id", 10L);
+            order.addOrderItem(orderItem);
+
+            Store store = StoreFixture.defaultStore();
+            ReflectionTestUtils.setField(store, "id", 1L);
+
+            Seller seller = SellerFixture.createDefaultSeller(store);
+            ReflectionTestUtils.setField(seller, "id", 1L);
+            ReflectionTestUtils.setField(order, "seller", seller);
+
+            Payment payment = PaymentFixture.createDefaultPayment(order);
+            ReflectionTestUtils.setField(order, "payment", payment);
+
+            PageRequest pageable = PageRequest.of(0, 10);
+            BbanglePageResponse<Order> orderPage = new BbanglePageResponse<>(
+                List.of(order),
+                0,
+                10,
+                1,
+                1L);
+
+            OrderSearchCommand command = OrderSearchCommand.builder()
+                .sellerId(1L)
+                .orderDeliveryStatus(null)
+                .searchType(CompletedOrderSearchType.ORDER_NUMBER)
+                .searchCondition(null)
+                .page(pageable)
+                .build();
+
+            given(orderRepository.searchOrderList(command)).willReturn(orderPage);
+            given(orderDeliveryRepository.findLatestByOrderItemIds(List.of(10L)))
+                .willReturn(Collections.emptyList());
+
+            // when
+            BbanglePageResponse<OrderResponse.OrderSearchResponse> result = sut.orderSearch(command);
+
+            log.info("=== OrderSearchResponse (JSON) ===");
+            if (!result.content().isEmpty()) {
+                try {
+                    ObjectMapper objectMapper = new ObjectMapper();
+                    String json = objectMapper.writerWithDefaultPrettyPrinter()
+                        .writeValueAsString(result.content().get(0));
+                    log.info(json);
+                } catch (Exception e) {
+                    log.error("Failed to serialize OrderSearchResponse to JSON", e);
+                }
+            }
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.totalElements()).isEqualTo(1L);
+            assertThat(result.content()).asList().hasSize(1);
+
+            OrderResponse.OrderSearchResponse response = result.content().get(0);
+
+            assertThat(response.orderNumber()).isEqualTo(orderNumber);
+            assertThat(response.totalOrderPrice()).isEqualTo(totalAmount.toString());
+            assertThat(response.recipientName()).isEqualTo(buyerName);
+            assertThat(response.orderItems()).isNotNull().asList().hasSize(1);
+
+            var orderItemList = response.orderItems().get(0);
+            assertThat(orderItemList.orderNumber()).isEqualTo(orderNumber);
+            assertThat(orderItemList.orderStatus()).isEqualTo(OrderStatus.PAYMENT_COMPLETED);
+            assertThat(orderItemList.orderItemInfo().itemName()).isEqualTo("카카오커피");
+            assertThat(orderItemList.orderItemInfo().quantity()).isEqualTo(2);
+            assertThat(orderItemList.orderItemInfo().unitPrice()).isEqualTo(25000L);
+            assertThat(orderItemList.orderItemInfo().totalPrice()).isEqualTo(50000L);
+
+            assertThat(orderItemList.orderDeliveryStatus()).isEqualTo(OrderDeliveryStatus.PREPARING);
+            assertThat(orderItemList.courierCompany()).isEqualTo(CourierCompany.NONE);
+            assertThat(orderItemList.trackingNumber()).isEqualTo("-");
+
+            assertThat(response.sellerId()).isEqualTo(1L);
+            assertThat(response.paymentInfo()).isNotNull();
+        }
+
+        @DisplayName("OrderItem이 없는 주문은 빈 orderItems 목록으로 응답에 포함된다.")
+        @Test
+        void givenOrdersWithMissingOrderItem_whenOrderSearch_thenIncludesOrderWithEmptyItemsList() {
+            // given
+            Store boardStore = StoreFixture.defaultStore();
+            ReflectionTestUtils.setField(boardStore, "id", 2L);
+            var board = BoardFixture.defaultBoardWithStore(boardStore, "카카오커피");
+            var product = ProductFixture.create(board, "카카오커피");
+
+            // 정상 주문 (OrderItem 있음)
+            Order validOrder = OrderFixture.createDefaultOrder();
+            ReflectionTestUtils.setField(validOrder, "id", 1L);
+            OrderItem validOrderItem = OrderItemFixture.createOrderItemWithProduct(product);
+            ReflectionTestUtils.setField(validOrderItem, "id", 10L);
+            validOrder.addOrderItem(validOrderItem);
+            Payment validPayment = PaymentFixture.createDefaultPayment(validOrder);
+            ReflectionTestUtils.setField(validOrder, "payment", validPayment);
+
+            // 비정상 주문 (OrderItem 없음)
+            Order invalidOrder = OrderFixture.createDefaultOrder();
+            ReflectionTestUtils.setField(invalidOrder, "id", 2L);
+            Payment invalidPayment = PaymentFixture.createDefaultPayment(invalidOrder);
+            ReflectionTestUtils.setField(invalidOrder, "payment", invalidPayment);
+
+            BbanglePageResponse<Order> orderPage = new BbanglePageResponse<>(
+                List.of(validOrder, invalidOrder),
+                0, 10, 1, 2L
+            );
+
+            OrderSearchCommand command = OrderSearchCommand.builder()
+                .sellerId(1L)
+                .orderDeliveryStatus(null)
+                .searchType(CompletedOrderSearchType.ORDER_NUMBER)
+                .page(PageRequest.of(0, 10))
+                .build();
+
+            // invalidOrder에 OrderItem이 없으므로 수집되는 ID는 validOrder의 10L만
+            given(orderRepository.searchOrderList(command)).willReturn(orderPage);
+            given(orderDeliveryRepository.findLatestByOrderItemIds(List.of(10L)))
+                .willReturn(Collections.emptyList());
+
+            // when
+            BbanglePageResponse<OrderResponse.OrderSearchResponse> result = sut.orderSearch(command);
+
+            // then: 두 주문 모두 응답에 포함됨 (skip 없음)
+            assertThat(result.content()).asList().hasSize(2);
+            assertThat(result.content().get(0).orderNumber()).isEqualTo(validOrder.getOrderNumber());
+            // invalidOrder는 orderItems가 빈 목록
+            assertThat(result.content().get(1).orderItems()).isEmpty();
+        }
+
+        @DisplayName("Payment가 없는 주문은 paymentInfo가 null인 상태로 응답에 포함된다.")
+        @Test
+        void givenOrdersWithMissingPayment_whenOrderSearch_thenIncludesOrderWithNullPaymentInfo() {
+            // given
+            Store boardStore = StoreFixture.defaultStore();
+            ReflectionTestUtils.setField(boardStore, "id", 2L);
+            var board = BoardFixture.defaultBoardWithStore(boardStore, "카카오커피");
+            var product = ProductFixture.create(board, "카카오커피");
+
+            // 정상 주문 (Payment 있음)
+            Order validOrder = OrderFixture.createDefaultOrder();
+            ReflectionTestUtils.setField(validOrder, "id", 1L);
+            OrderItem validOrderItem = OrderItemFixture.createOrderItemWithProduct(product);
+            ReflectionTestUtils.setField(validOrderItem, "id", 10L);
+            validOrder.addOrderItem(validOrderItem);
+            Payment validPayment = PaymentFixture.createDefaultPayment(validOrder);
+            ReflectionTestUtils.setField(validOrder, "payment", validPayment);
+
+            // 비정상 주문 (Payment 없음 - null 상태)
+            Order invalidOrder = OrderFixture.createDefaultOrder();
+            ReflectionTestUtils.setField(invalidOrder, "id", 2L);
+            OrderItem invalidOrderItem = OrderItemFixture.createOrderItemWithProduct(product);
+            ReflectionTestUtils.setField(invalidOrderItem, "id", 11L);
+            invalidOrder.addOrderItem(invalidOrderItem);
+            // payment 설정하지 않음 (null)
+
+            BbanglePageResponse<Order> orderPage = new BbanglePageResponse<>(
+                List.of(validOrder, invalidOrder),
+                0, 10, 1, 2L
+            );
+
+            OrderSearchCommand command = OrderSearchCommand.builder()
+                .sellerId(1L)
+                .page(PageRequest.of(0, 10))
+                .build();
+
+            given(orderRepository.searchOrderList(command)).willReturn(orderPage);
+            given(orderDeliveryRepository.findLatestByOrderItemIds(List.of(10L, 11L)))
+                .willReturn(Collections.emptyList());
+
+            // when
+            BbanglePageResponse<OrderResponse.OrderSearchResponse> result = sut.orderSearch(command);
+
+            // then: 두 주문 모두 응답에 포함됨 (skip 없음)
+            assertThat(result.content()).asList().hasSize(2);
+            // validOrder: paymentInfo 있음
+            assertThat(result.content().get(0).paymentInfo()).isNotNull();
+            // invalidOrder: paymentInfo null (payment 없음)
+            assertThat(result.content().get(1).paymentInfo()).isNull();
+        }
     }
 }


### PR DESCRIPTION
## History

* #615 
## 🚀 Major Changes & Explanations

### 1) SellerOrderService 단위 테스트 실패 해결
* 최근 진행된 주문/배송 도메인 리팩토링(발주 확인, 운송장 입력 부분 성공 처리 등)으로 인해 발생한 기존 단위 테스트의 실패 요인을 분석하고 수정 완료!!
<img width="1020" height="527" alt="image" src="https://github.com/user-attachments/assets/49642d3e-43e3-4f0c-a1fb-330056287482" />

* `Payment가 없는 주문 스킵`, `OrderItem이 없는 주문 스킵` 등의 테스트에서 변경된 `notFoundIds` 및 부분 성공(failedIds) 처리 로직을 정상적으로 검증하도록 Mock 데이터와 검증 로직 최신화

### 2) 예외 검증(Assertion) 및 에러 코드 동기화
* 최근 재정렬된 에러 코드(`-781` ~ `-785`)에 맞추어 테스트 코드 내 예외 검증 부분을 모두 업데이트
* `ORDER_INVALID_STATUS`, `DELIVERY_NOT_FOUND` 등의 도메인 에러가 변경된 번호와 메시지로 응답하고 매핑되는지 확인

## 💡 ETC

* 리팩토링으로 인한 기존 로직 사이드 이펙트가 없음을 테스트 코드로 검증 완료!!!! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 강화된 주문 확인, 배송 등록, 배송 수정, 주문 검색 관련 테스트 커버리지 및 테스트 조직화. 이는 내부 개선사항으로 사용자에게 보이는 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->