### PR TITLE
[Feature] (판매자) 반품 승인 후 운송장 입력 API 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/claim/domain/ClaimDelivery.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ClaimDelivery.java
@@ -68,7 +68,7 @@ public class ClaimDelivery extends BaseEntity {
         return new ClaimDelivery(
             claim,
             ClaimDeliveryType.RETURN_PICKUP,
-            Shipping.of(courierCode.getDisplayName(), trackingNumber),
+            Shipping.scheduled(courierCode.getDisplayName(), trackingNumber),
             ClaimShippingStatus.IN_TRANSIT
         );
     }

--- a/src/main/java/com/bbangle/bbangle/claim/domain/ClaimDelivery.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ClaimDelivery.java
@@ -6,6 +6,7 @@ import com.bbangle.bbangle.common.domain.BaseEntity;
 import com.bbangle.bbangle.delivery.domain.Receiver;
 import com.bbangle.bbangle.delivery.domain.Sender;
 import com.bbangle.bbangle.delivery.domain.Shipping;
+import com.bbangle.bbangle.order.domain.model.CourierCompany;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -55,5 +56,21 @@ public class ClaimDelivery extends BaseEntity {
     private ClaimShippingStatus status;
 
     private LocalDateTime collectedAt;
+
+    private ClaimDelivery(Claim claim, ClaimDeliveryType deliveryType, Shipping shipping, ClaimShippingStatus status) {
+        this.claim = claim;
+        this.deliveryType = deliveryType;
+        this.shipping = shipping;
+        this.status = status;
+    }
+
+    public static ClaimDelivery createReturnPickup(Claim claim, CourierCompany courierCode, String trackingNumber) {
+        return new ClaimDelivery(
+            claim,
+            ClaimDeliveryType.RETURN_PICKUP,
+            Shipping.of(courierCode.getDisplayName(), trackingNumber),
+            ClaimShippingStatus.IN_TRANSIT
+        );
+    }
 
 }

--- a/src/main/java/com/bbangle/bbangle/claim/domain/ReturnRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ReturnRequest.java
@@ -63,4 +63,9 @@ public class ReturnRequest extends Claim {
         this.sellerComment = reason;
         super.decide();
     }
