### PR TITLE
[Feat] (어드민) 업로드상품조회 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/AdminBoardController.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/AdminBoardController.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.board.admin.controller;
 
 import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
 import com.bbangle.bbangle.board.admin.controller.dto.AdminRemoveProductRequest;
+import com.bbangle.bbangle.board.admin.controller.dto.UploadApprovalResponse;
 import com.bbangle.bbangle.board.admin.controller.swagger.AdminBoardApi;
 import com.bbangle.bbangle.board.admin.service.AdminBoardService;
 import com.bbangle.bbangle.board.admin.service.dto.RemoveProductsCommand;
@@ -13,6 +14,7 @@ import com.bbangle.bbangle.config.security.AdminApiPath;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -61,4 +63,16 @@ public class AdminBoardController implements AdminBoardApi {
         adminBoardService.deleteProducts(command);
         return responseService.getSuccessResult();
     }
+
+    @Override
+    @GetMapping("/upload-approvals")
+    public SingleResult<BbanglePageResponse<UploadApprovalResponse>> getUploadApprovals(
+        @ParameterObject
+        @PageableDefault(size = 20, page = 0, sort = "createdAt", direction = Sort.Direction.DESC)
+        Pageable pageable
+    ) {
+        Page<UploadApprovalResponse> result = adminBoardService.getUploadApprovals(pageable);
+        return responseService.getSingleResult(BbanglePageResponse.of(result));
+    }
+
 }

--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/dto/UploadApprovalResponse.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/dto/UploadApprovalResponse.java
@@ -1,0 +1,25 @@
+package com.bbangle.bbangle.board.admin.controller.dto;
+
+import com.bbangle.bbangle.board.domain.Board;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "업로드 승인 대기 상품 조회 응답")
+public record UploadApprovalResponse(
+    @Schema(description = "상품(게시글) ID", example = "101")
+    Long boardId,
+
+    @Schema(description = "스토어명", example = "빠진 빵집")
+    String storeName,
+
+    @Schema(description = "상품명", example = "촉촉한 허니버터 식빵 3종 세트")
+    String boardTitle
+) {
+
+  public static UploadApprovalResponse fromEntity(Board board) {
+    return new UploadApprovalResponse(
+        board.getId(),
+        board.getStore().getName(),
+        board.getTitle()
+    );
+  }
+}

--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/swagger/AdminBoardApi.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/swagger/AdminBoardApi.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.board.admin.controller.swagger;
 
 import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
 import com.bbangle.bbangle.board.admin.controller.dto.AdminRemoveProductRequest;
+import com.bbangle.bbangle.board.admin.controller.dto.UploadApprovalResponse;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.page.BbanglePageResponse;
@@ -42,4 +43,13 @@ public interface AdminBoardApi {
         Long productId,
         @Valid AdminRemoveProductRequest request
     );
+
+    @Operation(
+        summary = "업로드 상품 승인 대기 목록 조회",
+        description = "판매자가 업로드한 승인 대기(PENDING) 상태의 상품 목록을 페이지네이션으로 조회합니다."
+    )
+    SingleResult<BbanglePageResponse<UploadApprovalResponse>> getUploadApprovals(
+        @ParameterObject Pageable pageable
+    );
+    
 }

--- a/src/main/java/com/bbangle/bbangle/board/admin/service/AdminBoardService.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/service/AdminBoardService.java
@@ -1,8 +1,10 @@
 package com.bbangle.bbangle.board.admin.service;
 
 import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
+import com.bbangle.bbangle.board.admin.controller.dto.UploadApprovalResponse;
 import com.bbangle.bbangle.board.admin.service.dto.RemoveProductsCommand;
 import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.SaleStatus;
 import com.bbangle.bbangle.board.repository.BoardDetailRepository;
 import com.bbangle.bbangle.board.repository.BoardRepository;
 import com.bbangle.bbangle.board.repository.ProductImgRepository;
@@ -50,5 +52,10 @@ public class AdminBoardService {
         } else {
             productRepository.softDeleteByProductIds(command.productIds());
         }
