### PR TITLE
[Feat] 판매자 완료 주문 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepository.java
@@ -4,6 +4,7 @@ import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.order.domain.Order;
 import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderSearchCommand;
+import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.CompletedOrderSearchCommand;
 import java.util.Map;
 
 public interface OrderDSLRepository {
@@ -12,4 +13,7 @@ public interface OrderDSLRepository {
 
     Map<OrderStatus, Long> countByOrderStatus(OrderSearchCommand command);
 
+    BbanglePageResponse<Order> searchCompletedOrderList(CompletedOrderSearchCommand command);
+
+    Map<OrderStatus, Long> countByCompletedOrderStatus(CompletedOrderSearchCommand command);
 }

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepositoryImpl.java
@@ -7,17 +7,22 @@ import com.bbangle.bbangle.order.domain.QOrder;
 import com.bbangle.bbangle.order.domain.QOrderDelivery;
 import com.bbangle.bbangle.order.domain.QOrderItem;
 import com.bbangle.bbangle.order.domain.model.CompletedOrderSearchType;
+import com.bbangle.bbangle.order.domain.model.CompletedOrderStatus;
 import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
 import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderSearchCommand;
+import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.CompletedOrderSearchCommand;
 import com.bbangle.bbangle.seller.domain.QSeller;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -29,6 +34,18 @@ import org.springframework.data.domain.Pageable;
 
 @RequiredArgsConstructor
 public class OrderDSLRepositoryImpl implements OrderDSLRepository {
+
+    // 완료 주문에 해당하는 전체 OrderStatus 집합 (구매확정, 취소, 반품, 교환)
+    private static final Set<OrderStatus> ALL_COMPLETED_STATUSES;
+
+    static {
+        Set<OrderStatus> statuses = new HashSet<>();
+        statuses.add(OrderStatus.PURCHASE_CONFIRMED);
+        statuses.addAll(OrderStatus.CANCELLED_GROUP);
+        statuses.addAll(OrderStatus.RETURNED_GROUP);
+        statuses.addAll(OrderStatus.EXCHANGED_GROUP);
+        ALL_COMPLETED_STATUSES = Collections.unmodifiableSet(statuses);
+    }
 
     private final JPAQueryFactory queryFactory;
     private final QOrder order = QOrder.order;
@@ -91,6 +108,124 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
         return countMap;
     }
 
+    @Override
+    public BbanglePageResponse<Order> searchCompletedOrderList(CompletedOrderSearchCommand command) {
+        Pageable pageable = command.pageable();
+
+        List<Long> orderIds = fetchCompletedOrderIds(command, pageable);
+        List<Order> orders = fetchOrdersWithDetails(orderIds);
+        Long total = fetchCompletedTotalCount(command);
+
+        return BbanglePageResponse.of(new PageImpl<>(orders, pageable, total));
+    }
+
+    @Override
+    public Map<OrderStatus, Long> countByCompletedOrderStatus(CompletedOrderSearchCommand command) {
+        CompletedOrderSearchType searchType = command.searchType();
+        String keyword = command.searchValue();
+
+        JPAQuery<Tuple> countQuery = queryFactory
+            .select(orderItem.orderStatus, orderItem.count())
+            .from(order)
+            .leftJoin(order.seller, seller)
+            .leftJoin(order.orderItems, orderItem);
+
+        addKeywordJoins(countQuery, searchType, keyword);
+
+        List<Tuple> results = countQuery
+            .where(
+                seller.id.eq(command.sellerId()),
+                dateRangePredicate(
+                    toStartDateTime(command.startDate()),
+                    toEndDateTime(command.endDate())),
+                completedOrderStatusPredicate(null),
+                keywordPredicate(searchType, keyword))
+            .groupBy(orderItem.orderStatus)
+            .fetch();
+
+        Map<OrderStatus, Long> countMap = new EnumMap<>(OrderStatus.class);
+        for (Tuple tuple : results) {
+            OrderStatus status = tuple.get(orderItem.orderStatus);
+            Long count = tuple.get(orderItem.count());
+            if (status != null && count != null) {
+                countMap.put(status, count);
+            }
+        }
+        return countMap;
+    }
+
+    private List<Long> fetchCompletedOrderIds(CompletedOrderSearchCommand command, Pageable pageable) {
+        CompletedOrderSearchType searchType = command.searchType();
+        String keyword = command.searchValue();
+
+        JPAQuery<Long> idQuery = queryFactory
+            .select(order.id)
+            .from(order)
+            .leftJoin(order.seller, seller)
+            .leftJoin(order.orderItems, orderItem);
+
+        addKeywordJoins(idQuery, searchType, keyword);
+
+        return idQuery
+            .where(
+                seller.id.eq(command.sellerId()),
+                dateRangePredicate(
+                    toStartDateTime(command.startDate()),
+                    toEndDateTime(command.endDate())),
+                completedOrderStatusPredicate(command.status()),
+                keywordPredicate(searchType, keyword))
+            .orderBy(order.orderDate.desc(), order.id.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+    }
+
+    private Long fetchCompletedTotalCount(CompletedOrderSearchCommand command) {
+        CompletedOrderSearchType searchType = command.searchType();
+        String keyword = command.searchValue();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(order.countDistinct())
+            .from(order)
+            .leftJoin(order.seller, seller)
+            .leftJoin(order.orderItems, orderItem);
+
+        addKeywordJoins(countQuery, searchType, keyword);
+
+        Long total = countQuery
+            .where(
+                seller.id.eq(command.sellerId()),
+                dateRangePredicate(
+                    toStartDateTime(command.startDate()),
+                    toEndDateTime(command.endDate())),
+                completedOrderStatusPredicate(command.status()),
+                keywordPredicate(searchType, keyword))
+            .fetchOne();
+
+        return total != null ? total : 0L;
+    }
+
+    private BooleanExpression completedOrderStatusPredicate(CompletedOrderStatus status) {
+        // status가 null이면 완료 상태 전체(구매확정/취소/반품/교환)를 조회
+        if (status == null) {
+            return orderItem.orderStatus.in(ALL_COMPLETED_STATUSES);
+        }
+
+        return switch (status) {
+            case PURCHASED -> orderItem.orderStatus.eq(OrderStatus.PURCHASE_CONFIRMED);
+            case CANCELED -> orderItem.orderStatus.in(OrderStatus.CANCELLED_GROUP);
+            case RETURNED -> orderItem.orderStatus.in(OrderStatus.RETURNED_GROUP);
+            case EXCHANGED -> orderItem.orderStatus.in(OrderStatus.EXCHANGED_GROUP);
+        };
+    }
+
+    /**
+     * [2단계 페이징 전략 - 1단계] fetchJoin과 페이징을 동시에 사용하면 카테시안 곱 문제가 발생합니다.
+     * 예) Order 1개에 OrderItem이 3개이면 fetchJoin 결과는 3행인데, LIMIT 10을 적용하면
+     * Order 10개가 아닌 OrderItem 10개(≈ Order 3~4개)만 가져오게 됩니다.
+     * 이를 방지하기 위해 1단계에서는 fetchJoin 없이 ID만 조회하여 올바른 LIMIT을 적용하고,
+     * 2단계(fetchOrdersWithDetails)에서 해당 ID 목록으로 fetchJoin 조회를 수행합니다.
+     */
     private List<Long> fetchOrderIds(OrderSearchCommand command, Pageable pageable) {
         CompletedOrderSearchType searchType = command.searchType();
         String keyword = command.searchCondition() != null
@@ -119,6 +254,12 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
             .fetch();
     }
 
+    /**
+     * [2단계 페이징 전략 - 2단계] 1단계에서 구한 orderIds로 Order 엔티티를 fetchJoin 조회합니다.
+     * distinct()를 사용하는 이유: leftJoin(order.orderItems).fetchJoin() 시 DB에서 Order 1개당
+     * OrderItem N개가 조인되어 N개의 중복 Order 행이 반환됩니다. distinct()로 JPA 레벨 중복을 제거합니다.
+     * (페이지네이션은 1단계에서 이미 처리했으므로 distinct()가 페이지 크기에 영향을 주지 않습니다)
+     */
     private List<Order> fetchOrdersWithDetails(List<Long> orderIds) {
         if (orderIds == null || orderIds.isEmpty()) {
             return Collections.emptyList();
@@ -136,6 +277,11 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
         return restoreOriginalOrder(orders, orderIds);
     }
 
+    /**
+     * [정렬 순서 복원] fetchJoin 이후 DB가 반환하는 Order 결과 순서는 OrderItem 수에 따라 달라질 수 있습니다.
+     * 1단계에서 orderDate DESC → id DESC 기준으로 정렬된 orderIds 순서가 실제 페이지 정렬 기준이므로,
+     * fetchJoin 결과를 Map으로 변환한 뒤 orderIds 순서대로 재조립하여 원래 정렬 순서를 복원합니다.
+     */
     private List<Order> restoreOriginalOrder(List<Order> orders, List<Long> orderIds) {
         Map<Long, Order> orderMap = orders.stream()
             .collect(Collectors.toMap(Order::getId, Function.identity()));
@@ -173,6 +319,14 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
         return total != null ? total : 0L;
     }
 
+    /**
+     * [동적 조인 추가] QueryDSL WHERE 절에서 특정 테이블 컬럼을 참조하려면
+     * 해당 테이블이 FROM/JOIN 절에 반드시 포함되어 있어야 합니다.
+     * 기본 쿼리에는 product·orderDelivery가 없으므로, 검색 타입에 따라 필요할 때만 동적으로 추가합니다.
+     * 불필요한 조인을 피해 쿼리 성능을 유지합니다.
+     * - PRODUCT_NAME 검색 시: orderItem → product 조인 추가
+     * - TRACKING_NUMBER 검색 시: orderItem → orderDeliveries → orderDelivery 조인 추가
+     */
     private void addKeywordJoins(JPAQuery<?> query, CompletedOrderSearchType searchType,
         String keyword) {
         if (keyword == null || keyword.isBlank()) {
@@ -204,10 +358,15 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
             return null;
         }
 
+        // 검색 타입별로 서로 다른 컬럼에 LIKE 검색 적용 (대소문자 무관)
         return switch (searchType) {
+            // 주문 번호로 검색 (Order.orderNumber)
             case ORDER_NUMBER -> order.orderNumber.containsIgnoreCase(keyword);
+            // 구매자명으로 검색 (Order.buyerName)
             case BUYER_NAME -> order.buyerName.containsIgnoreCase(keyword);
+            // 상품명으로 검색 (Product.title) — addKeywordJoins에서 product 조인이 선행 필요
             case PRODUCT_NAME -> product.title.containsIgnoreCase(keyword);
+            // 운송장 번호로 검색 (Shipping.trackingNumber) — addKeywordJoins에서 orderDelivery 조인이 선행 필요
             case TRACKING_NUMBER -> orderDelivery.shipping.trackingNumber.containsIgnoreCase(keyword);
         };
     }
@@ -222,6 +381,16 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
         return command.searchCondition() != null
             ? command.searchCondition().getEndDate().atTime(23, 59, 59)
             : null;
+    }
+
+    // LocalDate → 해당 날짜 00:00:00 LocalDateTime 변환 (null-safe)
+    private LocalDateTime toStartDateTime(LocalDate date) {
+        return date != null ? date.atStartOfDay() : null;
+    }
+
+    // LocalDate → 해당 날짜 23:59:59 LocalDateTime 변환 (null-safe)
+    private LocalDateTime toEndDateTime(LocalDate date) {
+        return date != null ? date.atTime(23, 59, 59) : null;
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepositoryImpl.java
@@ -138,7 +138,8 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
                 dateRangePredicate(
                     toStartDateTime(command.startDate()),
                     toEndDateTime(command.endDate())),
-                completedOrderStatusPredicate(null),
+                // 탭 배지용 카운트이므로 취소/반품/교환을 포함한 전체 완료 상태를 집계
+                orderItem.orderStatus.in(ALL_COMPLETED_STATUSES),
                 keywordPredicate(searchType, keyword))
             .groupBy(orderItem.orderStatus)
             .fetch();
@@ -206,17 +207,9 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
     }
 
     private BooleanExpression completedOrderStatusPredicate(CompletedOrderStatus status) {
-        // status가 null이면 완료 상태 전체(구매확정/취소/반품/교환)를 조회
-        if (status == null) {
-            return orderItem.orderStatus.in(ALL_COMPLETED_STATUSES);
-        }
-
-        return switch (status) {
-            case PURCHASED -> orderItem.orderStatus.eq(OrderStatus.PURCHASE_CONFIRMED);
-            case CANCELED -> orderItem.orderStatus.in(OrderStatus.CANCELLED_GROUP);
-            case RETURNED -> orderItem.orderStatus.in(OrderStatus.RETURNED_GROUP);
-            case EXCHANGED -> orderItem.orderStatus.in(OrderStatus.EXCHANGED_GROUP);
-        };
+        // 완료 탭 전용 API: 취소/반품/교환은 별도 API로 조회하므로 항상 구매확정만 필터링
+        // status 파라미터는 향후 확장을 위해 유지하지만 현재는 무시
+        return orderItem.orderStatus.eq(OrderStatus.PURCHASE_CONFIRMED);
     }
 
     /**

--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/SellerOrderApi.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/SellerOrderApi.java
@@ -6,6 +6,7 @@ import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.request.CompletedOrderFilter;
 import com.bbangle.bbangle.order.seller.controller.dto.request.OrderRequest;
 import com.bbangle.bbangle.order.seller.controller.dto.request.SellerOrderRequest;
+import com.bbangle.bbangle.order.seller.controller.dto.response.CompletedOrderResponse.CompletedOrderPageResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.CompletedOrderResponse.OrderSummary;
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse.OrderItemDetailResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.ExchangeCreateResponse;
@@ -29,7 +30,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface SellerOrderApi {
 
     @Operation(summary = "(판매자) 완료주문내역 페이징 조회")
-    SingleResult<BbanglePageResponse<OrderSummary>> getCompletedOrders(
+    SingleResult<CompletedOrderPageResponse> getCompletedOrders(
         @ParameterObject Pageable pageable,
         @ParameterObject CompletedOrderFilter filter,
         Long sellerId

--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/SellerOrderController.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/SellerOrderController.java
@@ -8,6 +8,8 @@ import com.bbangle.bbangle.config.security.SellerApiPath;
 import com.bbangle.bbangle.order.seller.controller.dto.request.CompletedOrderFilter;
 import com.bbangle.bbangle.order.seller.controller.dto.request.OrderRequest.OrderSearchRequest;
 import com.bbangle.bbangle.order.seller.controller.dto.request.SellerOrderRequest;
+import com.bbangle.bbangle.order.seller.controller.dto.response.CompletedOrderResponse;
+import com.bbangle.bbangle.order.seller.controller.dto.response.CompletedOrderResponse.CompletedOrderPageResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.CompletedOrderResponse.OrderSummary;
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse.OrderItemDetailResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse.OrderSearchPageResponse;
@@ -48,19 +50,27 @@ public class SellerOrderController implements SellerOrderApi {
 
     private final SellerExchangeService sellerExchangeService;
 
+    /**
+     * 완료 주문 목록 조회 (구매확정·취소·반품·교환 상태)
+     * 기본 페이지 크기 10: 완료 주문은 실시간 처리 대상이 아니므로 소량 조회합니다.
+     */
     @Override
     @GetMapping("/completed")
-    public SingleResult<BbanglePageResponse<OrderSummary>> getCompletedOrders(
+    public SingleResult<CompletedOrderPageResponse> getCompletedOrders(
         @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
         CompletedOrderFilter filter,
         @AuthenticationPrincipal Long sellerId) {
-        // TODO: 구현 필요
-        List<OrderSummary> orderSummaries = List.of(OrderSummary.sample());
-        PageImpl<OrderSummary> page = new PageImpl<>(orderSummaries, pageable, 10);
-        BbanglePageResponse<OrderSummary> response = BbanglePageResponse.of(page);
+
+        CompletedOrderPageResponse response = sellerOrderService.getCompletedOrders(
+            filter.toCommand(sellerId, pageable));
+
         return responseService.getSingleResult(response);
     }
 
+    /**
+     * 주문 항목 상세 조회
+     * 선택된 orderItemId 목록에 대한 구매자·배송·상품 정보를 반환합니다.
+     */
     @Override
     @PostMapping("/items")
     public ListResult<OrderItemDetailResponse> searchDetailItems(
@@ -70,6 +80,11 @@ public class SellerOrderController implements SellerOrderApi {
         return responseService.getListResult(responses);
     }
 
+    /**
+     * 주문 목록 검색 (결제완료~배송완료 상태)
+     * @PageableDefault(size = 100): 판매자가 주문을 한 번에 내려받아 일괄 처리하는 워크플로우를
+     * 지원하기 위해 기본 페이지 크기를 100으로 설정합니다.
+     */
     @Override
     @PostMapping("/list")
     public SingleResult<OrderSearchPageResponse> searchOrders(
@@ -83,6 +98,10 @@ public class SellerOrderController implements SellerOrderApi {
         return responseService.getSingleResult(response);
     }
 
+    /**
+     * 발주 확인 처리: 결제완료 상태 → 발주확인 상태로 전환
+     * 부분 성공 정책: 일부 항목이 실패해도 가능한 항목의 처리 결과를 반환합니다.
+     */
     @PostMapping("/{orderId}/confirm")
     @Override
     public SingleResult<OrderConfirmResponse> confirmOrder(
@@ -94,6 +113,10 @@ public class SellerOrderController implements SellerOrderApi {
         return responseService.getSingleResult(result);
     }
 
+    /**
+     * 신규 운송장 등록: 발주확인 상태 → 배송중 상태로 전환
+     * OrderDelivery가 없으면 새로 생성하여 택배사·운송장 번호를 설정합니다.
+     */
     @PostMapping("/{orderId}/shipment")
     public SingleResult<ShipmentRegisterResponse> registerShipment(
         @AuthenticationPrincipal Long sellerId,
@@ -104,6 +127,9 @@ public class SellerOrderController implements SellerOrderApi {
         return responseService.getSingleResult(result);
     }
 
+    /**
+     * 반품 접수 처리: 고객 반품 요청 항목에 대해 판매자가 반품 수거를 시작합니다.
+     */
     @PostMapping("/{orderId}/returns")
     @Override
     public SingleResult<ReturnCreateResponse> createReturn(
@@ -115,6 +141,9 @@ public class SellerOrderController implements SellerOrderApi {
         return responseService.getSingleResult(result);
     }
 
+    /**
+     * 교환 접수 처리: 고객 교환 요청 항목에 대해 판매자가 교환 처리를 시작합니다.
+     */
     @PostMapping("/{orderId}/exchanges")
     @Override
     public SingleResult<ExchangeCreateResponse> createExchange(
@@ -126,6 +155,10 @@ public class SellerOrderController implements SellerOrderApi {
         return responseService.getSingleResult(result);
     }
 
+    /**
+     * 운송장 수정: 이미 등록된 운송장 정보(택배사·운송장 번호)를 변경합니다.
+     * 기존 OrderDelivery가 존재해야 수정 가능하며, 없으면 실패 응답을 반환합니다.
+     */
     @PatchMapping("/{orderId}/shipment")
     @Override
     public SingleResult<ShipmentModifyResponse> modifyShipment(

--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/request/CompletedOrderFilter.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/request/CompletedOrderFilter.java
@@ -2,8 +2,10 @@ package com.bbangle.bbangle.order.seller.controller.dto.request;
 
 import com.bbangle.bbangle.order.domain.model.CompletedOrderSearchType;
 import com.bbangle.bbangle.order.domain.model.CompletedOrderStatus;
+import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.CompletedOrderSearchCommand;
 import io.swagger.v3.oas.annotations.Parameter;
 import java.time.LocalDate;
+import org.springframework.data.domain.Pageable;
 
 public record CompletedOrderFilter(
     @Parameter(description = "조회 시작일", example = "2024-01-01") LocalDate startDate,
@@ -12,5 +14,22 @@ public record CompletedOrderFilter(
     @Parameter(description = "검색 상세 조건") CompletedOrderSearchType searchType,
     @Parameter(description = "검색어", example = "저당 베이글") String searchValue
 ) {
-
+    /**
+     * Query Parameter로 수신한 필터 조건을 서비스 계층 커맨드로 변환합니다.
+     * sellerId와 pageable을 Filter 자체에 포함하지 않는 이유:
+     * - sellerId: JWT 인증 정보에서 추출되어 Controller가 @AuthenticationPrincipal로 주입합니다.
+     * - pageable: Spring HandlerMethodArgumentResolver가 쿼리 파라미터(page/size/sort)를 변환하여 주입합니다.
+     */
+    public CompletedOrderSearchCommand toCommand(Long sellerId, Pageable pageable) {
+        return CompletedOrderSearchCommand.builder()
+            .sellerId(sellerId)
+            .startDate(startDate)
+            .endDate(endDate)
+            .status(status)
+            .searchType(searchType)
+            .searchValue(searchValue)
+            .pageable(pageable)
+            .build();
+    }
 }
+

--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/response/CompletedOrderResponse.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/response/CompletedOrderResponse.java
@@ -65,6 +65,8 @@ public class CompletedOrderResponse {
         LocalDateTime paidAt,
         @Schema(description = "결제 요일") DayOfWeek paidDayOfWeek,
         @Schema(description = "수취인명") String recipient,
+        @Schema(description = "총 주문금액") Long totalAmount,
+        @Schema(description = "결제수단") String paymentMethod,
         List<OrderItem> orderItems
     ) {
 
@@ -74,14 +76,16 @@ public class CompletedOrderResponse {
          * 메서드 형태로 제공합니다. SellerOrderApi 인터페이스의 @Operation에서 참조됩니다.
          */
         public static OrderSummary sample() {
-            OrderItem item1 = OrderItem.of(1L, PURCHASED, "CJ대한통운", "123-123", "저칼로리 베이글", 5);
-            OrderItem item2 = OrderItem.of(2L, CANCELED, "롯데택배", "123-456", "저당 초콜릿", 10);
+            OrderItem item1 = OrderItem.of(1L, PURCHASED, "배송완료", "CJ대한통운", "123-123", "저칼로리 베이글", 5, 4700L);
+            OrderItem item2 = OrderItem.of(2L, CANCELED, null, "롯데택배", "123-456", "저당 초콜릿", 10, 3200L);
             return OrderSummary.of(
                 1L,
                 "000-123",
                 LocalDateTime.of(2024, 1, 1, 12, 0),
                 DayOfWeek.MONDAY,
                 "홍길동",
+                24400L,
+                "신용/체크카드",
                 List.of(item1, item2)
             );
         }
@@ -92,31 +96,37 @@ public class CompletedOrderResponse {
             LocalDateTime paidAt,
             DayOfWeek paidDayOfWeek,
             String recipient,
+            Long totalAmount,
+            String paymentMethod,
             List<OrderItem> orderItems
         ) {
             return new OrderSummary(orderId, orderNum, paidAt, paidDayOfWeek, recipient,
-                orderItems);
+                totalAmount, paymentMethod, orderItems);
         }
 
         public record OrderItem(
             @Schema(description = "주문상품ID") Long orderItemId,
             @Schema(description = "상태") CompletedOrderStatus status,
+            @Schema(description = "배송상태") String deliveryStatus,
             @Schema(description = "택배사") String deliveryCompany,
             @Schema(description = "운송장 번호") String trackingNumber,
             @Schema(description = "상품명") String productName,
-            @Schema(description = "판매 수량") Integer quantity
+            @Schema(description = "판매 수량") Integer quantity,
+            @Schema(description = "단가") Long unitPrice
         ) {
 
             public static OrderItem of(
                 Long orderItemId,
                 CompletedOrderStatus status,
+                String deliveryStatus,
                 String deliveryCompany,
                 String trackingNumber,
                 String productName,
-                Integer quantity
+                Integer quantity,
+                Long unitPrice
             ) {
-                return new OrderItem(orderItemId, status, deliveryCompany, trackingNumber,
-                    productName, quantity);
+                return new OrderItem(orderItemId, status, deliveryStatus, deliveryCompany,
+                    trackingNumber, productName, quantity, unitPrice);
             }
         }
     }

--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/response/CompletedOrderResponse.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/response/CompletedOrderResponse.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.order.seller.controller.dto.response;
 import static com.bbangle.bbangle.order.domain.model.CompletedOrderStatus.CANCELED;
 import static com.bbangle.bbangle.order.domain.model.CompletedOrderStatus.PURCHASED;
 
+import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.order.domain.model.CompletedOrderStatus;
 import com.bbangle.bbangle.order.domain.model.DayOfWeek;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -11,6 +12,49 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public class CompletedOrderResponse {
+
+    @Schema(description = "완료 주문 내역 조회 응답 (페이지 + 상태별 카운트)")
+    public record CompletedOrderPageResponse(
+        @Schema(description = "주문 목록 페이지")
+        BbanglePageResponse<OrderSummary> orders,
+
+        @Schema(description = "주문 상태별 카운트")
+        CompletedOrderStatusCounts statusCounts
+    ) {
+
+    }
+
+    @Schema(description = "완료 주문 상태별 카운트")
+    public record CompletedOrderStatusCounts(
+        @Schema(description = "전체", example = "13")
+        long total,
+
+        @Schema(description = "완료(구매확정)", example = "10")
+        long purchased,
+
+        @Schema(description = "취소", example = "2")
+        long canceled,
+
+        @Schema(description = "반품", example = "1")
+        long returned,
+
+        @Schema(description = "교환", example = "0")
+        long exchanged
+    ) {
+        /**
+         * 각 상태별 카운트를 받아 전체 합계(total)를 자동 계산합니다.
+         * 전체(ALL) 탭과 개별 탭 카운트를 한 번에 처리하기 위해 total을 내부에서 집계합니다.
+         */
+        public static CompletedOrderStatusCounts of(
+            long purchased,
+            long canceled,
+            long returned,
+            long exchanged
+        ) {
+            long total = purchased + canceled + returned + exchanged;
+            return new CompletedOrderStatusCounts(total, purchased, canceled, returned, exchanged);
+        }
+    }
 
     @Schema(description = "완료 주문 내역")
     public record OrderSummary(
@@ -24,6 +68,11 @@ public class CompletedOrderResponse {
         List<OrderItem> orderItems
     ) {
 
+        /**
+         * Swagger UI에서 응답 예시로 표시할 샘플 데이터를 생성합니다.
+         * 중첩 구조가 복잡하여 @Schema example 어노테이션으로 표현하기 어렵기 때문에
+         * 메서드 형태로 제공합니다. SellerOrderApi 인터페이스의 @Operation에서 참조됩니다.
+         */
         public static OrderSummary sample() {
             OrderItem item1 = OrderItem.of(1L, PURCHASED, "CJ대한통운", "123-123", "저칼로리 베이글", 5);
             OrderItem item2 = OrderItem.of(2L, CANCELED, "롯데택배", "123-456", "저당 초콜릿", 10);

--- a/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
@@ -596,6 +596,17 @@ public class SellerOrderService {
             ? order.getPayment().getPaidAt()
             : order.getOrderDate();
 
+        // 결제수단 추출 (결제 정보 없으면 null)
+        String paymentMethod = null;
+        if (order.getPayment() != null && order.getPayment().getPaymentMethod() != null) {
+            paymentMethod = order.getPayment().getPaymentMethod().getDescription();
+        }
+
+        // 총 주문금액 (없으면 null)
+        Long totalAmount = order.getTotalAmount() != null
+            ? order.getTotalAmount().longValue()
+            : null;
+
         List<CompletedOrderResponse.OrderSummary.OrderItem> summaryItems = order.getOrderItems().stream()
             .map(item -> buildOrderItemSummary(item, deliveryMap))
             .filter(item -> item.status() != null)
@@ -607,27 +618,42 @@ public class SellerOrderService {
             paidAt,
             resolvePaidDayOfWeek(paidAt),
             recipient,
+            totalAmount,
+            paymentMethod,
             summaryItems
         );
     }
 
-    // 주문 항목 하나에 대한 배송사/운송장 정보를 포함한 요약 DTO 생성
+    // 주문 항목 하나에 대한 배송사/운송장/배송상태/단가 정보를 포함한 요약 DTO 생성
     private CompletedOrderResponse.OrderSummary.OrderItem buildOrderItemSummary(
         OrderItem item, Map<Long, OrderDelivery> deliveryMap) {
         OrderDelivery itemDelivery = deliveryMap.get(item.getId());
         String deliveryCompany = null;
         String trackingNumber = null;
-        if (itemDelivery != null && itemDelivery.getShipping() != null) {
-            deliveryCompany = itemDelivery.getShipping().getCourierName();
-            trackingNumber = itemDelivery.getShipping().getTrackingNumber();
+        String deliveryStatus = null;
+        if (itemDelivery != null) {
+            // 배송상태 추출 (없으면 null)
+            if (itemDelivery.getStatus() != null) {
+                deliveryStatus = itemDelivery.getStatus().getDescription();
+            }
+            // 배송사/운송장 추출
+            if (itemDelivery.getShipping() != null) {
+                deliveryCompany = itemDelivery.getShipping().getCourierName();
+                trackingNumber = itemDelivery.getShipping().getTrackingNumber();
+            }
         }
+        // 단가 추출 (없으면 null)
+        Long unitPrice = item.getUnitPrice() != null ? item.getUnitPrice().longValue() : null;
+
         return CompletedOrderResponse.OrderSummary.OrderItem.of(
             item.getId(),
             mapToCompletedOrderStatus(item.getOrderStatus()),
+            deliveryStatus,
             deliveryCompany,
             trackingNumber,
             item.getProduct() != null ? item.getProduct().getTitle() : null,
-            item.getQuantity()
+            item.getQuantity(),
+            unitPrice
         );
     }
 

--- a/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
@@ -9,6 +9,8 @@ import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.order.domain.Order;
 import com.bbangle.bbangle.order.domain.OrderDelivery;
 import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.CompletedOrderStatus;
+import com.bbangle.bbangle.order.domain.model.DayOfWeek;
 import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
 import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.repository.OrderDeliveryRepository;
@@ -22,6 +24,8 @@ import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse.Or
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse.OrderSearchPageResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse.OrderSearchResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse.OrderStatusCounts;
+import com.bbangle.bbangle.order.seller.controller.dto.response.CompletedOrderResponse;
+import com.bbangle.bbangle.order.seller.controller.dto.response.CompletedOrderResponse.OrderSummary;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.ShipmentContent;
@@ -31,6 +35,7 @@ import com.bbangle.bbangle.order.seller.controller.model.PaymentInfo;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderConfirmCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentModifyCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderSearchCommand;
+import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.CompletedOrderSearchCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentRegisterCommand;
 import com.bbangle.bbangle.payment.domain.Payment;
 import com.bbangle.bbangle.seller.domain.Seller;
@@ -65,6 +70,12 @@ public class SellerOrderService {
     // [예주] 발주 확인 / 운송장 관리
     // ========================================================================================
 
+    /**
+     * 발주 확인 처리 (부분 성공 정책 적용)
+     * 요청된 orderItemIds 중 일부만 확정 가능한 경우에도 가능한 항목은 계속 처리합니다.
+     * 실패 항목(DB에 없거나 상태 전환 불가)은 failedIds에 수집하여 응답으로 반환합니다.
+     * 일부 실패가 발생해도 성공한 항목은 롤백하지 않습니다.
+     */
     @Transactional
     public OrderConfirmResponse confirmOrder(OrderConfirmCommand command) {
         List<Long> uniqueOrderItemIds = validateAndDeduplicateIds(command.orderItemIds());
@@ -76,8 +87,10 @@ public class SellerOrderService {
         List<OrderItem> orderItems = orderItemRepository.findByOrderIdAndIdIn(
             order.getId(), uniqueOrderItemIds
         );
+        // DB에서 조회되지 않은 ID는 즉시 실패 목록에 추가
         List<Long> notFoundIds = computeNotFoundIds(uniqueOrderItemIds, orderItems);
         List<Long> foundIds = orderItems.stream().map(OrderItem::getId).toList();
+        // 조회된 항목이 이 판매자의 스토어 소속인지 소유권 검증
         if (!foundIds.isEmpty()) {
             assertOwnedOrderItems(order.getId(), foundIds, seller.getStore().getId());
         }
@@ -86,9 +99,11 @@ public class SellerOrderService {
         List<Long> failedIds = new ArrayList<>(notFoundIds);
 
         for (OrderItem orderItem : orderItems) {
+            // confirmOrder()는 현재 상태가 발주확인 가능한 상태(결제완료)일 때만 true를 반환
             if (orderItem.confirmOrder()) {
                 confirmedIds.add(orderItem.getId());
             } else {
+                // 이미 확인 처리됐거나 전환 불가능한 상태이면 실패 처리
                 failedIds.add(orderItem.getId());
             }
         }
@@ -102,6 +117,13 @@ public class SellerOrderService {
         return OrderConfirmResponse.of(content);
     }
 
+    /**
+     * 신규 운송장 등록 (부분 성공 정책 적용)
+     * 각 OrderItem에 대해 기존 OrderDelivery를 재사용하거나 새로 생성하여 택배사·운송장 번호를 등록합니다.
+     * - 기존 OrderDelivery가 있으면 재사용, 없으면 판매자·주문 정보로 새로 생성 후 저장
+     * - loadDeliveryMap으로 배송 정보를 일괄 사전 로드하여 반복문 내 N+1 쿼리를 방지합니다
+     * 각 항목 처리 중 BbangleException이 발생하면 해당 항목만 실패 처리하고 나머지는 계속 진행합니다.
+     */
     @Transactional
     public ShipmentRegisterResponse registerShipment(ShipmentRegisterCommand command) {
         List<Long> uniqueOrderItemIds = validateAndDeduplicateIds(command.orderItemIds());
@@ -118,6 +140,7 @@ public class SellerOrderService {
         if (!foundIds.isEmpty()) {
             assertOwnedOrderItems(order.getId(), foundIds, seller.getStore().getId());
         }
+        // orderItemId → OrderDelivery 매핑을 미리 로드 (for문 내 개별 조회로 인한 N+1 방지)
         Map<Long, OrderDelivery> deliveryMap = loadDeliveryMap(uniqueOrderItemIds);
 
         List<Long> successIds = new ArrayList<>();
@@ -126,13 +149,17 @@ public class SellerOrderService {
 
         for (OrderItem orderItem : orderItems) {
             try {
+                // 기존 OrderDelivery가 없으면 판매자·주문 정보로 신규 생성 후 저장
                 OrderDelivery delivery = getOrCreateDelivery(deliveryMap, orderItem, seller);
+                // 택배사·운송장 번호를 설정하고 출고 시각을 기록
                 delivery.registerShipment(command.courierName(), command.trackingNumber());
+                // OrderItem 상태를 배송중(SHIPPED)으로 전환
                 orderItem.shipOrder();
 
                 successIds.add(orderItem.getId());
                 shippedAt = delivery.getShipping().getShippedAt();
             } catch (BbangleException e) {
+                // 개별 항목 실패는 로그만 남기고 다음 항목 처리를 계속 (부분 성공 정책)
                 log.warn("운송장 등록 실패 - orderId: {}, orderItemId: {}, sellerId: {}, reason: {}",
                     command.orderId(), orderItem.getId(), command.sellerId(), e.getMessage());
                 failedIds.add(orderItem.getId());
@@ -153,6 +180,12 @@ public class SellerOrderService {
         return ShipmentRegisterResponse.of(content);
     }
 
+    /**
+     * 기존 운송장 수정 (registerShipment와의 차이점)
+     * registerShipment는 OrderDelivery가 없으면 신규 생성하지만,
+     * modifyShipment는 반드시 기존 OrderDelivery가 존재해야 합니다.
+     * OrderDelivery가 없는 항목은 DELIVERY_NOT_FOUND 예외로 failedIds에 수집됩니다.
+     */
     @Transactional
     public ShipmentModifyResponse modifyShipment(ShipmentModifyCommand command) {
         List<Long> uniqueOrderItemIds = validateAndDeduplicateIds(command.orderItemIds());
@@ -293,6 +326,15 @@ public class SellerOrderService {
     // [Joon Gyu] 주문 조회
     // ========================================================================================
 
+    /**
+     * 주문 항목 상세 조회 (배송 정보 포함)
+     * OrderItem과 Order는 fetchJoin으로 함께 조회하고, 배송 정보(OrderDelivery)는 별도로 조회합니다.
+     * 배송 정보를 분리 조회하는 이유: 운송장 등록 전에는 OrderDelivery가 없을 수도 있어 optional한 관계이며,
+     * orderItem.orderDeliveries fetchJoin 시 카테시안 곱 문제가 발생할 수 있기 때문입니다.
+     *
+     * Fallback 패턴: 수취인 이름·전화번호는 OrderDelivery.Receiver가 있으면 우선 사용하고,
+     * 없으면 주문자(Order.buyerName/buyerPhone) 정보로 대체합니다.
+     */
     @Transactional(readOnly = true)
     public List<OrderItemDetailResponse> searchOrderItemDetails(List<Long> orderItemIds, Long sellerId) {
         if (orderItemIds == null || orderItemIds.isEmpty()) {
@@ -453,6 +495,11 @@ public class SellerOrderService {
         return storeId;
     }
 
+    /**
+     * DB 조회 결과인 OrderStatus별 카운트 Map을 UI 표시용 7개 탭 카운트로 변환합니다.
+     * OrderStatus는 세부 상태(예: CANCEL_REQUESTED, CANCELLED)를 포함하는 enum이므로,
+     * 탭별로 관련 상태들의 카운트를 합산합니다 (예: CANCELLED_GROUP = {CANCEL_REQUESTED, CANCELLED}).
+     */
     private OrderStatusCounts buildStatusCounts(Map<OrderStatus, Long> countMap) {
         return OrderStatusCounts.of(
             sumCounts(countMap, OrderStatus.PAYMENT_COMPLETED_GROUP),
@@ -496,5 +543,114 @@ public class SellerOrderService {
                 item,
                 deliveryMap.get(item.getId())))
             .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public CompletedOrderResponse.CompletedOrderPageResponse getCompletedOrders(CompletedOrderSearchCommand command) {
+        BbanglePageResponse<Order> orderPage = orderRepository.searchCompletedOrderList(command);
+        Map<OrderStatus, Long> statusCountMap = orderRepository.countByCompletedOrderStatus(command);
+
+        Map<Long, OrderDelivery> latestDeliveryMap = fetchLatestDeliveries(orderPage.content());
+
+        List<OrderSummary> orderSummaries = orderPage.content().stream()
+            .map(order -> buildOrderSummary(order, latestDeliveryMap))
+            .toList();
+
+        BbanglePageResponse<OrderSummary> pageResponse = new BbanglePageResponse<>(
+            orderSummaries,
+            orderPage.page(),
+            orderPage.size(),
+            orderPage.totalPages(),
+            orderPage.totalElements()
+        );
+
+        long purchasedCount = sumCounts(statusCountMap, Set.of(OrderStatus.PURCHASE_CONFIRMED));
+        long canceledCount = sumCounts(statusCountMap, OrderStatus.CANCELLED_GROUP);
+        long returnedCount = sumCounts(statusCountMap, OrderStatus.RETURNED_GROUP);
+        long exchangedCount = sumCounts(statusCountMap, OrderStatus.EXCHANGED_GROUP);
+
+        CompletedOrderResponse.CompletedOrderStatusCounts counts = CompletedOrderResponse.CompletedOrderStatusCounts.of(
+            purchasedCount, canceledCount, returnedCount, exchangedCount
+        );
+
+        return new CompletedOrderResponse.CompletedOrderPageResponse(pageResponse, counts);
+    }
+
+    // ID 오름차순 기준으로 첫 번째 배송 정보를 선택하여 OrderSummary 조립
+    private OrderSummary buildOrderSummary(Order order, Map<Long, OrderDelivery> deliveryMap) {
+        OrderDelivery firstDelivery = order.getOrderItems().stream()
+            .sorted(Comparator.comparingLong(OrderItem::getId))
+            .map(item -> deliveryMap.get(item.getId()))
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+
+        // 배송 수취인이 있으면 우선 사용, 없으면 주문자 이름으로 fallback
+        String recipient = order.getBuyerName();
+        if (firstDelivery != null && firstDelivery.getReceiver() != null) {
+            recipient = firstDelivery.getReceiver().getRecipientName();
+        }
+
+        // 결제일 기준 (결제 정보 없으면 주문일로 대체)
+        LocalDateTime paidAt = order.getPayment() != null
+            ? order.getPayment().getPaidAt()
+            : order.getOrderDate();
+
+        List<CompletedOrderResponse.OrderSummary.OrderItem> summaryItems = order.getOrderItems().stream()
+            .map(item -> buildOrderItemSummary(item, deliveryMap))
+            .filter(item -> item.status() != null)
+            .toList();
+
+        return OrderSummary.of(
+            order.getId(),
+            order.getOrderNumber(),
+            paidAt,
+            resolvePaidDayOfWeek(paidAt),
+            recipient,
+            summaryItems
+        );
+    }
+
+    // 주문 항목 하나에 대한 배송사/운송장 정보를 포함한 요약 DTO 생성
+    private CompletedOrderResponse.OrderSummary.OrderItem buildOrderItemSummary(
+        OrderItem item, Map<Long, OrderDelivery> deliveryMap) {
+        OrderDelivery itemDelivery = deliveryMap.get(item.getId());
+        String deliveryCompany = null;
+        String trackingNumber = null;
+        if (itemDelivery != null && itemDelivery.getShipping() != null) {
+            deliveryCompany = itemDelivery.getShipping().getCourierName();
+            trackingNumber = itemDelivery.getShipping().getTrackingNumber();
+        }
+        return CompletedOrderResponse.OrderSummary.OrderItem.of(
+            item.getId(),
+            mapToCompletedOrderStatus(item.getOrderStatus()),
+            deliveryCompany,
+            trackingNumber,
+            item.getProduct() != null ? item.getProduct().getTitle() : null,
+            item.getQuantity()
+        );
+    }
+
+    // LocalDateTime에서 커스텀 DayOfWeek enum으로 변환 (null-safe)
+    private DayOfWeek resolvePaidDayOfWeek(LocalDateTime paidAt) {
+        if (paidAt == null) {
+            return null;
+        }
+        return DayOfWeek.valueOf(paidAt.getDayOfWeek().name());
+    }
+
+    // OrderStatus → CompletedOrderStatus 변환
+    // 쿼리 레이어에서 완료 상태만 보장하나, 예상치 못한 상태에는 방어적으로 null 반환 후 상위에서 필터링
+    private CompletedOrderStatus mapToCompletedOrderStatus(OrderStatus status) {
+        if (OrderStatus.PURCHASE_CONFIRMED.equals(status)) {
+            return CompletedOrderStatus.PURCHASED;
+        } else if (OrderStatus.CANCELLED_GROUP.contains(status)) {
+            return CompletedOrderStatus.CANCELED;
+        } else if (OrderStatus.RETURNED_GROUP.contains(status)) {
+            return CompletedOrderStatus.RETURNED;
+        } else if (OrderStatus.EXCHANGED_GROUP.contains(status)) {
+            return CompletedOrderStatus.EXCHANGED;
+        }
+        return null;
     }
 }

--- a/src/main/java/com/bbangle/bbangle/order/seller/service/model/SellerOrderCommand.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/service/model/SellerOrderCommand.java
@@ -2,13 +2,24 @@ package com.bbangle.bbangle.order.seller.service.model;
 
 import com.bbangle.bbangle.common.dto.SearchFormDto.DefaultSearchCondition;
 import com.bbangle.bbangle.order.domain.model.CompletedOrderSearchType;
+import com.bbangle.bbangle.order.domain.model.CompletedOrderStatus;
 import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 import org.springframework.data.domain.Pageable;
 
+/**
+ * 판매자 주문 관련 커맨드(Command) 객체 모음.
+ * Controller에서 Service 계층으로 요청 정보를 전달하는 불변 값 객체(record)입니다.
+ */
 public class SellerOrderCommand {
 
+    /**
+     * 발주 확인 처리 커맨드.
+     * 판매자가 특정 주문의 OrderItem 목록에 대해 발주를 확정할 때 사용합니다.
+     * (OrderItem 상태: 결제완료 → 발주확인)
+     */
     @Builder
     public record OrderConfirmCommand(
         Long orderId,
@@ -17,6 +28,11 @@ public class SellerOrderCommand {
     ) {
     }
 
+    /**
+     * 신규 운송장 등록 커맨드.
+     * 발주 확인된 OrderItem에 택배사·운송장 번호를 처음 등록할 때 사용합니다.
+     * OrderDelivery가 없으면 새로 생성하고, 있으면 기존 것에 운송장 정보를 덮어씁니다.
+     */
     @Builder
     public record ShipmentRegisterCommand(
         Long orderId,
@@ -27,6 +43,11 @@ public class SellerOrderCommand {
     ) {
     }
 
+    /**
+     * 기존 운송장 수정 커맨드.
+     * 이미 등록된 운송장 정보(택배사·운송장 번호)를 변경할 때 사용합니다.
+     * OrderDelivery가 반드시 존재해야 합니다 (없으면 DELIVERY_NOT_FOUND 예외로 실패 처리됨).
+     */
     @Builder
     public record ShipmentModifyCommand(
         Long orderId,
@@ -36,6 +57,11 @@ public class SellerOrderCommand {
         Long sellerId
      ) {
     }
+
+    /**
+     * 주문 목록 검색 커맨드 (배송 전 주문 탭 기준).
+     * 판매자 주문 관리 화면에서 결제완료~배송완료 상태의 주문을 조회할 때 사용합니다.
+     */
     @Builder
     public record OrderSearchCommand(
         Long sellerId,
@@ -43,6 +69,22 @@ public class SellerOrderCommand {
         CompletedOrderSearchType searchType,
         DefaultSearchCondition searchCondition,
         Pageable page
+    ) {
+    }
+
+    /**
+     * 완료 주문 목록 검색 커맨드 (구매확정/취소/반품/교환 탭 기준).
+     * 결제가 종결된 주문(구매확정, 취소, 반품, 교환)을 날짜·상태·키워드로 조회할 때 사용합니다.
+     */
+    @Builder
+    public record CompletedOrderSearchCommand(
+        Long sellerId,
+        LocalDate startDate,
+        LocalDate endDate,
+        CompletedOrderStatus status,
+        CompletedOrderSearchType searchType,
+        String searchValue,
+        Pageable pageable
     ) {
     }
 

--- a/src/test/java/com/bbangle/bbangle/order/seller/controller/SellerOrderCompletedApiIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/controller/SellerOrderCompletedApiIntegrationTest.java
@@ -29,8 +29,11 @@ import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.repository.StoreRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,12 +47,16 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
 @DisplayName("[통합테스트] SellerOrderController - 완료 주문 API")
 class SellerOrderCompletedApiIntegrationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
 
     @Autowired
     private MockMvc mvc;
@@ -135,22 +142,34 @@ class SellerOrderCompletedApiIntegrationTest {
                 .with(authentication(new UsernamePasswordAuthenticationToken(
                     sellerA.getId(), "N/A", List.of(new SimpleGrantedAuthority("ROLE_SELLER")))))
                 .contentType(MediaType.APPLICATION_JSON))
+            .andDo(result -> {
+                String body = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+                String pretty = objectMapper.writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(objectMapper.readTree(body));
+                log.info("=== [판매자 격리] Response ===\n{}", pretty);
+            })
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.orders.content.length()").value(1))
             .andExpect(jsonPath("$.result.orders.content[0].orderNum").value("ORD-A-001"));
     }
 
-    @DisplayName("완료 주문 조회 - 특정 상태(CANCELED) 필터링 시 결과 없음 (엣지 케이스)")
+    @DisplayName("완료 주문 조회 - 상태별 카운트 정확성 검증 (구매확정 1건, 취소 0건)")
     @Test
-    void getCompletedOrders_FilterByStatus_NoMatch() throws Exception {
-        // When: Seller A가 '취소' 상태인 주문 조회 (현재는 구매확정만 있음)
+    void getCompletedOrders_StatusCounts_CorrectlyAggregated() throws Exception {
+        // When: Seller A가 완료 주문 조회 (구매확정 주문 1건 존재)
+        // 완료 탭 전용 API이므로 status 필터와 무관하게 구매확정 주문만 조회됨
         mvc.perform(get("/api/v1/seller/orders/completed")
                 .with(authentication(new UsernamePasswordAuthenticationToken(
                     sellerA.getId(), "N/A", List.of(new SimpleGrantedAuthority("ROLE_SELLER")))))
-                .param("status", CompletedOrderStatus.CANCELED.name())
                 .contentType(MediaType.APPLICATION_JSON))
+            .andDo(result -> {
+                String body = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+                String pretty = objectMapper.writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(objectMapper.readTree(body));
+                log.info("=== [상태별 카운트] Response ===\n{}", pretty);
+            })
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.result.orders.content").isEmpty())
+            .andExpect(jsonPath("$.result.orders.content.length()").value(1))
             .andExpect(jsonPath("$.result.statusCounts.purchased").value(1))
             .andExpect(jsonPath("$.result.statusCounts.canceled").value(0));
     }
@@ -166,6 +185,12 @@ class SellerOrderCompletedApiIntegrationTest {
                 .param("size", "1")
                 .param("sort", "id,desc")
                 .contentType(MediaType.APPLICATION_JSON))
+            .andDo(result -> {
+                String body = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+                String pretty = objectMapper.writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(objectMapper.readTree(body));
+                log.info("=== [페이징] Response ===\n{}", pretty);
+            })
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.orders.page").value(0))
             .andExpect(jsonPath("$.result.orders.size").value(1))

--- a/src/test/java/com/bbangle/bbangle/order/seller/controller/SellerOrderCompletedApiIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/controller/SellerOrderCompletedApiIntegrationTest.java
@@ -1,0 +1,175 @@
+package com.bbangle.bbangle.order.seller.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.board.repository.BoardRepository;
+import com.bbangle.bbangle.board.repository.ProductRepository;
+import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
+import com.bbangle.bbangle.fixture.board.domain.ProductFixture;
+import com.bbangle.bbangle.fixture.order.domain.OrderFixture;
+import com.bbangle.bbangle.fixture.order.domain.OrderItemFixture;
+import com.bbangle.bbangle.fixture.payment.domain.PaymentFixture;
+import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
+import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.CompletedOrderStatus;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderItemRepository;
+import com.bbangle.bbangle.order.repository.OrderRepository;
+import com.bbangle.bbangle.payment.domain.Payment;
+import com.bbangle.bbangle.payment.repository.PaymentRepository;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.repository.StoreRepository;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@DisplayName("[통합테스트] SellerOrderController - 완료 주문 API")
+class SellerOrderCompletedApiIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private SellerRepository sellerRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private OrderItemRepository orderItemRepository;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Seller sellerA;
+    private Seller sellerB;
+
+    @BeforeEach
+    void setUp() {
+        // Seller A & Store A
+        Store storeA = storeRepository.save(StoreFixture.defaultStore("Store A"));
+        sellerA = sellerRepository.save(SellerFixture.createDefaultSeller(storeA));
+
+        // Seller B & Store B
+        Store storeB = storeRepository.save(StoreFixture.defaultStore("Store B"));
+        sellerB = sellerRepository.save(SellerFixture.createDefaultSeller(storeB));
+
+        // Board & Product for Seller A
+        Board boardA = boardRepository.save(BoardFixture.defaultBoardWithStore(storeA, "Product A"));
+        Product productA = productRepository.save(ProductFixture.create(boardA, "Product A Item"));
+
+        // Order for Seller A (PURCHASE_CONFIRMED -> PURCHASED status)
+        Order orderA = OrderFixture.createOrderWithNumber("ORD-A-001").toBuilder()
+            .seller(sellerA).buyerName("Buyer A").build();
+        orderRepository.save(orderA);
+        OrderItem itemA = OrderItemFixture.defaultOrderItem()
+            .product(productA)
+            .order(orderA)
+            .orderStatus(OrderStatus.PURCHASE_CONFIRMED)
+            .build();
+        orderA.addOrderItem(itemA);
+        orderItemRepository.save(itemA);
+        paymentRepository.save(PaymentFixture.createDefaultPayment(orderA));
+
+        // Order for Seller B
+        Board boardB = boardRepository.save(BoardFixture.defaultBoardWithStore(storeB, "Product B"));
+        Product productB = productRepository.save(ProductFixture.create(boardB, "Product B Item"));
+        Order orderB = OrderFixture.createOrderWithNumber("ORD-B-001").toBuilder()
+            .seller(sellerB).buyerName("Buyer B").build();
+        orderRepository.save(orderB);
+        OrderItem itemB = OrderItemFixture.defaultOrderItem()
+            .product(productB)
+            .order(orderB)
+            .orderStatus(OrderStatus.PURCHASE_CONFIRMED)
+            .build();
+        orderB.addOrderItem(itemB);
+        orderItemRepository.save(itemB);
+        paymentRepository.save(PaymentFixture.createDefaultPayment(orderB));
+
+        em.flush();
+        em.clear();
+    }
+
+    @DisplayName("완료 주문 조회 - 타 판매자의 주문은 조회되지 않아야 함 (판매자 격리 엣지 케이스)")
+    @Test
+    void getCompletedOrders_IsolationBySeller() throws Exception {
+        // When: Seller A가 자신의 완료 주문 조회
+        mvc.perform(get("/api/v1/seller/orders/completed")
+                .with(authentication(new UsernamePasswordAuthenticationToken(
+                    sellerA.getId(), "N/A", List.of(new SimpleGrantedAuthority("ROLE_SELLER")))))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.orders.content.length()").value(1))
+            .andExpect(jsonPath("$.result.orders.content[0].orderNum").value("ORD-A-001"));
+    }
+
+    @DisplayName("완료 주문 조회 - 특정 상태(CANCELED) 필터링 시 결과 없음 (엣지 케이스)")
+    @Test
+    void getCompletedOrders_FilterByStatus_NoMatch() throws Exception {
+        // When: Seller A가 '취소' 상태인 주문 조회 (현재는 구매확정만 있음)
+        mvc.perform(get("/api/v1/seller/orders/completed")
+                .with(authentication(new UsernamePasswordAuthenticationToken(
+                    sellerA.getId(), "N/A", List.of(new SimpleGrantedAuthority("ROLE_SELLER")))))
+                .param("status", CompletedOrderStatus.CANCELED.name())
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.orders.content").isEmpty())
+            .andExpect(jsonPath("$.result.statusCounts.purchased").value(1))
+            .andExpect(jsonPath("$.result.statusCounts.canceled").value(0));
+    }
+
+    @DisplayName("완료 주문 조회 - 페이징 적용 확인 (엣지 케이스: 첫 페이지 조회)")
+    @Test
+    void getCompletedOrders_PaginationAndSorting() throws Exception {
+        // When: Seller A가 페이징 정보를 담아 호출
+        mvc.perform(get("/api/v1/seller/orders/completed")
+                .with(authentication(new UsernamePasswordAuthenticationToken(
+                    sellerA.getId(), "N/A", List.of(new SimpleGrantedAuthority("ROLE_SELLER")))))
+                .param("page", "0")
+                .param("size", "1")
+                .param("sort", "id,desc")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.orders.page").value(0))
+            .andExpect(jsonPath("$.result.orders.size").value(1))
+            .andExpect(jsonPath("$.result.orders.totalElements").value(1));
+    }
+
+}

--- a/src/test/java/com/bbangle/bbangle/order/seller/controller/SellerOrderCompletedControllerSliceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/controller/SellerOrderCompletedControllerSliceTest.java
@@ -1,0 +1,152 @@
+package com.bbangle.bbangle.order.seller.controller;
+
+import static com.bbangle.bbangle.common.service.ResponseService.CommonResponse.SUCCESS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
+import com.bbangle.bbangle.common.page.BbanglePageResponse;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.JsonDataEncoder;
+import com.bbangle.bbangle.config.security.SecurityConfig;
+import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.exception.GlobalControllerAdvice;
+import com.bbangle.bbangle.order.seller.controller.dto.response.CompletedOrderResponse;
+import com.bbangle.bbangle.order.seller.controller.dto.response.CompletedOrderResponse.CompletedOrderPageResponse;
+import com.bbangle.bbangle.order.seller.controller.dto.response.CompletedOrderResponse.CompletedOrderStatusCounts;
+import com.bbangle.bbangle.order.seller.service.SellerOrderService;
+import com.bbangle.bbangle.claim.seller.service.SellerReturnService;
+import com.bbangle.bbangle.claim.seller.service.SellerExchangeService;
+import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.CompletedOrderSearchCommand;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@DisplayName("[단위테스트] SellerOrderController - 완료 주문 내역")
+@Import({
+    TestSlackAdaptorConfig.class,
+    JsonDataEncoder.class,
+    TokenProvider.class,
+    TestJwtPropertiesConfig.class,
+    ResponseService.class,
+    SecurityConfig.class
+})
+@WebMvcTest(controllers = SellerOrderController.class)
+class SellerOrderCompletedControllerSliceTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @SpyBean
+    private ResponseService responseService;
+
+    @SpyBean
+    private GlobalControllerAdvice globalControllerAdvice;
+
+    @MockBean
+    private SellerOrderService sellerOrderService;
+
+    @MockBean
+    private SellerReturnService sellerReturnService;
+
+    @MockBean
+    private SellerExchangeService sellerExchangeService;
+
+    @DisplayName("완료 주문 내역 조회 - 검색 결과가 없는 경우 (엣지 케이스)")
+    @Test
+    void getCompletedOrders_ReturnsEmpty_WhenNoOrdersFound() throws Exception {
+        // Given
+        Long sellerId = 1L;
+        CompletedOrderPageResponse mockResponse = new CompletedOrderPageResponse(
+            new BbanglePageResponse<>(Collections.emptyList(), 0, 10, 0, 0L),
+            CompletedOrderStatusCounts.of(0, 0, 0, 0)
+        );
+
+        given(sellerOrderService.getCompletedOrders(any(CompletedOrderSearchCommand.class)))
+            .willReturn(mockResponse);
+
+        // When & Then
+        mvc.perform(get("/api/v1/seller/orders/completed")
+                .with(authentication(new UsernamePasswordAuthenticationToken(
+                    sellerId, "N/A", List.of(new SimpleGrantedAuthority("ROLE_SELLER")))))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.result.orders.content").isEmpty())
+            .andExpect(jsonPath("$.result.statusCounts.total").value(0));
+
+        then(sellerOrderService).should(times(1)).getCompletedOrders(any());
+    }
+
+    @DisplayName("완료 주문 내역 조회 - 모든 필터가 null인 경우 (엣지 케이스)")
+    @Test
+    void getCompletedOrders_HandlesNullFilters_Successfully() throws Exception {
+        // Given
+        Long sellerId = 1L;
+        CompletedOrderPageResponse mockResponse = new CompletedOrderPageResponse(
+            new BbanglePageResponse<>(Collections.emptyList(), 0, 10, 0, 0L),
+            CompletedOrderStatusCounts.of(0, 0, 0, 0)
+        );
+
+        given(sellerOrderService.getCompletedOrders(any(CompletedOrderSearchCommand.class)))
+            .willReturn(mockResponse);
+
+        // When & Then
+        mvc.perform(get("/api/v1/seller/orders/completed")
+                .with(authentication(new UsernamePasswordAuthenticationToken(
+                    sellerId, "N/A", List.of(new SimpleGrantedAuthority("ROLE_SELLER")))))
+                .contentType(MediaType.APPLICATION_JSON)) // 파라미터 전혀 없이 호출
+            .andExpect(status().isOk());
+
+        then(sellerOrderService).should(times(1)).getCompletedOrders(any());
+    }
+
+    @DisplayName("완료 주문 내역 조회 - 서비스 내부 에러 발생 시 (엣지 케이스)")
+    @Test
+    void getCompletedOrders_ThrowsException_WhenServiceFails() throws Exception {
+        // Given
+        Long sellerId = 1L;
+        given(sellerOrderService.getCompletedOrders(any(CompletedOrderSearchCommand.class)))
+            .willThrow(new BbangleException(BbangleErrorCode.INTERNAL_SERVER_ERROR));
+
+        // When & Then
+        mvc.perform(get("/api/v1/seller/orders/completed")
+                .with(authentication(new UsernamePasswordAuthenticationToken(
+                    sellerId, "N/A", List.of(new SimpleGrantedAuthority("ROLE_SELLER")))))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().is5xxServerError())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value(BbangleErrorCode.INTERNAL_SERVER_ERROR.getCode()));
+
+        then(sellerOrderService).should(times(1)).getCompletedOrders(any());
+        then(globalControllerAdvice).should(times(1))
+            .handleBbangleException(any(HttpServletRequest.class), any(BbangleException.class));
+        then(responseService).should(times(1)).getFailResult(anyString(), anyInt());
+    }
+
+}

--- a/src/test/java/com/bbangle/bbangle/order/seller/controller/SellerOrderControllerSliceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/controller/SellerOrderControllerSliceTest.java
@@ -33,6 +33,8 @@ import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse.OrderSearchResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
 import com.bbangle.bbangle.order.seller.service.SellerOrderService;
+import com.bbangle.bbangle.claim.seller.service.SellerReturnService;
+import com.bbangle.bbangle.claim.seller.service.SellerExchangeService;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderSearchCommand;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDate;
@@ -79,6 +81,18 @@ class SellerOrderControllerSliceTest {
     @MockBean
     private SellerOrderService sellerOrderService;
 
+    @MockBean
+    private SellerReturnService sellerReturnService;
+
+    @MockBean
+    private SellerExchangeService sellerExchangeService;
+
+    /**
+     * [시나리오] 판매자가 발주 확인 요청 시 일부 항목만 처리 가능한 경우를 검증합니다.
+     * - 요청: orderItemIds [100, 101, 102] 3건
+     * - 서비스 응답(Mock): 100·102 성공, 101 실패 (부분 성공 정책)
+     * - 검증: HTTP 200, 응답 JSON 내 summary와 confirmedIds/failedIds 값 일치 여부
+     */
     @DisplayName("발주 확인 API - 성공")
     @Test
     void givenValidRequest_whenConfirmOrder_thenReturnsSuccess() throws Exception {
@@ -126,6 +140,12 @@ class SellerOrderControllerSliceTest {
         then(responseService).should(times(1)).getSingleResult(serviceResponse);
     }
 
+    /**
+     * [시나리오] 존재하지 않는 orderId로 발주 확인 요청 시 4xx 오류를 반환하는지 검증합니다.
+     * - 요청: orderId = -1 (존재하지 않는 ID)
+     * - 서비스 응답(Mock): ORDER_NOT_FOUND 예외 발생
+     * - 검증: HTTP 4xx, 응답 JSON 내 success=false 및 에러 코드·메시지 일치 여부
+     */
     @DisplayName("발주 확인 API - 실패(주문 없음)")
     @Test
     void givenNonExistingOrder_whenConfirmOrder_thenReturns4xx() throws Exception {
@@ -157,6 +177,12 @@ class SellerOrderControllerSliceTest {
         then(responseService).should(times(1)).getFailResult(anyString(), anyInt());
     }
 
+    /**
+     * [시나리오] orderItemIds가 빈 리스트인 경우 @Valid 검증에서 막혀 Service가 호출되지 않음을 검증합니다.
+     * - 요청: orderItemIds = [] (빈 배열)
+     * - 기대 동작: @NotEmpty 검증 실패로 400 응답 반환, Service 미호출
+     * - 검증: HTTP 400, sellerOrderService 미호출 여부
+     */
     @DisplayName("발주 확인 API - 실패(orderItemIds 비어있음 -> validation 400)")
     @Test
     void givenEmptyOrderItemIds_whenConfirmOrder_thenReturns400() throws Exception {
@@ -175,6 +201,12 @@ class SellerOrderControllerSliceTest {
         then(sellerOrderService).shouldHaveNoInteractions();
     }
 
+    /**
+     * [시나리오] 유효한 검색 조건으로 주문 목록을 요청할 때 빈 결과를 정상 반환하는지 검증합니다.
+     * - 요청: 날짜 범위·검색 조건 포함, page=0, size=20
+     * - 서비스 응답(Mock): 빈 주문 목록 (content=[])
+     * - 검증: HTTP 200, 페이지 메타 정보(page=0, size=20, totalPages=0, totalElements=0) 일치 여부
+     */
     @DisplayName("주문 검색 API - 성공")
     @Test
     void givenValidSearchRequest_whenSearchOrders_thenReturnsOrderList() throws Exception {
@@ -224,6 +256,12 @@ class SellerOrderControllerSliceTest {
         then(responseService).should(times(1)).getSingleResult(mockResponse);
     }
 
+    /**
+     * [시나리오] 주문 번호 "2503020013"으로 검색 시 일치하는 결과 1건이 반환되는지 검증합니다.
+     * - 요청: ORDER_NUMBER 검색 타입, 키워드 "2503020013"
+     * - 서비스 응답(Mock): 해당 주문번호의 주문 1건 (수취인 홍길동, 총액 24400)
+     * - 검증: HTTP 200, 첫 번째 항목의 orderNumber·recipientName·totalOrderPrice 값 일치 여부
+     */
     @DisplayName("주문 검색 API - 성공(검색 결과 있음)")
     @Test
     void givenValidSearchRequest_whenSearchOrders_thenReturnsOrderListWithData() throws Exception {

--- a/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceUnitTest.java
@@ -22,27 +22,35 @@ import com.bbangle.bbangle.order.domain.Order;
 import com.bbangle.bbangle.order.domain.OrderDelivery;
 import com.bbangle.bbangle.order.domain.OrderItem;
 import com.bbangle.bbangle.order.domain.model.CompletedOrderSearchType;
+import com.bbangle.bbangle.order.domain.model.CompletedOrderStatus;
 import com.bbangle.bbangle.order.domain.model.CourierCompany;
 import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
 import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.repository.OrderDeliveryRepository;
 import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.order.repository.OrderRepository;
+import com.bbangle.bbangle.order.seller.controller.dto.response.CompletedOrderResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.OrderResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.OrderConfirmResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.ShipmentModifyResponse;
 import com.bbangle.bbangle.order.seller.controller.dto.response.SellerOrderResponse.ShipmentRegisterResponse;
+import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.CompletedOrderSearchCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderConfirmCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderSearchCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentModifyCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.ShipmentRegisterCommand;
 import com.bbangle.bbangle.payment.domain.Payment;
+import com.bbangle.bbangle.payment.domain.PaymentMethod;
+import com.bbangle.bbangle.payment.domain.PaymentStatus;
 import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.store.domain.Store;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -789,6 +797,193 @@ class SellerOrderServiceUnitTest {
                 log.info("=== OrderItemDetailResponse (JSON) ===");
                 log.info(json);
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("완료 주문 목록 조회 (getCompletedOrders)")
+    class GetCompletedOrdersTest {
+
+        private CompletedOrderSearchCommand defaultCommand() {
+            return CompletedOrderSearchCommand.builder()
+                .sellerId(1L)
+                .pageable(PageRequest.of(0, 10))
+                .build();
+        }
+
+        @DisplayName("결제·배송 정보가 모두 있으면 모든 필드가 올바르게 매핑된다")
+        @Test
+        void givenFullPaymentAndDelivery_whenGetCompletedOrders_thenAllFieldsMapped() {
+            // given
+            Long orderItemId = 10L;
+            LocalDateTime paidAt = LocalDateTime.of(2025, 3, 1, 12, 0, 0);
+
+            Order order = OrderFixture.createDefaultOrder(); // totalAmount=50000, buyerName="홍길동"
+            ReflectionTestUtils.setField(order, "id", 1L);
+
+            OrderItem orderItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.PURCHASE_CONFIRMED);
+            ReflectionTestUtils.setField(orderItem, "id", orderItemId);
+            order.addOrderItem(orderItem);
+
+            // 결제 정보: CARD, 고정 paidAt
+            Payment payment = Payment.create(order, PaymentStatus.COMPLETED, PaymentMethod.CARD, paidAt);
+            ReflectionTestUtils.setField(order, "payment", payment);
+
+            // 수취인이 buyerName("홍길동")과 다른 배송 정보 → 배송 수취인 우선 사용 검증
+            Receiver receiver = Receiver.of("김철수", "010-0000-0000", null, null, null, null);
+            Shipping shipping = Shipping.of("CJ대한통운", "1234");
+            OrderDelivery delivery = OrderDelivery.create(null, receiver, shipping, OrderDeliveryStatus.DELIVERED, orderItem);
+
+            BbanglePageResponse<Order> orderPage = new BbanglePageResponse<>(List.of(order), 0, 10, 1, 1L);
+            CompletedOrderSearchCommand command = defaultCommand();
+
+            given(orderRepository.searchCompletedOrderList(command)).willReturn(orderPage);
+            given(orderRepository.countByCompletedOrderStatus(command)).willReturn(Collections.emptyMap());
+            given(orderDeliveryRepository.findLatestByOrderItemIds(List.of(orderItemId))).willReturn(List.of(delivery));
+
+            // when
+            CompletedOrderResponse.CompletedOrderPageResponse result = sut.getCompletedOrders(command);
+
+            // then
+            assertThat(result.orders().content()).hasSize(1);
+            CompletedOrderResponse.OrderSummary summary = result.orders().content().get(0);
+
+            assertThat(summary.totalAmount()).isEqualTo(50000L);
+            assertThat(summary.paymentMethod()).isEqualTo("신용/체크카드"); // PaymentMethod.CARD
+            assertThat(summary.recipient()).isEqualTo("김철수"); // buyerName("홍길동") 대신 배송 수취인 우선
+            assertThat(summary.paidAt()).isEqualTo(paidAt); // order.orderDate 대신 payment.paidAt 우선
+            assertThat(summary.orderItems()).hasSize(1);
+
+            CompletedOrderResponse.OrderSummary.OrderItem item = summary.orderItems().get(0);
+            assertThat(item.unitPrice()).isEqualTo(25000L); // OrderItemFixture 기본 unitPrice
+            assertThat(item.deliveryStatus()).isEqualTo("배송완료"); // OrderDeliveryStatus.DELIVERED
+            assertThat(item.deliveryCompany()).isEqualTo("CJ대한통운");
+            assertThat(item.status()).isEqualTo(CompletedOrderStatus.PURCHASED); // PURCHASE_CONFIRMED → PURCHASED
+
+            log.info("=== CompletedOrderResponse (JSON) ===");
+            try {
+                ObjectMapper objectMapper = new ObjectMapper();
+                objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+                String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(summary);
+                log.info(json);
+            } catch (Exception e) {
+                log.error("JSON 직렬화 실패", e);
+            }
+        }
+
+        @DisplayName("결제 정보가 없으면 paidAt은 주문일로 대체되고 paymentMethod는 null이다")
+        @Test
+        void givenNoPayment_whenGetCompletedOrders_thenFallsBackToOrderDate() {
+            // given
+            Order order = OrderFixture.createDefaultOrder(); // orderDate=2025-01-01T10:00, buyerName="홍길동"
+            ReflectionTestUtils.setField(order, "id", 1L);
+
+            OrderItem orderItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.PURCHASE_CONFIRMED);
+            ReflectionTestUtils.setField(orderItem, "id", 10L);
+            order.addOrderItem(orderItem);
+            // payment 미설정 → order.getPayment() == null
+
+            BbanglePageResponse<Order> orderPage = new BbanglePageResponse<>(List.of(order), 0, 10, 1, 1L);
+            CompletedOrderSearchCommand command = defaultCommand();
+
+            given(orderRepository.searchCompletedOrderList(command)).willReturn(orderPage);
+            given(orderRepository.countByCompletedOrderStatus(command)).willReturn(Collections.emptyMap());
+            given(orderDeliveryRepository.findLatestByOrderItemIds(List.of(10L))).willReturn(Collections.emptyList());
+
+            // when
+            CompletedOrderResponse.CompletedOrderPageResponse result = sut.getCompletedOrders(command);
+
+            // then
+            CompletedOrderResponse.OrderSummary summary = result.orders().content().get(0);
+            assertThat(summary.paymentMethod()).isNull(); // 결제 정보 없음 → null
+            assertThat(summary.paidAt()).isEqualTo(order.getOrderDate()); // payment 없음 → 주문일로 fallback
+            assertThat(summary.recipient()).isEqualTo("홍길동"); // 배송 없음 → buyerName fallback
+        }
+
+        @DisplayName("배송 정보가 없으면 recipient는 buyerName, 배송 관련 필드는 null이다")
+        @Test
+        void givenNoDelivery_whenGetCompletedOrders_thenDeliveryFieldsAreNull() {
+            // given
+            Order order = OrderFixture.createDefaultOrder(); // buyerName="홍길동"
+            ReflectionTestUtils.setField(order, "id", 1L);
+
+            OrderItem orderItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.PURCHASE_CONFIRMED);
+            ReflectionTestUtils.setField(orderItem, "id", 10L);
+            order.addOrderItem(orderItem);
+
+            Payment payment = Payment.create(order, PaymentStatus.COMPLETED, PaymentMethod.CARD, LocalDateTime.now());
+            ReflectionTestUtils.setField(order, "payment", payment);
+
+            BbanglePageResponse<Order> orderPage = new BbanglePageResponse<>(List.of(order), 0, 10, 1, 1L);
+            CompletedOrderSearchCommand command = defaultCommand();
+
+            given(orderRepository.searchCompletedOrderList(command)).willReturn(orderPage);
+            given(orderRepository.countByCompletedOrderStatus(command)).willReturn(Collections.emptyMap());
+            // deliveryMap 비어있음 → firstDelivery=null, itemDelivery=null
+            given(orderDeliveryRepository.findLatestByOrderItemIds(List.of(10L))).willReturn(Collections.emptyList());
+
+            // when
+            CompletedOrderResponse.CompletedOrderPageResponse result = sut.getCompletedOrders(command);
+
+            // then
+            CompletedOrderResponse.OrderSummary summary = result.orders().content().get(0);
+            assertThat(summary.recipient()).isEqualTo("홍길동"); // 배송 수취인 없음 → buyerName 사용
+
+            CompletedOrderResponse.OrderSummary.OrderItem item = summary.orderItems().get(0);
+            assertThat(item.deliveryStatus()).isNull(); // OrderDelivery 없음
+            assertThat(item.deliveryCompany()).isNull();
+            assertThat(item.trackingNumber()).isNull();
+        }
+
+        @DisplayName("statusCounts는 OrderStatus 그룹별로 카운트를 올바르게 집계한다")
+        @Test
+        void givenStatusCountMap_whenGetCompletedOrders_thenAggregatesCountsByGroup() {
+            // given
+            CompletedOrderSearchCommand command = defaultCommand();
+            BbanglePageResponse<Order> emptyPage = new BbanglePageResponse<>(Collections.emptyList(), 0, 10, 0, 0L);
+
+            // PURCHASE_CONFIRMED=3, CANCEL_APPROVED=2 (CANCELLED_GROUP), RETURN_APPROVED=1 (RETURNED_GROUP)
+            Map<OrderStatus, Long> statusCountMap = new EnumMap<>(OrderStatus.class);
+            statusCountMap.put(OrderStatus.PURCHASE_CONFIRMED, 3L);
+            statusCountMap.put(OrderStatus.CANCEL_APPROVED, 2L);
+            statusCountMap.put(OrderStatus.RETURN_APPROVED, 1L);
+
+            given(orderRepository.searchCompletedOrderList(command)).willReturn(emptyPage);
+            given(orderRepository.countByCompletedOrderStatus(command)).willReturn(statusCountMap);
+
+            // when
+            CompletedOrderResponse.CompletedOrderPageResponse result = sut.getCompletedOrders(command);
+
+            // then
+            CompletedOrderResponse.CompletedOrderStatusCounts counts = result.statusCounts();
+            assertThat(counts.purchased()).isEqualTo(3L); // PURCHASE_CONFIRMED=3
+            assertThat(counts.canceled()).isEqualTo(2L);  // CANCELLED_GROUP 합산 (CANCEL_APPROVED=2)
+            assertThat(counts.returned()).isEqualTo(1L);  // RETURNED_GROUP 합산 (RETURN_APPROVED=1)
+            assertThat(counts.exchanged()).isEqualTo(0L); // EXCHANGED_GROUP 없음 → 0
+            assertThat(counts.total()).isEqualTo(6L);     // 3+2+1+0
+        }
+
+        @DisplayName("조회 결과가 없으면 빈 content와 모든 count가 0인 응답이 반환된다")
+        @Test
+        void givenEmptyResult_whenGetCompletedOrders_thenReturnsEmptyWithZeroCounts() {
+            // given
+            CompletedOrderSearchCommand command = defaultCommand();
+            BbanglePageResponse<Order> emptyPage = new BbanglePageResponse<>(Collections.emptyList(), 0, 10, 0, 0L);
+
+            given(orderRepository.searchCompletedOrderList(command)).willReturn(emptyPage);
+            given(orderRepository.countByCompletedOrderStatus(command)).willReturn(Collections.emptyMap());
+
+            // when
+            CompletedOrderResponse.CompletedOrderPageResponse result = sut.getCompletedOrders(command);
+
+            // then
+            assertThat(result.orders().content()).isEmpty();
+            CompletedOrderResponse.CompletedOrderStatusCounts counts = result.statusCounts();
+            assertThat(counts.total()).isEqualTo(0L);
+            assertThat(counts.purchased()).isEqualTo(0L);
+            assertThat(counts.canceled()).isEqualTo(0L);
+            assertThat(counts.returned()).isEqualTo(0L);
+            assertThat(counts.exchanged()).isEqualTo(0L);
         }
     }
 }


### PR DESCRIPTION
## History
* Resolves #622

## 🚀 Major Changes & Explanations
- 판매자 완료 주문 목록 조회 API 구현 (구매확정·취소·반품·교환 페이징 + 상태별 카운트)
  - SellerOrderService: 완료 상태 주문 필터링 및 페이징 처리 로직 추가
  - OrderDSLRepositoryImpl: 완료 주문 조회용 QueryDSL 쿼리 구현
  - SellerOrderController: 완료 주문 목록 조회 엔드포인트 추가
  - CompletedOrderResponse: 완료 주문 응답 DTO 추가
  - SellerOrderCommand: 완료 주문 관련 커맨드 모델 추가
- 판매자 완료 주문 목록 조회 API 테스트 추가
  - SellerOrderCompletedControllerSliceTest: 컨트롤러 슬라이스 테스트
  - SellerOrderCompletedApiIntegrationTest: 통합 테스트

## 📷 Test Image

## 💡 ETC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 완료된 주문 전용 조회 탭 추가: 상태별 카운트, 필터(기간·상태) 및 페이징/정렬 지원
  - 주문 요약에 결제금액·결제수단·상품 배송상태 노출
  - 주문 검색 고도화: 주문번호·구매자명·상품명·운송장 기반 키워드 검색

- **버그 수정**
  - 주문 확인·배송 등록 등에서 항목별 부분 처리 개선(실패 항목 격리)

- **테스트**
  - 완료된 주문 API 및 컨트롤러용 통합/슬라이스 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->