+
+    public void startReturnPickup() {
+        this.status.validateTransition(ReturnRequestRequestStatus.PICKUP_SCHEDULED);
+        this.status = ReturnRequestRequestStatus.PICKUP_SCHEDULED;
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/claim/domain/constant/ReturnRequestRequestStatus.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/constant/ReturnRequestRequestStatus.java
@@ -1,5 +1,8 @@
 package com.bbangle.bbangle.claim.domain.constant;
 
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+
 public enum ReturnRequestRequestStatus {
     REQUESTED,        // 고객이 반품 요청함
     PICKUP_SCHEDULED, // 반품 수거 예정
@@ -8,4 +11,21 @@ public enum ReturnRequestRequestStatus {
     APPROVED,         // 반품 승인 (환불 진행 가능)
     REJECTED,         // 반품 거절
     COMPLETED;        // 환불까지 완료됨
+
+    public void validateTransition(ReturnRequestRequestStatus next) {
+        if (!canTransitionTo(next)) {
+            throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
+        }
+    }
+
+    private boolean canTransitionTo(ReturnRequestRequestStatus next) {
+        return switch (this) {
+            case REQUESTED -> next == PICKUP_SCHEDULED;
+            case APPROVED -> next == PICKUP_SCHEDULED;
+            case PICKUP_SCHEDULED -> next == PICKED_UP;
+            case PICKED_UP -> next == INSPECTING;
+            case INSPECTING -> next == APPROVED || next == REJECTED;
+            default -> false;
+        };
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/claim/domain/constant/ReturnRequestRequestStatus.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/constant/ReturnRequestRequestStatus.java
@@ -20,7 +20,6 @@ public enum ReturnRequestRequestStatus {
 
     private boolean canTransitionTo(ReturnRequestRequestStatus next) {
         return switch (this) {
-            case REQUESTED -> next == PICKUP_SCHEDULED;
             case APPROVED -> next == PICKUP_SCHEDULED;
             case PICKUP_SCHEDULED -> next == PICKED_UP;
             case PICKED_UP -> next == INSPECTING;

--- a/src/main/java/com/bbangle/bbangle/claim/domain/constant/ReturnRequestRequestStatus.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/constant/ReturnRequestRequestStatus.java
@@ -4,13 +4,14 @@ import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 
 public enum ReturnRequestRequestStatus {
-    REQUESTED,        // 고객이 반품 요청함
-    PICKUP_SCHEDULED, // 반품 수거 예정
-    PICKED_UP,        // 반품 수거 완료
-    INSPECTING,       // 반품 상품 검수 중
-    APPROVED,         // 반품 승인 (환불 진행 가능)
-    REJECTED,         // 반품 거절
-    COMPLETED;        // 환불까지 완료됨
+    REQUESTED,           // 고객이 반품 요청함
+    APPROVED,            // 판매자 초기 승인 — 수거 예약 진행 가능
+    PICKUP_SCHEDULED,    // 반품 수거 예정
+    PICKED_UP,           // 반품 수거 완료
+    INSPECTING,          // 반품 상품 검수 중
+    INSPECTION_APPROVED, // 검수 후 최종 승인 — 환불 진행 가능
+    REJECTED,            // 반품 거절
+    COMPLETED;           // 환불까지 완료됨
 
     public void validateTransition(ReturnRequestRequestStatus next) {
         if (!canTransitionTo(next)) {
@@ -20,10 +21,11 @@ public enum ReturnRequestRequestStatus {
 
     private boolean canTransitionTo(ReturnRequestRequestStatus next) {
         return switch (this) {
-            case APPROVED -> next == PICKUP_SCHEDULED;
-            case PICKUP_SCHEDULED -> next == PICKED_UP;
-            case PICKED_UP -> next == INSPECTING;
-            case INSPECTING -> next == APPROVED || next == REJECTED;
+            case APPROVED            -> next == PICKUP_SCHEDULED;
+            case PICKUP_SCHEDULED    -> next == PICKED_UP;
+            case PICKED_UP           -> next == INSPECTING;
+            case INSPECTING          -> next == INSPECTION_APPROVED || next == REJECTED;
+            case INSPECTION_APPROVED -> next == COMPLETED;
             default -> false;
         };
     }

--- a/src/main/java/com/bbangle/bbangle/claim/repository/ClaimDeliveryRepository.java
+++ b/src/main/java/com/bbangle/bbangle/claim/repository/ClaimDeliveryRepository.java
@@ -1,0 +1,7 @@
+package com.bbangle.bbangle.claim.repository;
+
+import com.bbangle.bbangle.claim.domain.ClaimDelivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClaimDeliveryRepository extends JpaRepository<ClaimDelivery, Long> {
+}

--- a/src/main/java/com/bbangle/bbangle/claim/repository/ReturnRequestRepository.java
+++ b/src/main/java/com/bbangle/bbangle/claim/repository/ReturnRequestRepository.java
@@ -2,7 +2,14 @@ package com.bbangle.bbangle.claim.repository;
 
 import com.bbangle.bbangle.claim.domain.ReturnRequest;
 import com.bbangle.bbangle.claim.repository.custom.ReturnRequestCustomRepository;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 public interface ReturnRequestRepository extends JpaRepository<ReturnRequest, Long>, ReturnRequestCustomRepository {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<ReturnRequest> findWithLockById(Long id);
+
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerReturnController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerReturnController.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.claim.seller.controller;
 
+import com.bbangle.bbangle.claim.seller.controller.dto.RegisterReturnInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ReturnDecisionRequest;
 import com.bbangle.bbangle.claim.seller.controller.swagger.SellerReturnApi;
 import com.bbangle.bbangle.claim.seller.service.SellerReturnService;
@@ -9,6 +10,8 @@ import com.bbangle.bbangle.config.security.SellerApiPath;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +32,16 @@ public class SellerReturnController implements SellerReturnApi {
     ) {
         sellerReturnService.decision(returnDecisionRequest.returnIds(), sellerId,
             returnDecisionRequest.decisionType(), returnDecisionRequest.reason());
+        return responseService.getSuccessResult();
+    }
+
+    @PatchMapping("/{returnId}/invoice")
+    public CommonResult registerReturnInvoice(
+        @PathVariable Long returnId,
+        @Valid @RequestBody RegisterReturnInvoiceRequest request,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        sellerReturnService.registerReturnInvoice(returnId, sellerId, request.courierCode(), request.trackingNumber());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/RegisterReturnInvoiceRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/RegisterReturnInvoiceRequest.java
@@ -1,0 +1,22 @@
+package com.bbangle.bbangle.claim.seller.controller.dto;
+
+import com.bbangle.bbangle.order.domain.model.CourierCompany;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "반품 운송장 입력 요청 DTO")
+public record RegisterReturnInvoiceRequest(
+
+    @Schema(description = "택배사 코드", example = "CJ_LOGISTICS")
+    @NotNull(message = "택배사 코드는 필수입니다.")
+    CourierCompany courierCode,
+
+    @Schema(description = "운송장 번호 (10~14자리 숫자)", example = "1234567890")
+    @NotBlank(message = "운송장 번호는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{10,14}$", message = "운송장 번호는 10~14자리 숫자여야 합니다.")
+    String trackingNumber
+
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/RegisterReturnInvoiceRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/RegisterReturnInvoiceRequest.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.claim.seller.controller.dto;
 
 import com.bbangle.bbangle.order.domain.model.CourierCompany;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -19,4 +20,10 @@ public record RegisterReturnInvoiceRequest(
     String trackingNumber
 
 ) {
+
+    @Schema(hidden = true)
+    @AssertTrue(message = "유효한 택배사 코드를 입력해야 합니다. NONE은 허용되지 않습니다.")
+    public boolean isCourierCodeValid() {
+        return courierCode != null && courierCode != CourierCompany.NONE;
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerReturnApi.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerReturnApi.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.claim.seller.controller.swagger;
 
+import com.bbangle.bbangle.claim.seller.controller.dto.RegisterReturnInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ReturnDecisionRequest;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,6 +16,16 @@ public interface SellerReturnApi {
     )
     CommonResult returnDecision(
         ReturnDecisionRequest returnDecisionRequest,
+        @Parameter(hidden = true) Long sellerId
+    );
+
+    @Operation(
+        summary = "반품 운송장 입력",
+        description = "반품 승인(APPROVED) 상태의 클레임에 택배사 코드와 운송장 번호를 등록하고, 상태를 반품 수거 예정(PICKUP_SCHEDULED)으로 변경한다."
+    )
+    CommonResult registerReturnInvoice(
+        @Parameter(description = "반품 요청 ID") Long returnId,
+        RegisterReturnInvoiceRequest request,
         @Parameter(hidden = true) Long sellerId
     );
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerReturnService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerReturnService.java
@@ -1,8 +1,11 @@
 package com.bbangle.bbangle.claim.seller.service;
 
+import com.bbangle.bbangle.claim.domain.ClaimDelivery;
 import com.bbangle.bbangle.claim.domain.ReturnRequest;
 import com.bbangle.bbangle.claim.domain.constant.DecisionType;
 import com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus;
+import com.bbangle.bbangle.claim.repository.ClaimDeliveryRepository;
+import com.bbangle.bbangle.claim.repository.ClaimRepository;
 import com.bbangle.bbangle.claim.repository.ReturnRequestRepository;
 import com.bbangle.bbangle.claim.seller.service.model.ReturnCreateCommand;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
@@ -10,6 +13,7 @@ import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.order.domain.Order;
 import com.bbangle.bbangle.order.domain.OrderItem;
 import com.bbangle.bbangle.order.domain.OrderItemHistory;
+import com.bbangle.bbangle.order.domain.model.CourierCompany;
 import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
 import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.order.repository.OrderRepository;
@@ -30,6 +34,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class SellerReturnService {
 
     private final ReturnRequestRepository returnRequestRepository;
+    private final ClaimDeliveryRepository claimDeliveryRepository;
+    private final ClaimRepository claimRepository;
     private final OrderItemHistoryRepository orderItemHistoryRepository;
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
@@ -107,6 +113,21 @@ public class SellerReturnService {
         );
 
         return ReturnCreateResponse.of(content);
+    }
+
+    @Transactional
+    public void registerReturnInvoice(Long returnId, Long sellerId, CourierCompany courierCode, String trackingNumber) {
+        if (!claimRepository.existsClaimRequestBySeller(returnId, sellerId)) {
+            throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+        }
+
+        ReturnRequest returnRequest = returnRequestRepository.findWithLockById(returnId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.CLAIM_NOT_FOUND));
+
+        returnRequest.startReturnPickup();
+
+        ClaimDelivery claimDelivery = ClaimDelivery.createReturnPickup(returnRequest, courierCode, trackingNumber);
+        claimDeliveryRepository.save(claimDelivery);
     }
 
     private Long getStoreIdOrThrow(Long sellerId) {

--- a/src/main/java/com/bbangle/bbangle/delivery/domain/Shipping.java
+++ b/src/main/java/com/bbangle/bbangle/delivery/domain/Shipping.java
@@ -35,6 +35,10 @@ public class Shipping {
     public static Shipping of(String courierName, String trackingNumber) {
         return new Shipping(courierName, trackingNumber, LocalDateTime.now());
     }
+    
+    public static Shipping scheduled(String courierName, String trackingNumber) {
+        return new Shipping(courierName, trackingNumber, null);
+    }
 
     public static Shipping empty() {
         return new Shipping(null, null, null);

--- a/src/test/java/com/bbangle/bbangle/claim/domain/ReturnRequestTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/domain/ReturnRequestTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.claim.ReturnRequestFixture;
 import com.bbangle.bbangle.fixture.order.OrderItemFixture;
@@ -12,6 +13,9 @@ import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 @DisplayName("[단위 테스트] ReturnRequest")
 class ReturnRequestTest {
@@ -55,6 +59,57 @@ class ReturnRequestTest {
 
             // when & then
             assertThatThrownBy(() -> returnRequest.approve("승인 사유"))
+                .isInstanceOf(BbangleException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("startReturnPickup()")
+    class StartReturnPickup {
+
+        @Test
+        @DisplayName("APPROVED 상태에서 호출하면 PICKUP_SCHEDULED로 변경된다")
+        void startReturnPickup_success_when_approved() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_APPROVED);
+            ReturnRequest returnRequest = ReturnRequestFixture.approved(orderItem);
+
+            // when
+            returnRequest.startReturnPickup();
+
+            // then
+            assertThat(returnRequest.getStatus())
+                .isEqualTo(ReturnRequestRequestStatus.PICKUP_SCHEDULED);
+        }
+
+        @ParameterizedTest(name = "{0} 상태에서 호출하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        @EnumSource(
+            value = ReturnRequestRequestStatus.class,
+            mode = Mode.EXCLUDE,
+            names = "APPROVED"
+        )
+        @DisplayName("APPROVED 외 상태에서 호출하면 예외가 발생한다 (경계값 테스트)")
+        void startReturnPickup_fails_on_invalid_status(ReturnRequestRequestStatus invalidStatus) {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_REQUESTED);
+            ReturnRequest returnRequest = ReturnRequestFixture.withStatus(invalidStatus, orderItem);
+
+            // when & then
+            assertThatThrownBy(returnRequest::startReturnPickup)
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+        }
+
+        @Test
+        @DisplayName("PICKUP_SCHEDULED 상태에서 재호출하면 중복 수거 등록이 차단된다")
+        void startReturnPickup_fails_when_already_pickup_scheduled() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_REQUESTED);
+            ReturnRequest returnRequest = ReturnRequestFixture.pickupScheduled(orderItem);
+
+            // when & then
+            assertThatThrownBy(returnRequest::startReturnPickup)
                 .isInstanceOf(BbangleException.class);
         }
     }

--- a/src/test/java/com/bbangle/bbangle/claim/seller/controller/SellerReturnControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/controller/SellerReturnControllerTest.java
@@ -6,13 +6,16 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bbangle.bbangle.claim.domain.constant.DecisionType;
+import com.bbangle.bbangle.claim.seller.controller.dto.RegisterReturnInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ReturnDecisionRequest;
+import com.bbangle.bbangle.order.domain.model.CourierCompany;
 import com.bbangle.bbangle.claim.seller.service.SellerReturnService;
 import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
 import com.bbangle.bbangle.common.service.ResponseService;
@@ -59,6 +62,176 @@ class SellerReturnControllerTest {
 
     @MockBean
     private SellerReturnService sellerReturnService;
+
+    @Nested
+    @DisplayName("PATCH /api/v1/seller/returns/{returnId}/invoice")
+    class RegisterReturnInvoice {
+
+        private static final String INVOICE_URL = BASE_URL + "/{returnId}/invoice";
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("유효한 운송장 정보로 요청하면 200 OK와 success=true를 반환한다")
+        void given_validRequest_when_registerReturnInvoice_then_success() throws Exception {
+            // given
+            RegisterReturnInvoiceRequest request =
+                new RegisterReturnInvoiceRequest(CourierCompany.CJ_LOGISTICS, "1234567890");
+
+            willDoNothing().given(sellerReturnService)
+                .registerReturnInvoice(any(), any(), any(CourierCompany.class), any());
+
+            // when & then
+            mvc.perform(
+                    patch(INVOICE_URL, 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0));
+
+            then(sellerReturnService).should()
+                .registerReturnInvoice(eq(1L), isNull(), eq(CourierCompany.CJ_LOGISTICS), eq("1234567890"));
+        }
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("운송장 번호가 9자리(미달)면 400 Bad Request를 반환한다")
+        void given_tooShortTrackingNumber_when_register_then_badRequest() throws Exception {
+            // given
+            RegisterReturnInvoiceRequest request =
+                new RegisterReturnInvoiceRequest(CourierCompany.CJ_LOGISTICS, "123456789");
+
+            // when & then
+            mvc.perform(
+                    patch(INVOICE_URL, 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("운송장 번호가 15자리(초과)면 400 Bad Request를 반환한다")
+        void given_tooLongTrackingNumber_when_register_then_badRequest() throws Exception {
+            // given
+            RegisterReturnInvoiceRequest request =
+                new RegisterReturnInvoiceRequest(CourierCompany.CJ_LOGISTICS, "123456789012345");
+
+            // when & then
+            mvc.perform(
+                    patch(INVOICE_URL, 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("운송장 번호에 문자가 포함되면 400 Bad Request를 반환한다")
+        void given_alphanumericTrackingNumber_when_register_then_badRequest() throws Exception {
+            // given
+            RegisterReturnInvoiceRequest request =
+                new RegisterReturnInvoiceRequest(CourierCompany.CJ_LOGISTICS, "12345ABCDE");
+
+            // when & then
+            mvc.perform(
+                    patch(INVOICE_URL, 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("courierCode가 null이면 400 Bad Request를 반환한다")
+        void given_nullCourierCode_when_register_then_badRequest() throws Exception {
+            // given
+            RegisterReturnInvoiceRequest request =
+                new RegisterReturnInvoiceRequest(null, "1234567890");
+
+            // when & then
+            mvc.perform(
+                    patch(INVOICE_URL, 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("셀러-클레임 불일치 시 401 Unauthorized와 에러코드 -772를 반환한다")
+        void given_mismatchedSeller_when_register_then_unauthorized() throws Exception {
+            // given
+            RegisterReturnInvoiceRequest request =
+                new RegisterReturnInvoiceRequest(CourierCompany.CJ_LOGISTICS, "1234567890");
+
+            willThrow(new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH))
+                .given(sellerReturnService)
+                .registerReturnInvoice(any(), any(), any(CourierCompany.class), any());
+
+            // when & then
+            mvc.perform(
+                    patch(INVOICE_URL, 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(-772))
+                .andExpect(jsonPath("$.message").value(BbangleErrorCode.SELLER_CLAIM_MISMATCH.getMessage()));
+        }
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("이미 처리된 상태의 클레임이면 400 Bad Request와 에러코드 -773을 반환한다")
+        void given_invalidStatusClaim_when_register_then_claimInvalidStatus() throws Exception {
+            // given
+            RegisterReturnInvoiceRequest request =
+                new RegisterReturnInvoiceRequest(CourierCompany.CJ_LOGISTICS, "1234567890");
+
+            willThrow(new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS))
+                .given(sellerReturnService)
+                .registerReturnInvoice(any(), any(), any(CourierCompany.class), any());
+
+            // when & then
+            mvc.perform(
+                    patch(INVOICE_URL, 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(-773))
+                .andExpect(jsonPath("$.message").value(BbangleErrorCode.CLAIM_INVALID_STATUS.getMessage()));
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 401 Unauthorized를 반환한다")
+        void given_unauthenticatedUser_when_register_then_unauthorized() throws Exception {
+            // given
+            RegisterReturnInvoiceRequest request =
+                new RegisterReturnInvoiceRequest(CourierCompany.CJ_LOGISTICS, "1234567890");
+
+            // when & then
+            mvc.perform(
+                    patch(INVOICE_URL, 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonDataEncoder.encode(request))
+                )
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+        }
+    }
 
     @Nested
     @DisplayName("POST /api/v1/seller/returns/decision")

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerReturnServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerReturnServiceUnitTest.java
@@ -1,5 +1,6 @@
 package com.bbangle.bbangle.claim.seller.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -8,16 +9,23 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
+import com.bbangle.bbangle.claim.domain.ClaimDelivery;
 import com.bbangle.bbangle.claim.domain.ReturnRequest;
 import com.bbangle.bbangle.claim.domain.constant.DecisionType;
+import com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus;
+import com.bbangle.bbangle.claim.repository.ClaimDeliveryRepository;
+import com.bbangle.bbangle.claim.repository.ClaimRepository;
 import com.bbangle.bbangle.claim.repository.ReturnRequestRepository;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.claim.ReturnRequestFixture;
 import com.bbangle.bbangle.fixture.order.OrderItemFixture;
 import com.bbangle.bbangle.order.domain.OrderItem;
-import com.bbangle.bbangle.order.domain.OrderItemHistory;
+import com.bbangle.bbangle.order.domain.model.CourierCompany;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,7 +45,110 @@ class SellerReturnServiceUnitTest {
     private ReturnRequestRepository returnRequestRepository;
 
     @Mock
+    private ClaimDeliveryRepository claimDeliveryRepository;
+
+    @Mock
+    private ClaimRepository claimRepository;
+
+    @Mock
     private OrderItemHistoryRepository orderItemHistoryRepository;
+
+    @Nested
+    @DisplayName("registerReturnInvoice()")
+    class RegisterReturnInvoiceTests {
+
+        private static final Long RETURN_ID = 1L;
+        private static final Long SELLER_ID = 10L;
+        private static final CourierCompany COURIER = CourierCompany.CJ_LOGISTICS;
+        private static final String TRACKING_NUMBER = "1234567890";
+
+        @Test
+        @DisplayName("APPROVED 상태의 클레임에 운송장을 입력하면 PICKUP_SCHEDULED로 변경되고 ClaimDelivery가 저장된다")
+        void registerReturnInvoice_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_APPROVED);
+            ReturnRequest returnRequest = ReturnRequestFixture.approved(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+            given(claimDeliveryRepository.save(any(ClaimDelivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            sut.registerReturnInvoice(RETURN_ID, SELLER_ID, COURIER, TRACKING_NUMBER);
+
+            // then
+            assertThat(returnRequest.getStatus()).isEqualTo(ReturnRequestRequestStatus.PICKUP_SCHEDULED);
+            then(claimDeliveryRepository).should(times(1)).save(any(ClaimDelivery.class));
+        }
+
+        @Test
+        @DisplayName("셀러 소유권 검증 실패 시 SELLER_CLAIM_MISMATCH 예외가 발생하고 이후 로직은 실행되지 않는다")
+        void registerReturnInvoice_fails_when_seller_mismatch() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> sut.registerReturnInvoice(RETURN_ID, SELLER_ID, COURIER, TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+
+            then(returnRequestRepository).should(never()).findWithLockById(any());
+            then(claimDeliveryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 claimId로 요청하면 CLAIM_NOT_FOUND 예외가 발생한다")
+        void registerReturnInvoice_fails_when_claim_not_found() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sut.registerReturnInvoice(RETURN_ID, SELLER_ID, COURIER, TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_NOT_FOUND);
+
+            then(claimDeliveryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("APPROVED가 아닌 상태의 클레임에 운송장을 입력하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void registerReturnInvoice_fails_when_invalid_status() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_REQUESTED);
+            ReturnRequest returnRequest = ReturnRequestFixture.requested(orderItem);  // REQUESTED 상태
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.registerReturnInvoice(RETURN_ID, SELLER_ID, COURIER, TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(claimDeliveryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("이미 PICKUP_SCHEDULED 상태면 운송장 중복 입력이 차단된다")
+        void registerReturnInvoice_fails_when_already_pickup_scheduled() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_REQUESTED);
+            ReturnRequest returnRequest = ReturnRequestFixture.pickupScheduled(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.registerReturnInvoice(RETURN_ID, SELLER_ID, COURIER, TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+        }
+    }
 
     @Nested
     @DisplayName("decision()")

--- a/src/test/java/com/bbangle/bbangle/fixture/claim/ReturnRequestFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/claim/ReturnRequestFixture.java
@@ -32,6 +32,10 @@ public class ReturnRequestFixture {
         return withStatus(ReturnRequestRequestStatus.REJECTED, orderItem);
     }
 
+    public static ReturnRequest pickupScheduled(OrderItem orderItem) {
+        return withStatus(ReturnRequestRequestStatus.PICKUP_SCHEDULED, orderItem);
+    }
+
     public static ReturnRequest withId(ReturnRequest rr, Long id) {
         ReflectionTestUtils.setField(rr, "id", id); // Claim의 id 필드
         return rr;


### PR DESCRIPTION
## History

* #512 

## 🚀 Major Changes & Explanations

### 1) 반품 운송장 등록 API 구현 (PATCH /api/v1/seller/returns/{returnId}/invoice)
* 판매자가 반품 승인 후 실제 회수용 운송장 정보를 입력할 수 있는 기능을 추가
*  택배사 코드(CourierCompany)와 운송장 번호를 입력받아 ClaimDelivery 정보를 생성
* 반품 승인(APPROVED) 상태에서만 운송장 등록이 가능하도록 canTransitionTo 로직 구현
* 운송장 등록 성공 시 상태가 PICKUP_SCHEDULED(수거 예정)로 자동 전환되도록 엔티티 내 비즈니스 로직 구현
* PESSIMISTIC_WRITE를 활용해 동일 클레임에 대한 중복 운송장 입력을 원천 차단

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 판매자용 반품 운송장 등록 API(PATCH) 추가 — 택배사 및 운송장 입력으로 반품 픽업 등록 가능
  * 운송 정보 예약 등록 지원 및 입력 DTO의 운송사/운송장 검증 추가

* **개선 사항**
  * 반품 상태 전환 검증 강화(승인 → 픽업예약 → 점검 승인 → 완료 흐름 명확화)
  * 동시성 안전한 조회(락) 및 반품 픽업 처리의 무결성 향상
  * 관련 단위/통합 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->