+    }
+
+    public Page<UploadApprovalResponse> getUploadApprovals(Pageable pageable) {
+        Page<Board> boards = boardRepository.findBySaleStatusAndIsDeletedFalse(SaleStatus.PENDING, pageable);
+        return boards.map(UploadApprovalResponse::fromEntity);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/board/repository/BoardRepository.java
+++ b/src/main/java/com/bbangle/bbangle/board/repository/BoardRepository.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.board.repository;
 
 import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.SaleStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -9,8 +10,6 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-
-import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long>, BoardQueryDSLRepository {
 
@@ -22,6 +21,9 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardQueryD
 
     @EntityGraph(attributePaths = {"boardStatistic"})
     Page<Board> findByIsCrawlingTrueAndIsDeletedFalse(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"store", "boardStatistic"})
+    Page<Board> findBySaleStatusAndIsDeletedFalse(SaleStatus saleStatus, Pageable pageable);
 
     @Modifying(clearAutomatically = true)
     @Query("""

--- a/src/test/java/com/bbangle/bbangle/board/admin/controller/AdminBoardControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/admin/controller/AdminBoardControllerTest.java
@@ -11,7 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
+import com.bbangle.bbangle.board.admin.controller.dto.UploadApprovalResponse;
 import com.bbangle.bbangle.board.admin.service.AdminBoardService;
+import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
 import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.common.service.ResponseService;
@@ -21,6 +23,7 @@ import com.bbangle.bbangle.config.security.SecurityConfig;
 import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
 import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.fixture.board.admin.controller.dto.AdminProductResponseFixture;
+import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,6 +39,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import com.bbangle.bbangle.common.dto.SingleResult;
 
 @DisplayName("[컨트롤러 테스트] AdminBoardController")
 @Import({
@@ -163,6 +167,91 @@ class AdminBoardControllerTest {
 
         then(adminBoardService).should().deleteBoards(productIds);
         then(responseService).should().getSuccessResult();
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("[업로드 승인 대기] 관리자는 업로드 대기 상품을 페이징 형태로 조회할 수 있다")
+    void getUploadApprovals_success() throws Exception {
+        // given
+        int page = 0;
+        int size = 20;
+
+        Board board = BoardFixture.defaultBoard();
+        UploadApprovalResponse response = new UploadApprovalResponse(
+            board.getId(),
+            board.getStore().getName(),
+            board.getTitle()
+        );
+        Page<UploadApprovalResponse> pageResult =
+            new PageImpl<>(List.of(response), PageRequest.of(page, size), 1);
+
+        given(adminBoardService.getUploadApprovals(any(Pageable.class)))
+            .willReturn(pageResult);
+
+        // when & then
+        mvc.perform(get(AdminApiPath.PREFIX + "/products/upload-approvals")
+                .param("page", String.valueOf(page))
+                .param("size", String.valueOf(size))
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(0))
+            .andExpect(jsonPath("$.result.content.length()").value(1))
+            .andExpect(jsonPath("$.result.content[0].boardId").value(board.getId()))
+            .andExpect(jsonPath("$.result.content[0].storeName").value(board.getStore().getName()))
+            .andExpect(jsonPath("$.result.content[0].boardTitle").value(board.getTitle()))
+            .andExpect(jsonPath("$.result.page").value(page))
+            .andExpect(jsonPath("$.result.size").value(size))
+            .andExpect(jsonPath("$.result.totalPages").value(1))
+            .andExpect(jsonPath("$.result.totalElements").value(1));
+
+        then(adminBoardService).should().getUploadApprovals(any(Pageable.class));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("[업로드 승인 대기] 조회 결과가 없으면 빈 목록을 반환한다")
+    void getUploadApprovals_emptyResult() throws Exception {
+        // given
+        int page = 0;
+        int size = 20;
+
+        Page<UploadApprovalResponse> emptyPage =
+            new PageImpl<>(List.of(), PageRequest.of(page, size), 0);
+
+        given(adminBoardService.getUploadApprovals(any(Pageable.class)))
+            .willReturn(emptyPage);
+
+        // when & then
+        mvc.perform(get(AdminApiPath.PREFIX + "/products/upload-approvals")
+                .param("page", String.valueOf(page))
+                .param("size", String.valueOf(size))
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(0))
+            .andExpect(jsonPath("$.result.content.length()").value(0))
+            .andExpect(jsonPath("$.result.page").value(page))
+            .andExpect(jsonPath("$.result.size").value(size))
+            .andExpect(jsonPath("$.result.totalPages").value(0))
+            .andExpect(jsonPath("$.result.totalElements").value(0));
+
+        then(adminBoardService).should().getUploadApprovals(any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("[업로드 승인 대기] ADMIN 권한이 없으면 접근에 실패한다")
+    void getUploadApprovals_fail_whenNoAdminRole() throws Exception {
+        // when & then
+        mvc.perform(get(AdminApiPath.PREFIX + "/products/upload-approvals")
+                .param("page", "0")
+                .param("size", "20")
+            )
+            .andExpect(status().isUnauthorized());
+
+        then(adminBoardService).shouldHaveNoInteractions();
+        then(responseService).shouldHaveNoInteractions();
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/board/admin/service/AdminBoardServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/admin/service/AdminBoardServiceIntegrationTest.java
@@ -3,13 +3,14 @@ package com.bbangle.bbangle.board.admin.service;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
+import com.bbangle.bbangle.board.admin.controller.dto.UploadApprovalResponse;
 import com.bbangle.bbangle.board.admin.service.dto.RemoveProductsCommand;
 import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.domain.Product;
 import com.bbangle.bbangle.board.repository.BoardRepository;
 import com.bbangle.bbangle.board.repository.ProductRepository;
-import com.bbangle.bbangle.fixture.board.domain.ProductFixture;
 import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
+import com.bbangle.bbangle.fixture.board.domain.ProductFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.repository.StoreRepository;
@@ -221,6 +222,132 @@ class AdminBoardServiceIntegrationTest {
         assertThat(deletedProduct1.isDeleted()).isTrue();
         assertThat(deletedProduct2.isDeleted()).isTrue();
         assertThat(keptProduct.isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("업로드 상품 조회는 PENDING 상태만 필터링된다")
+    void getUploadApprovals_filtersByPendingStatus() {
+        // given
+        Store store = storeRepository.save(StoreFixture.defaultStore());
+
+        Board pending1 = BoardFixture.pendingBoardWithStore(store, "승인대기상품1");
+        Board pending2 = BoardFixture.pendingBoardWithStore(store, "승인대기상품2");
+        Board outOfStock = BoardFixture.outOfStockBoardWithStore(store, "품절상품");
+        Board stopped = BoardFixture.stoppedBoardWithStore(store, "판매중지상품");
+        Board banned = BoardFixture.bannedBoardWithStore(store, "판매금지상품");
+
+        boardRepository.saveAll(List.of(pending1, pending2, outOfStock, stopped, banned));
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<UploadApprovalResponse> result = adminBoardService.getUploadApprovals(pageable);
+
+        // then
+        assertThat(result.getContent())
+            .hasSize(2)
+            .extracting(UploadApprovalResponse::boardTitle)
+            .containsExactlyInAnyOrder("승인대기상품1", "승인대기상품2");
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("업로드 상품 조회는 삭제된 상품을 제외한다")
+    void getUploadApprovals_excludesDeleted() {
+        // given
+        Store store = storeRepository.save(StoreFixture.defaultStore());
+
+        Board pending = BoardFixture.pendingBoardWithStore(store, "정상_승인대기");
+        boardRepository.save(pending);
+
+        // 삭제된 PENDING 상품 생성
+        Board pendingDeleted = BoardFixture.pendingBoardWithStore(store, "삭제된_승인대기");
+        boardRepository.save(pendingDeleted);
+        org.springframework.test.util.ReflectionTestUtils.setField(pendingDeleted, "isDeleted", true);
+        boardRepository.saveAndFlush(pendingDeleted);
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<UploadApprovalResponse> result = adminBoardService.getUploadApprovals(pageable);
+
+        // then
+        assertThat(result.getContent())
+            .hasSize(1)
+            .extracting(UploadApprovalResponse::boardTitle)
+            .contains("정상_승인대기");
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("업로드 상품 조회는 페이지네이션을 지원한다")
+    void getUploadApprovals_respectsPagination() {
+        // given
+        Store store = storeRepository.save(StoreFixture.defaultStore());
+
+        for (int i = 0; i < 15; i++) {
+            boardRepository.save(BoardFixture.pendingBoardWithStore(store, "상품" + i));
+        }
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<UploadApprovalResponse> result = adminBoardService.getUploadApprovals(pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(10);
+        assertThat(result.getTotalElements()).isEqualTo(15);
+        assertThat(result.getTotalPages()).isEqualTo(2);
+        assertThat(result.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("업로드 상품 조회는 생성일자 역순으로 정렬된다")
+    void getUploadApprovals_sortsByCreatedAtDesc() {
+        // given
+        Store store = storeRepository.save(StoreFixture.defaultStore());
+
+        Board older = boardRepository.save(BoardFixture.pendingBoardWithStore(store, "오래된상품"));
+        Board newer = boardRepository.save(BoardFixture.pendingBoardWithStore(store, "최신상품"));
+
+        Pageable pageable = PageRequest.of(0, 10, org.springframework.data.domain.Sort.by("createdAt").descending());
+
+        // when
+        Page<UploadApprovalResponse> result = adminBoardService.getUploadApprovals(pageable);
+
+        // then
+        assertThat(result.getContent())
+            .hasSize(2)
+            .extracting(UploadApprovalResponse::boardTitle)
+            .containsExactly("최신상품", "오래된상품");
+    }
+
+    @Test
+    @DisplayName("조회 대상이 되는 상품이 없으면 빈 페이지를 반환한다")
+    void getUploadApprovals_emptyWhenNoValidBoards() {
+        // given
+        Store store = storeRepository.save(StoreFixture.defaultStore());
+
+        boardRepository.saveAll(
+            List.of(
+                BoardFixture.outOfStockBoardWithStore(store, "품절상품"),
+                BoardFixture.stoppedBoardWithStore(store, "판매중지상품"),
+                BoardFixture.bannedBoardWithStore(store, "판매금지상품")
+            )
+        );
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<UploadApprovalResponse> result = adminBoardService.getUploadApprovals(pageable);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        assertThat(result.getTotalPages()).isZero();
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/board/admin/service/AdminBoardServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/admin/service/AdminBoardServiceUnitTest.java
@@ -5,8 +5,10 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import com.bbangle.bbangle.board.admin.controller.dto.AdminProductResponse;
+import com.bbangle.bbangle.board.admin.controller.dto.UploadApprovalResponse;
 import com.bbangle.bbangle.board.admin.service.dto.RemoveProductsCommand;
 import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.SaleStatus;
 import com.bbangle.bbangle.board.repository.BoardDetailRepository;
 import com.bbangle.bbangle.board.repository.BoardRepository;
 import com.bbangle.bbangle.board.repository.ProductImgRepository;
@@ -146,6 +148,54 @@ class AdminBoardServiceUnitTest {
         // then
         then(productRepository).should().softDeleteByProductIds(productIds);
         then(productRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("업로드 대기 상품을 페이징 형태로 조회한다")
+    void getUploadApprovals_success() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        Board board = BoardFixture.defaultBoard();
+        Page<Board> boardPage = new PageImpl<>(List.of(board), pageable, 1);
+
+        given(boardRepository.findBySaleStatusAndIsDeletedFalse(SaleStatus.PENDING, pageable))
+            .willReturn(boardPage);
+
+        // when
+        Page<UploadApprovalResponse> result = sut.getUploadApprovals(pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+
+        UploadApprovalResponse response = result.getContent().get(0);
+        assertThat(response.boardId()).isEqualTo(board.getId());
+        assertThat(response.boardTitle()).isEqualTo(board.getTitle());
+        assertThat(response.storeName()).isEqualTo(board.getStore().getName());
+
+        assertThat(result.getNumber()).isEqualTo(0);
+        assertThat(result.getSize()).isEqualTo(20);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        then(boardRepository).should().findBySaleStatusAndIsDeletedFalse(SaleStatus.PENDING, pageable);
+    }
+
+    @Test
+    @DisplayName("업로드 대기 상품 조회 결과가 없으면 빈 Page를 반환한다")
+    void getUploadApprovals_emptyResult() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Board> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+        given(boardRepository.findBySaleStatusAndIsDeletedFalse(SaleStatus.PENDING, pageable))
+            .willReturn(emptyPage);
+
+        // when
+        Page<UploadApprovalResponse> result = sut.getUploadApprovals(pageable);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        then(boardRepository).should().findBySaleStatusAndIsDeletedFalse(SaleStatus.PENDING, pageable);
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/board/repository/BoardRepositoryDataJpaTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/repository/BoardRepositoryDataJpaTest.java
@@ -1,0 +1,214 @@
+package com.bbangle.bbangle.board.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bbangle.bbangle.TestContainersConfig;
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.SaleStatus;
+import com.bbangle.bbangle.config.QueryDslConfig;
+import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
+import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.search.repository.component.SearchFilter;
+import com.bbangle.bbangle.search.repository.component.SearchSort;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.repository.StoreRepository;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("[Repository] BoardRepository")
+@Import({
+    TestContainersConfig.class,
+    QueryDslConfig.class,
+    SearchFilter.class,
+    SearchSort.class
+})
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BoardRepositoryDataJpaTest {
+
+    @Autowired
+    private BoardRepository sut;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Nested
+    @DisplayName("findBySaleStatusAndIsDeletedFalse")
+    class FindBySaleStatusAndIsDeletedFalseTests {
+
+        private Store store;
+
+        @BeforeEach
+        void setUp() {
+            store = storeRepository.save(StoreFixture.defaultStore());
+            em.flush();
+            em.clear();
+        }
+
+        @Test
+        @DisplayName("다양한 SaleStatus 중 PENDING만 반환한다")
+        void given_multipleSaleStatuses_when_findBySaleStatusPending_then_returnOnlyPendingBoards() {
+            // given
+            Board pendingBoard = sut.save(BoardFixture.pendingBoardWithStore(store, "pending1"));
+            sut.save(BoardFixture.outOfStockBoardWithStore(store, "outOfStock1"));
+            sut.save(BoardFixture.stoppedBoardWithStore(store, "stopped1"));
+            sut.save(BoardFixture.bannedBoardWithStore(store, "banned1"));
+
+            em.flush();
+            em.clear();
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Board> result = sut.findBySaleStatusAndIsDeletedFalse(SaleStatus.PENDING, pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).getId()).isEqualTo(pendingBoard.getId());
+            assertThat(result.getTotalElements()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("삭제된 상품은 제외하고 활성 상품만 반환한다")
+        void given_deletedAndActivePendingBoards_when_findBySaleStatusPending_then_excludeDeletedBoards() {
+            // given - Active PENDING 2개 생성
+            Board activePending1 = sut.save(BoardFixture.pendingBoardWithStore(store, "active1"));
+            Board activePending2 = sut.save(BoardFixture.pendingBoardWithStore(store, "active2"));
+
+            // Deleted PENDING 2개 생성
+            Board deletedPending1 = BoardFixture.pendingBoardWithStore(store, "deleted1");
+            ReflectionTestUtils.setField(deletedPending1, "isDeleted", true);
+            sut.save(deletedPending1);
+
+            Board deletedPending2 = BoardFixture.pendingBoardWithStore(store, "deleted2");
+            ReflectionTestUtils.setField(deletedPending2, "isDeleted", true);
+            sut.save(deletedPending2);
+
+            em.flush();
+            em.clear();
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Board> result = sut.findBySaleStatusAndIsDeletedFalse(SaleStatus.PENDING, pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.getContent()).extracting(Board::getId)
+                .containsExactlyInAnyOrder(activePending1.getId(), activePending2.getId());
+            assertThat(result.getTotalElements()).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("페이지네이션이 올바르게 적용된다")
+        void given_moreThanPageSize_when_findBySaleStatusWithPageable_then_applyPagination() {
+            // given - 15개의 PENDING 상품 생성
+            List<Board> boards = new ArrayList<>();
+            for (int i = 0; i < 15; i++) {
+                boards.add(sut.save(BoardFixture.pendingBoardWithStore(store, "pending" + i)));
+            }
+
+            em.flush();
+            em.clear();
+
+            // when - page=0, size=10
+            Page<Board> firstPage = sut.findBySaleStatusAndIsDeletedFalse(
+                SaleStatus.PENDING,
+                PageRequest.of(0, 10)
+            );
+
+            // then
+            assertThat(firstPage.getContent()).hasSize(10);
+            assertThat(firstPage.getTotalElements()).isEqualTo(15L);
+            assertThat(firstPage.getTotalPages()).isEqualTo(2);
+            assertThat(firstPage.hasNext()).isTrue();
+            assertThat(firstPage.hasPrevious()).isFalse();
+
+            // when - page=1, size=10
+            Page<Board> secondPage = sut.findBySaleStatusAndIsDeletedFalse(
+                SaleStatus.PENDING,
+                PageRequest.of(1, 10)
+            );
+
+            // then
+            assertThat(secondPage.getContent()).hasSize(5);
+            assertThat(secondPage.getTotalElements()).isEqualTo(15L);
+            assertThat(secondPage.hasNext()).isFalse();
+            assertThat(secondPage.hasPrevious()).isTrue();
+        }
+
+        @Test
+        @DisplayName("해당 상태의 상품이 없을 때 빈 Page를 반환한다")
+        void given_noPendingBoards_when_findBySaleStatusPending_then_returnEmptyPage() {
+            // given
+            sut.save(BoardFixture.outOfStockBoardWithStore(store, "outOfStock1"));
+            sut.save(BoardFixture.stoppedBoardWithStore(store, "stopped1"));
+            sut.save(BoardFixture.bannedBoardWithStore(store, "banned1"));
+
+            em.flush();
+            em.clear();
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Board> result = sut.findBySaleStatusAndIsDeletedFalse(SaleStatus.PENDING, pageable);
+
+            // then
+            assertThat(result.isEmpty()).isTrue();
+            assertThat(result.getTotalElements()).isEqualTo(0L);
+            assertThat(result.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("createdAt 기준으로 내림차순 정렬된다")
+        void given_multipleBoards_when_findBySaleStatusWithPageableSortByCreatedAt_then_orderByCreatedAtDesc() {
+            // given - 생성 시간차가 있는 5개 상품
+            List<Board> boards = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                boards.add(sut.save(BoardFixture.pendingBoardWithStore(store, "pending" + i)));
+                try {
+                    Thread.sleep(10);  // 생성 시간 간격
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            em.flush();
+            em.clear();
+
+            Pageable pageable = PageRequest.of(0, 10, Sort.by(Order.desc("createdAt")));
+
+            // when
+            Page<Board> result = sut.findBySaleStatusAndIsDeletedFalse(SaleStatus.PENDING, pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(5);
+            // 역순으로 정렬되어야 함 (가장 최신이 먼저)
+            assertThat(result.getContent().get(0).getId()).isEqualTo(boards.get(4).getId());
+            assertThat(result.getContent().get(1).getId()).isEqualTo(boards.get(3).getId());
+            assertThat(result.getContent().get(2).getId()).isEqualTo(boards.get(2).getId());
+            assertThat(result.getContent().get(3).getId()).isEqualTo(boards.get(1).getId());
+            assertThat(result.getContent().get(4).getId()).isEqualTo(boards.get(0).getId());
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/fixture/board/domain/BoardFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/board/domain/BoardFixture.java
@@ -102,4 +102,48 @@ public final class BoardFixture {
         ReflectionTestUtils.setField(board, "isDeleted", true);
         return board;
     }
+
+    /* =====================
+       SaleStatus 관련 메서드
+     ===================== */
+
+    /**
+     * 판매대기(PENDING) 상태 Board saleStatus = PENDING, isDeleted = false
+     */
+    public static Board pendingBoardWithStore(Store store, String title) {
+        Board board = baseBuilder(store, title).build();
+        ReflectionTestUtils.setField(board, "saleStatus", SaleStatus.PENDING);
+        ReflectionTestUtils.setField(board, "isDeleted", false);
+        return board;
+    }
+
+    /**
+     * 품절(OUT_OF_STOCK) 상태 Board saleStatus = OUT_OF_STOCK, isDeleted = false
+     */
+    public static Board outOfStockBoardWithStore(Store store, String title) {
+        Board board = baseBuilder(store, title).build();
+        ReflectionTestUtils.setField(board, "saleStatus", SaleStatus.OUT_OF_STOCK);
+        ReflectionTestUtils.setField(board, "isDeleted", false);
+        return board;
+    }
+
+    /**
+     * 판매중지(STOPPED) 상태 Board saleStatus = STOPPED, isDeleted = false
+     */
+    public static Board stoppedBoardWithStore(Store store, String title) {
+        Board board = baseBuilder(store, title).build();
+        ReflectionTestUtils.setField(board, "saleStatus", SaleStatus.STOPPED);
+        ReflectionTestUtils.setField(board, "isDeleted", false);
+        return board;
+    }
+
+    /**
+     * 판매금지(BANNED) 상태 Board saleStatus = BANNED, isDeleted = false
+     */
+    public static Board bannedBoardWithStore(Store store, String title) {
+        Board board = baseBuilder(store, title).build();
+        ReflectionTestUtils.setField(board, "saleStatus", SaleStatus.BANNED);
+        ReflectionTestUtils.setField(board, "isDeleted", false);
+        return board;
+    }
 }


### PR DESCRIPTION
## 📋 History

업로드상품 조회 API 구현 및 3단계 테스트(Repository/Service/Controller) 작성을 완료했습니다.

## 🚀 Major Changes & Explanations

### API 엔드포인트 구현
- **Endpoint**: `GET /api/v1/admin/products/upload-approvals`
- **기능**: 관리자가 판매중 대기(PENDING) 상태의 상품을 페이징 조회
- **응답**: UploadApprovalResponse (boardId, storeName, boardTitle)

### 파일 변경 사항

#### 1️⃣ AdminBoardApi (신규)
- `getUploadApprovals(Pageable pageable)` 메서드 추가
- Swagger 어노테이션 추가

#### 2️⃣ AdminBoardController (수정)
- `/products/upload-approvals` 엔드포인트 구현
- AdminBoardApi 구현

#### 3️⃣ AdminBoardService (수정)
- `getUploadApprovals(Pageable pageable)` 메서드 추가
- SaleStatus.PENDING 필터링 로직

#### 4️⃣ BoardRepository (수정)
- JPA 쿼리 메서드: `findBySaleStatusAndIsDeletedFalse(SaleStatus, Pageable)`
- @EntityGraph 적용으로 N+1 문제 해결

#### 5️⃣ UploadApprovalResponse DTO (신규)
- boardId, storeName, boardTitle 필드

### 테스트 작성 (3단계 - 모두 완료 ✅)

#### Phase 1: BoardRepositoryDataJpaTest (c831d3b2)
- **테스트 메서드**: 5개
  - 다중 SaleStatus 중 PENDING만 반환 검증
  - 삭제된 상품 제외 검증
  - 페이지네이션 정확성 검증
  - 빈 결과 반환 검증
  - createdAt DESC 정렬 검증

#### Phase 2: AdminBoardServiceUnitTest (ceef04f6)
- **테스트 메서드**: 2개
  - getUploadApprovals 성공 케이스
  - 빈 Page 반환 케이스

#### Phase 3: AdminBoardControllerTest (96c34318)
- **테스트 메서드**: 3개
  - 200 OK 응답 및 페이지네이션 검증
  - 빈 배열 반환 검증
  - 어드민 권한 검증 (401 Unauthorized)

### 테스트 결과
```
✅ BoardRepositoryDataJpaTest - 5/5 통과
✅ AdminBoardServiceUnitTest - 2/2 통과  
✅ AdminBoardControllerTest - 3/3 통과

BUILD SUCCESSFUL
```

## 💡 ETC

### 기술 사항
- **Java 버전**: Java 17 (필수)
- **테스트 프레임워크**: JUnit 5, Mockito, TestContainers
- **쿼리 방식**: JPA Query Method + @EntityGraph (N+1 최적화)

### 테스트 실행 명령어
```bash
# Java 17 설정
export JAVA_HOME=$(/usr/libexec/java_home -v 17)

# 전체 테스트
./gradlew test

# 개별 테스트
./gradlew test --tests BoardRepositoryDataJpaTest
./gradlew test --tests AdminBoardServiceUnitTest
./gradlew test --tests AdminBoardControllerTest

# 코드 커버리지
./gradlew jacocoTestReport
```

### 관련 이슈
- Resolves: 업로드상품 조회 API 구현 요청

---
**작성자**: Claude Code  
**작성일**: 2026-03-15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* 승인 대기 중인 업로드 목록을 조회할 수 있습니다. 스토어명, 게시물 제목 정보를 포함하여 페이지 단위로 표시되며 최신순으로 정렬됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->