### PR TITLE
[Feature] (판매자) 스토어 상세 정보 수정 API

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -139,6 +139,7 @@ public enum BbangleErrorCode {
     INVALID_SHORT_DESCRIPTION(-730, "유효하지 않은 한 줄 소개입니다.", BAD_REQUEST),
     ALREADY_RESERVED_STORE(-731, "이미 등록된 스토어입니다.", BAD_REQUEST),
     ALREADY_UPDATE_STORE_NAME(-732, "이미 변경된 스토어명입니다.", BAD_REQUEST),
+    STORE_UPDATE_FAILED(-733, "스토어 상세 정보 변경에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // AUTH (741~ 760)
     ADMIN_NOT_FOUND(-741, "존재하지 않는 관리자입니다.", NOT_FOUND),

--- a/src/main/java/com/bbangle/bbangle/seller/seller/controller/SellerController.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/controller/SellerController.java
@@ -6,7 +6,6 @@ import com.bbangle.bbangle.config.security.SellerApiPath;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.AccountVerificationRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerAccountUpdateRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerDocumentsRegisterRequest;
-import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerUpdateRequest;
 import com.bbangle.bbangle.seller.seller.controller.swagger.SellerApi;
 import com.bbangle.bbangle.seller.seller.facade.SellerFacade;
 import com.bbangle.bbangle.seller.seller.service.AccountVerificationService;
@@ -20,7 +19,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,17 +39,6 @@ public class SellerController implements SellerApi {
         @AuthenticationPrincipal Long sellerId
     ) {
         return responseService.getListResult(sellerFacade.registerDocuments(request.toCommand(sellerId)));
-    }
-
-    // TODO : v3 - Store 상세 정보 변경 API (Store/Seller/Controller로 이동할 것)
-    @PutMapping
-    @Override
-    public CommonResult updateSeller(
-        @RequestBody @Validated SellerUpdateRequest request,
-        @AuthenticationPrincipal Long sellerId
-    ) {
-        sellerService.updateSeller(request, sellerId);
-        return responseService.getSuccessResult();
     }
 
     @PatchMapping("/account")

--- a/src/main/java/com/bbangle/bbangle/seller/seller/controller/swagger/SellerApi.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/controller/swagger/SellerApi.java
@@ -5,7 +5,6 @@ import com.bbangle.bbangle.exception.GlobalControllerAdvice;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.AccountVerificationRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerAccountUpdateRequest;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerDocumentsRegisterRequest;
-import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -75,16 +74,6 @@ public interface SellerApi {
     CommonResult registerDocuments(
         SellerDocumentsRegisterRequest request,
         Long sellerId
-    );
-
-    // TODO: v2
-    @Operation(
-        summary = "판매자 정보 수정",
-        description = "기존 판매자 정보를 전체 수정합니다."
-    )
-    CommonResult updateSeller(
-        @RequestBody SellerUpdateRequest request,
-        @AuthenticationPrincipal Long sellerId
     );
 
     @Operation(

--- a/src/main/java/com/bbangle/bbangle/seller/seller/service/SellerService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/service/SellerService.java
@@ -7,7 +7,6 @@ import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerAccountUpdateRequest;
-import com.bbangle.bbangle.seller.seller.controller.dto.SellerRequest.SellerUpdateRequest;
 import com.bbangle.bbangle.seller.seller.service.command.SellerCreateCommand;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -19,11 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class SellerService {
 
     private final SellerRepository sellerRepository;
-
-    // TODO : v3 - Store/Seller/SellerStoreService로 이동
-    public void updateSeller(SellerUpdateRequest request, Long sellerId) {
-        // TODO: 실제 비즈니스 로직 구현
-    }
 
     public void updateAccount(SellerAccountUpdateRequest request, Long sellerId) {
         // TODO: 실제 비즈니스 로직 구현

--- a/src/main/java/com/bbangle/bbangle/store/domain/Store.java
+++ b/src/main/java/com/bbangle/bbangle/store/domain/Store.java
@@ -105,6 +105,7 @@ public class Store extends SoftDeleteBaseEntity {
             .build();
     }
 
+    // TODO : Test
     public void updateDetail(
         String profile,
         String introduce,
@@ -117,7 +118,10 @@ public class Store extends SoftDeleteBaseEntity {
         PhoneNumberVO newPhoneNumberVO = PhoneNumberVO.of(phone, subPhone);
         EmailVO newEmailVO = EmailVO.of(email);
 
-        this.profile = profile;
+        if (profile != null) {
+            this.profile = profile;
+        }
+
         this.introduce = introduce;
         this.phoneNumberVO = newPhoneNumberVO;
         this.emailVO = newEmailVO;

--- a/src/main/java/com/bbangle/bbangle/store/domain/Store.java
+++ b/src/main/java/com/bbangle/bbangle/store/domain/Store.java
@@ -105,7 +105,6 @@ public class Store extends SoftDeleteBaseEntity {
             .build();
     }
 
-    // TODO : Test
     public void updateDetail(
         String profile,
         String introduce,

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
@@ -109,7 +109,7 @@ public class SellerStoreController implements SellerStoreApi {
     // TODO : Test
     @Override
     @PutMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    public SingleResult<SellerStoreDetail> updateSeller(
+    public SingleResult<SellerStoreDetail> updateStoreDetail(
         @AuthenticationPrincipal Long sellerId,
         @Valid @RequestPart("request") UpdateStoreDetailRequest request,
         @RequestPart(value = "profileImage", required = false) MultipartFile profileImage

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
@@ -106,7 +106,6 @@ public class SellerStoreController implements SellerStoreApi {
         return responseService.getSingleResult(sellerStoreFacade.updateStoreName(sellerId, request));
     }
 
-    // TODO : Test
     @Override
     @PutMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public SingleResult<SellerStoreDetail> updateStoreDetail(

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/SellerStoreController.java
@@ -6,8 +6,10 @@ import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.SellerApiPath;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreApplicationRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreApplicationResponse;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreDetailRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreNameRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDetail;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.UpdateStoreNameResponse;
 import com.bbangle.bbangle.store.seller.controller.swagger.SellerStoreApi;
 import com.bbangle.bbangle.store.seller.facade.SellerStoreApplicationFacade;
@@ -22,6 +24,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -101,5 +104,16 @@ public class SellerStoreController implements SellerStoreApi {
         @Valid @RequestBody UpdateStoreNameRequest request
     ) {
         return responseService.getSingleResult(sellerStoreFacade.updateStoreName(sellerId, request));
+    }
+
+    // TODO : Test
+    @Override
+    @PutMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public SingleResult<SellerStoreDetail> updateSeller(
+        @AuthenticationPrincipal Long sellerId,
+        @Valid @RequestPart("request") UpdateStoreDetailRequest request,
+        @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+    ) {
+        return responseService.getSingleResult(sellerStoreFacade.updateStoreDetail(sellerId, request, profileImage));
     }
 }

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/dto/StoreApplicationRequest.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/dto/StoreApplicationRequest.java
@@ -10,7 +10,7 @@ public class StoreApplicationRequest {
 
     public record StoreApplicationCreateRequest(
         @Schema(description = "스토어명", example = "빵그리의 오븐 1호점")
-        @Size(min = 1, max = 50, message = "스토어명은 1자 이상 50자 이하로 입력해주세요.") // 주석 반영
+        @Size(min = 3, max = 50, message = "스토어명은 1자 이상 50자 이하로 입력해주세요.") // 주석 반영
         @NotBlank(message = "스토어명은 필수입니다.")
         String storeName,
 
@@ -27,7 +27,6 @@ public class StoreApplicationRequest {
 
         @Schema(description = "서브 연락처", example = "01012345678")
         @Pattern(regexp = "^[0-9]{9,11}$", message = "서브 연락처는 11자리 이하의 숫자만 입력 가능합니다.") // 주석 반영
-        @NotBlank(message = "추가 연락처는 필수입니다.")
         String subPhoneNumber,
 
         @Schema(description = "이메일", example = "user@example.com", format = "email")

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/dto/StoreApplicationRequest.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/dto/StoreApplicationRequest.java
@@ -10,7 +10,7 @@ public class StoreApplicationRequest {
 
     public record StoreApplicationCreateRequest(
         @Schema(description = "스토어명", example = "빵그리의 오븐 1호점")
-        @Size(min = 3, max = 50, message = "스토어명은 1자 이상 50자 이하로 입력해주세요.") // 주석 반영
+        @Size(min = 3, max = 50, message = "스토어명은 3자 이상 50자 이하로 입력해주세요.") // 주석 반영
         @NotBlank(message = "스토어명은 필수입니다.")
         String storeName,
 

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/dto/StoreRequest.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/dto/StoreRequest.java
@@ -1,15 +1,45 @@
 package com.bbangle.bbangle.store.seller.controller.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public class StoreRequest {
 
     public record UpdateStoreNameRequest(
         @Schema(description = "변경할 스토어명", example = "빵그리의 오븐 1호점")
-        @Size(min = 1, max = 50, message = "스토어명은 1자 이상 50자 이하로 입력해주세요.")
+        @Size(min = 3, max = 50, message = "스토어명은 1자 이상 50자 이하로 입력해주세요.")
         @NotBlank(message = "스토어명은 필수입니다.")
         String newName
+    ) {}
+
+    public record UpdateStoreDetailRequest(
+        @Schema(description = "한줄소개", example = "건강한 재료로 만드는 비건 베이커리")
+        String introduce,
+
+        @Schema(description = "연락처", example = "01012345678")
+        @Pattern(regexp = "^[0-9]{9,11}$", message = "연락처는 11자리 이하의 숫자만 입력 가능합니다.")
+        @NotBlank(message = "연락처는 필수입니다.")
+        String phoneNumber,
+
+        @Schema(description = "서브 연락처", example = "01012345678")
+        @Pattern(regexp = "^[0-9]{9,11}$", message = "서브 연락처는 11자리 이하의 숫자만 입력 가능합니다.")
+        String subPhoneNumber,
+
+        @Schema(description = "이메일", example = "user@example.com", format = "email")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @NotBlank(message = "이메일은 필수입니다.")
+        String email,
+
+        @Schema(description = "판매자 주소", example = "(우편번호) 성남시 금광동 222-31")
+        @NotBlank(message = "출고지 주소는 필수입니다.")
+        String originAddress,
+
+        @Schema(description = "판매자 상세 주소", example = "나동 202호")
+        @Size(max = 50, message = "상세 주소는 50자까지 입력 가능합니다.")
+        @NotBlank(message = "출고지 상세 주소는 필수입니다.")
+        String originAddressDetail
     ) {}
 }

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/dto/StoreRequest.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/dto/StoreRequest.java
@@ -10,7 +10,7 @@ public class StoreRequest {
 
     public record UpdateStoreNameRequest(
         @Schema(description = "변경할 스토어명", example = "빵그리의 오븐 1호점")
-        @Size(min = 3, max = 50, message = "스토어명은 1자 이상 50자 이하로 입력해주세요.")
+        @Size(min = 3, max = 50, message = "스토어명은 3자 이상 50자 이하로 입력해주세요.")
         @NotBlank(message = "스토어명은 필수입니다.")
         String newName
     ) {}

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
@@ -124,7 +124,7 @@ public interface SellerStoreApi {
             - 이미지 파일을 업로드하지 않았을 경우 기존 스토어 프로필을 유지합니다.
             """
     )
-    SingleResult<SellerStoreDetail> updateSeller(
+    SingleResult<SellerStoreDetail> updateStoreDetail(
         @AuthenticationPrincipal Long sellerId,
         @Valid @RequestPart("request") UpdateStoreDetailRequest request,
         @RequestPart(value = "profileImage", required = false) MultipartFile profileImage

--- a/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/controller/swagger/SellerStoreApi.java
@@ -6,7 +6,9 @@ import com.bbangle.bbangle.exception.GlobalControllerAdvice;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreApplicationRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreApplicationResponse;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreDetailRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDetail;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -112,5 +114,19 @@ public interface SellerStoreApi {
     SingleResult<StoreResponse.UpdateStoreNameResponse> updateStoreName(
         @AuthenticationPrincipal Long sellerId,
         @Valid @RequestBody StoreRequest.UpdateStoreNameRequest request
+    );
+
+    @Operation(
+        summary = "판매자의 스토어 상세 정보 수정",
+        description = """
+            ## 판매자의 스토어 상세 정보를 수정합니다.
+            ### 스토어 정보(JSON)와 프로필 이미지 파일을 업로드합니다.
+            - 이미지 파일을 업로드하지 않았을 경우 기존 스토어 프로필을 유지합니다.
+            """
+    )
+    SingleResult<SellerStoreDetail> updateSeller(
+        @AuthenticationPrincipal Long sellerId,
+        @Valid @RequestPart("request") UpdateStoreDetailRequest request,
+        @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     );
 }

--- a/src/main/java/com/bbangle/bbangle/store/seller/facade/SellerStoreFacade.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/facade/SellerStoreFacade.java
@@ -80,7 +80,6 @@ public class SellerStoreFacade {
         );
     }
 
-    // TODO : Test
     public SellerStoreDetail updateStoreDetail(
         Long sellerId,
         UpdateStoreDetailRequest request,

--- a/src/main/java/com/bbangle/bbangle/store/seller/facade/SellerStoreFacade.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/facade/SellerStoreFacade.java
@@ -2,12 +2,15 @@ package com.bbangle.bbangle.store.seller.facade;
 
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.image.customer.service.S3Service;
 import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.seller.service.SellerService;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreDetailRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreNameRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDetail;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.StoreNameCheck;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.UpdateStoreNameResponse;
 import com.bbangle.bbangle.store.seller.controller.mapper.SellerStoreMapper;
@@ -16,14 +19,18 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class SellerStoreFacade {
 
+    private static final String SELLER_IMAGE_FOLDER = "seller-images";
+
     private final SellerStoreService sellerStoreService;
     private final SellerService sellerService;
+    private final S3Service s3Service;
     private final SellerStoreMapper sellerStoreMapper;
 
     public StoreNameCheck checkStoreName(String storeName) {
@@ -71,5 +78,47 @@ public class SellerStoreFacade {
         return sellerStoreMapper.toUpdateStoreNameResponse(
             sellerStoreService.updateStoreName(request, seller)
         );
+    }
+
+    // TODO : Test
+    public SellerStoreDetail updateStoreDetail(
+        Long sellerId,
+        UpdateStoreDetailRequest request,
+        MultipartFile profileImage
+    ) {
+        Seller seller = sellerService.getSellerById(sellerId);
+        Store store = seller.getStore();
+
+        // 스토어를 등록하지 않았을 경우 예외
+        if (store == null) {
+            throw new BbangleException(BbangleErrorCode.STORE_NOT_FOUND);
+        }
+
+        // Store Profile 업로드
+        String profileImagePath = null;
+        if (profileImage != null) {
+            profileImagePath = s3Service.saveAndReturnWithCdn(
+                SELLER_IMAGE_FOLDER + "/" + seller.getId(), profileImage
+            );
+        }
+
+        try {
+            return sellerStoreMapper.toSellerStoreDetail(
+                sellerStoreService.updateStoreDetail(request, profileImagePath, store)
+            );
+        } catch (BbangleException e) {
+            if (profileImagePath != null) {
+                log.warn("Store 상세 정보 업데이트 실패로 인한 S3 이미지 롤백: {}", profileImagePath);
+                s3Service.deleteImage(profileImagePath);
+            }
+            throw e;
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            if (profileImagePath != null) {
+                log.error("Store 상세 정보 업데이트 실패로 인한 S3 이미지 롤백: {}", profileImagePath);
+                s3Service.deleteImage(profileImagePath);
+            }
+            throw new BbangleException(BbangleErrorCode.STORE_UPDATE_FAILED);
+        }
     }
 }

--- a/src/main/java/com/bbangle/bbangle/store/seller/service/SellerStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/service/SellerStoreService.java
@@ -10,6 +10,7 @@ import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
 import com.bbangle.bbangle.store.repository.StoreNameRequestRepository;
 import com.bbangle.bbangle.store.repository.StoreRepository;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreDetailRequest;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo.StoreInfo;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -58,5 +59,25 @@ public class SellerStoreService {
         return storeNameRequestRepository.save(
             StoreNameRequest.createStoreNameRequest(seller.getStore(), seller, request.newName())
         );
+    }
+
+    // TODO : Test
+    @Transactional
+    public Store updateStoreDetail(
+        UpdateStoreDetailRequest request,
+        String profileImagePath,
+        Store store
+    ) {
+        store.updateDetail(
+            profileImagePath,
+            request.introduce(),
+            request.phoneNumber(),
+            request.subPhoneNumber(),
+            request.email(),
+            request.originAddress(),
+            request.originAddressDetail()
+        );
+
+        return store;
     }
 }

--- a/src/main/java/com/bbangle/bbangle/store/seller/service/SellerStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/seller/service/SellerStoreService.java
@@ -61,7 +61,6 @@ public class SellerStoreService {
         );
     }
 
-    // TODO : Test
     @Transactional
     public Store updateStoreDetail(
         UpdateStoreDetailRequest request,

--- a/src/test/java/com/bbangle/bbangle/fixture/store/seller/controller/dto/SellerStoreRequestFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/store/seller/controller/dto/SellerStoreRequestFixture.java
@@ -1,5 +1,11 @@
 package com.bbangle.bbangle.fixture.store.seller.controller.dto;
 
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_ADDRESS;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_DETAIL_ADDRESS;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_EMAIL;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_INTRODUCE;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_PHONE;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_SUBPHONE;
 import static com.bbangle.bbangle.fixture.store.domain.StoreNameRequestFixture.NEW_STORE_NAME;
 
 import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest;
@@ -14,5 +20,49 @@ public class SellerStoreRequestFixture {
 
     public static StoreRequest.UpdateStoreNameRequest defaultUpdateStoreNameRequest(String newName) {
         return new StoreRequest.UpdateStoreNameRequest(newName);
+    }
+
+    private static StoreRequest.UpdateStoreDetailRequest baseUpdateStoreDetailRequest(
+        String introduce,
+        String phone,
+        String subPhone,
+        String email,
+        String address,
+        String detailAddress
+    ) {
+        return new StoreRequest.UpdateStoreDetailRequest(
+            introduce,
+            phone,
+            subPhone,
+            email,
+            address,
+            detailAddress
+        );
+    }
+
+    public static StoreRequest.UpdateStoreDetailRequest defaultUpdateStoreDetailRequest(
+        String introduce,
+        String subPhone
+    ) {
+        return baseUpdateStoreDetailRequest(
+            introduce,
+            NEW_PHONE,
+            subPhone,
+            NEW_EMAIL,
+            NEW_ADDRESS,
+            NEW_DETAIL_ADDRESS
+        );
+    }
+
+    public static StoreRequest.UpdateStoreDetailRequest defaultUpdateStoreDetailRequest(
+    ) {
+        return baseUpdateStoreDetailRequest(
+            NEW_INTRODUCE,
+            NEW_PHONE,
+            NEW_SUBPHONE,
+            NEW_EMAIL,
+            NEW_ADDRESS,
+            NEW_DETAIL_ADDRESS
+        );
     }
 }

--- a/src/test/java/com/bbangle/bbangle/fixture/store/seller/controller/dto/SellerStoreResponseFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/store/seller/controller/dto/SellerStoreResponseFixture.java
@@ -1,11 +1,18 @@
 package com.bbangle.bbangle.fixture.store.seller.controller.dto;
 
 import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.DEFAULT_STORE_NAME;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_ADDRESS;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_DETAIL_ADDRESS;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_EMAIL;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_INTRODUCE;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_PHONE;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_SUBPHONE;
 import static com.bbangle.bbangle.fixture.store.domain.StoreNameRequestFixture.NEW_STORE_NAME;
 
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
 import com.bbangle.bbangle.store.domain.model.StoreNameRejectCategory;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDetail;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.UpdateStoreNameResponse;
 
 public class SellerStoreResponseFixture {
@@ -52,5 +59,19 @@ public class SellerStoreResponseFixture {
             .rejectCategory(rejectReason)
             .rejectDetail(rejectDetail)
             .build();
+    }
+
+    public static StoreResponse.SellerStoreDetail defaultSellerStoreDetailResponse(String profile) {
+        return new SellerStoreDetail(
+            1L,
+            NEW_STORE_NAME,
+            NEW_INTRODUCE,
+            profile,
+            NEW_PHONE,
+            NEW_SUBPHONE,
+            NEW_EMAIL,
+            NEW_ADDRESS,
+            NEW_DETAIL_ADDRESS
+        );
     }
 }

--- a/src/test/java/com/bbangle/bbangle/store/domain/StoreUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/domain/StoreUnitTest.java
@@ -23,10 +23,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("[단위 테스트] Store")
@@ -110,21 +113,32 @@ public class StoreUnitTest {
     @DisplayName("updateDetail() 테스트")
     class UpdateDetailTest {
 
-        @Test
+        static Stream<Arguments> updateParams() {
+            return Stream.of(
+                Arguments.of(null, null),
+                Arguments.of(NEW_PROFILE, null),
+                Arguments.of(NEW_PROFILE, NEW_SUBPHONE),
+                Arguments.of(null, NEW_SUBPHONE)
+            );
+        }
+
+        @ParameterizedTest
         @DisplayName("스토어 상세 정보 수정에 성공한다")
-        void success_update_store() {
+        @MethodSource("updateParams")
+        void success_update_store(String newProfile, String newSubPhone) {
 
             // given
             Store store = StoreFixture.defaultStore();
+            String profile = newProfile == null ? store.getProfile() : newProfile;
 
             // when
-            store.updateDetail(NEW_PROFILE, NEW_INTRODUCE, NEW_PHONE, NEW_SUBPHONE, NEW_EMAIL, NEW_ADDRESS, NEW_DETAIL_ADDRESS);
+            store.updateDetail(newProfile, NEW_INTRODUCE, NEW_PHONE, newSubPhone, NEW_EMAIL, NEW_ADDRESS, NEW_DETAIL_ADDRESS);
 
             // then
-            assertThat(store.getProfile()).isEqualTo(NEW_PROFILE);
+            assertThat(store.getProfile()).isEqualTo(profile);
             assertThat(store.getIntroduce()).isEqualTo(NEW_INTRODUCE);
             assertThat(store.getPhoneNumberVO().getPhoneNumber()).isEqualTo(NEW_PHONE);
-            assertThat(store.getPhoneNumberVO().getSubPhoneNumber()).isEqualTo(NEW_SUBPHONE);
+            assertThat(store.getPhoneNumberVO().getSubPhoneNumber()).isEqualTo(newSubPhone);
             assertThat(store.getEmailVO().getEmail()).isEqualTo(NEW_EMAIL);
             assertThat(store.getOriginAddressLine()).isEqualTo(NEW_ADDRESS);
             assertThat(store.getOriginAddressDetail()).isEqualTo(NEW_DETAIL_ADDRESS);
@@ -146,6 +160,9 @@ public class StoreUnitTest {
                 )
             ).isInstanceOf(BbangleException.class)
                 .hasMessageContaining(BbangleErrorCode.INVALID_PHONE_NUMBER.getMessage());
+
+            assertThat(store.getProfile()).isEqualTo(DEFAULT_PROFILE);
+            assertThat(store.getIntroduce()).isEqualTo(DEFAULT_INTRODUCE);
             assertThat(store.getPhoneNumberVO().getPhoneNumber()).isEqualTo(DEFAULT_PHONE);
         }
 
@@ -165,6 +182,9 @@ public class StoreUnitTest {
                 )
             ).isInstanceOf(BbangleException.class)
                 .hasMessageContaining(BbangleErrorCode.INVALID_PHONE_NUMBER.getMessage());
+
+            assertThat(store.getProfile()).isEqualTo(DEFAULT_PROFILE);
+            assertThat(store.getIntroduce()).isEqualTo(DEFAULT_INTRODUCE);
             assertThat(store.getPhoneNumberVO().getSubPhoneNumber()).isEqualTo(DEFAULT_SUBPHONE);
         }
 
@@ -184,7 +204,29 @@ public class StoreUnitTest {
                 )
             ).isInstanceOf(BbangleException.class)
                 .hasMessageContaining(BbangleErrorCode.INVALID_EMAIL.getMessage());
+
+            assertThat(store.getProfile()).isEqualTo(DEFAULT_PROFILE);
+            assertThat(store.getIntroduce()).isEqualTo(DEFAULT_INTRODUCE);
             assertThat(store.getEmailVO().getEmail()).isEqualTo(DEFAULT_EMAIL);
+        }
+
+        @Test
+        @DisplayName("스토어 상세 정보 수정 중 하나라도 유효하지 않으면 수정이 실패하고 상태는 유지된다.")
+        void fail_update_store_any_invalid() {
+
+            // given
+            Store store = StoreFixture.defaultStore();
+            String originalProfile = store.getProfile();
+
+            // when & then
+            assertThatThrownBy(() -> store.updateDetail(
+                    NEW_PROFILE, NEW_INTRODUCE, NEW_PHONE, NEW_SUBPHONE,
+                    null,
+                    NEW_ADDRESS, NEW_DETAIL_ADDRESS
+                )
+            );
+
+            assertThat(store.getProfile()).isEqualTo(originalProfile);
         }
     }
 

--- a/src/test/java/com/bbangle/bbangle/store/seller/controller/SellerStoreControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/seller/controller/SellerStoreControllerTest.java
@@ -569,8 +569,8 @@ class SellerStoreControllerTest {
     }
 
     @Nested
-    @DisplayName("updateSeller() 테스트")
-    class UpdateSellerTest {
+    @DisplayName("updateStoreDetail() 테스트")
+    class UpdateStoreDetailTest {
 
         private MockPart createRequest(
             UpdateStoreDetailRequest request

--- a/src/test/java/com/bbangle/bbangle/store/seller/controller/SellerStoreControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/seller/controller/SellerStoreControllerTest.java
@@ -1,11 +1,20 @@
 package com.bbangle.bbangle.store.seller.controller;
 
 import static com.bbangle.bbangle.common.service.ResponseService.CommonResponse.SUCCESS;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.DEFAULT_PROFILE;
 import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.DEFAULT_STORE_NAME;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_ADDRESS;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_DETAIL_ADDRESS;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_EMAIL;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_INTRODUCE;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_PHONE;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_PROFILE;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_SUBPHONE;
 import static com.bbangle.bbangle.fixture.store.domain.StoreNameRequestFixture.NEW_STORE_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -32,6 +41,7 @@ import com.bbangle.bbangle.fixture.store.seller.controller.dto.StoreApplicationR
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreApplicationRequest.StoreApplicationCreateRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreApplicationResponse.StoreApplicationDetail;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreDetailRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreNameRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDetail;
@@ -55,6 +65,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockPart;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -554,6 +565,130 @@ class SellerStoreControllerTest {
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.code").value(BbangleErrorCode.ALREADY_RESERVED_STORE.getCode()))
                 .andExpect(jsonPath("$.message").value(BbangleErrorCode.ALREADY_RESERVED_STORE.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("updateSeller() 테스트")
+    class UpdateSellerTest {
+
+        private MockPart createRequest(
+            UpdateStoreDetailRequest request
+        ) throws JsonProcessingException  {
+            MockPart requestPart = new MockPart(
+                "request",
+                objectMapper.writeValueAsBytes(request)
+            );
+            requestPart.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+            return requestPart;
+        }
+
+        private MockMultipartFile createProfileFile() {
+            return new MockMultipartFile(
+                "profileImage",
+                "profile.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "profile image content".getBytes()
+            );
+        }
+
+        @Test
+        @WithMockAuthenticationPrincipal(role = "SELLER")
+        @DisplayName("스토어 상세 정보를 업데이트하면 변경된 데이터를 반환한다.")
+        void success_updateStoreDetail() throws Exception {
+
+            // given
+            UpdateStoreDetailRequest request = SellerStoreRequestFixture.defaultUpdateStoreDetailRequest();
+            MockPart requestPart = createRequest(request);
+            MockMultipartFile profileImage = createProfileFile();
+
+            given(sellerStoreFacade.updateStoreDetail(
+                eq(1L),
+                any(UpdateStoreDetailRequest.class),
+                any(MultipartFile.class)
+            )).willReturn(SellerStoreResponseFixture.defaultSellerStoreDetailResponse(NEW_PROFILE));
+
+            // when & then
+            mockMvc.perform(
+                    multipart(SellerApiPath.PREFIX + "/stores")
+                        .part(requestPart)
+                        .file(profileImage)
+                        .with(req -> {
+                            req.setMethod("PUT");
+                            return req;
+                        })
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.storeId").value(1L))
+                .andExpect(jsonPath("$.result.name").value(NEW_STORE_NAME))
+                .andExpect(jsonPath("$.result.introduce").value(NEW_INTRODUCE))
+                .andExpect(jsonPath("$.result.profile").value(NEW_PROFILE))
+                .andExpect(jsonPath("$.result.phoneNumber").value(NEW_PHONE))
+                .andExpect(jsonPath("$.result.subPhoneNumber").value(NEW_SUBPHONE))
+                .andExpect(jsonPath("$.result.email").value(NEW_EMAIL))
+                .andExpect(jsonPath("$.result.originAddress").value(NEW_ADDRESS))
+                .andExpect(jsonPath("$.result.originAddressDetail").value(NEW_DETAIL_ADDRESS));
+        }
+
+        @Test
+        @WithMockAuthenticationPrincipal(role = "SELLER")
+        @DisplayName("이미지 파일을 업로드 하지 않은 경우 기존 프로필을 유지한다.")
+        void success_updateStoreDetail_without_profile() throws Exception {
+
+            // given
+            UpdateStoreDetailRequest request = SellerStoreRequestFixture.defaultUpdateStoreDetailRequest();
+            MockPart requestPart = createRequest(request);
+
+            given(sellerStoreFacade.updateStoreDetail(
+                eq(1L),
+                any(UpdateStoreDetailRequest.class),
+                isNull()
+            )).willReturn(SellerStoreResponseFixture.defaultSellerStoreDetailResponse(DEFAULT_PROFILE));
+
+            // when & then
+            mockMvc.perform(
+                    multipart(SellerApiPath.PREFIX + "/stores")
+                        .part(requestPart)
+                        .with(req -> {
+                            req.setMethod("PUT");
+                            return req;
+                        })
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.storeId").value(1L))
+                .andExpect(jsonPath("$.result.name").value(NEW_STORE_NAME))
+                .andExpect(jsonPath("$.result.introduce").value(NEW_INTRODUCE))
+                .andExpect(jsonPath("$.result.profile").value(DEFAULT_PROFILE))
+                .andExpect(jsonPath("$.result.phoneNumber").value(NEW_PHONE))
+                .andExpect(jsonPath("$.result.subPhoneNumber").value(NEW_SUBPHONE))
+                .andExpect(jsonPath("$.result.email").value(NEW_EMAIL))
+                .andExpect(jsonPath("$.result.originAddress").value(NEW_ADDRESS))
+                .andExpect(jsonPath("$.result.originAddressDetail").value(NEW_DETAIL_ADDRESS));
+        }
+
+        @Test
+        @WithMockAuthenticationPrincipal(role = "SELLER")
+        @DisplayName("스토어를 등록하지 않은 계정인 경우 상세 정보 수정에 실패한다.")
+        void fail_updateStoreDetail_noExists_store() throws Exception {
+
+            // given
+            UpdateStoreDetailRequest request = SellerStoreRequestFixture.defaultUpdateStoreDetailRequest();
+            MockPart requestPart = createRequest(request);
+
+            given(sellerStoreFacade.updateStoreDetail(anyLong(), any(), any()))
+                .willThrow(new BbangleException(BbangleErrorCode.STORE_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(
+                    multipart(SellerApiPath.PREFIX + "/stores")
+                        .part(requestPart)
+                        .with(req -> {
+                            req.setMethod("PUT");
+                            return req;
+                        })
+                )
+                .andExpect(status().isBadRequest());
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/store/seller/facade/SellerStoreFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/seller/facade/SellerStoreFacadeIntegrationTest.java
@@ -4,21 +4,23 @@ import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.DEFAULT_STOR
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.bbangle.bbangle.config.S3IntegrationTestSupport;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
-import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.fixture.store.domain.StoreNameRequestFixture;
 import com.bbangle.bbangle.fixture.store.seller.controller.dto.SellerStoreRequestFixture;
+import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.domain.StoreNameRequest;
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
 import com.bbangle.bbangle.store.repository.StoreNameRequestRepository;
 import com.bbangle.bbangle.store.repository.StoreRepository;
-import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDTO;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreDetailRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreNameRequest;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDTO;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.StoreNameCheck;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.UpdateStoreNameResponse;
 import jakarta.persistence.EntityManager;
@@ -26,15 +28,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
 @DisplayName("[통합테스트] SellerStoreFacade")
-@SpringBootTest
-@ActiveProfiles("test")
 @Transactional
-class SellerStoreFacadeIntegrationTest {
+class SellerStoreFacadeIntegrationTest extends S3IntegrationTestSupport {
 
     @Autowired
     private SellerStoreFacade sellerStoreFacade;
@@ -248,6 +247,101 @@ class SellerStoreFacadeIntegrationTest {
                 .satisfies(e -> {
                     BbangleException ex = (BbangleException) e;
                     assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ALREADY_RESERVED_STORE);
+                });
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStoreDetail() 테스트")
+    class UpdateStoreDetailTest {
+
+        private MockMultipartFile mockProfileImage() {
+            return new MockMultipartFile(
+                "profileImage",
+                "test-image.png",
+                "image/png",
+                "fake image content".getBytes()
+            );
+        }
+
+        private Seller saveNewSeller() {
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            Seller seller = sellerRepository.save(SellerFixture.defaultSeller(store));
+            em.flush();
+            em.clear();
+
+            return seller;
+        }
+
+        @Test
+        @DisplayName("유효한 정보가 주어지는 경우 스토어 상세 정보 변경에 성공한다.")
+        void success_updateStoreDetail() {
+
+            // given
+            Seller seller = saveNewSeller();
+            UpdateStoreDetailRequest request = SellerStoreRequestFixture.defaultUpdateStoreDetailRequest();
+            MockMultipartFile mockFile = mockProfileImage();
+
+            // when
+            sellerStoreFacade.updateStoreDetail(seller.getId(), request, mockFile);
+            em.flush();
+            em.clear();
+
+            // then
+            Store updatedStore = storeRepository.findById(seller.getStore().getId()).orElseThrow();
+
+            assertThat(updatedStore.getProfile()).isNotEqualTo(seller.getStore().getProfile());
+            assertThat(updatedStore.getIntroduce()).isEqualTo(request.introduce());
+            assertThat(updatedStore.getPhoneNumberVO().getPhoneNumber()).isEqualTo(request.phoneNumber());
+            assertThat(updatedStore.getPhoneNumberVO().getSubPhoneNumber()).isEqualTo(request.subPhoneNumber());
+            assertThat(updatedStore.getEmailVO().getEmail()).isEqualTo(request.email());
+            assertThat(updatedStore.getOriginAddressLine()).isEqualTo(request.originAddress());
+            assertThat(updatedStore.getOriginAddressDetail()).isEqualTo(request.originAddressDetail());
+        }
+
+        @Test
+        @DisplayName("업로드한 사진이 없을 경우 기존 프로필을 유지한다.")
+        void success_updateStoreDetail_withoutImage() {
+
+            // given
+            Seller seller = saveNewSeller();
+            UpdateStoreDetailRequest request = SellerStoreRequestFixture.defaultUpdateStoreDetailRequest();
+
+            // when
+            sellerStoreFacade.updateStoreDetail(seller.getId(), request, null);
+            em.flush();
+            em.clear();
+
+            // then
+            Store updatedStore = storeRepository.findById(seller.getStore().getId()).orElseThrow();
+
+            assertThat(updatedStore.getProfile()).isEqualTo(seller.getStore().getProfile());
+            assertThat(updatedStore.getIntroduce()).isEqualTo(request.introduce());
+            assertThat(updatedStore.getPhoneNumberVO().getPhoneNumber()).isEqualTo(request.phoneNumber());
+            assertThat(updatedStore.getPhoneNumberVO().getSubPhoneNumber()).isEqualTo(request.subPhoneNumber());
+            assertThat(updatedStore.getEmailVO().getEmail()).isEqualTo(request.email());
+            assertThat(updatedStore.getOriginAddressLine()).isEqualTo(request.originAddress());
+            assertThat(updatedStore.getOriginAddressDetail()).isEqualTo(request.originAddressDetail());
+        }
+
+        @Test
+        @DisplayName("스토어를 등록하지 않은 판매자 계정일 경우 예외를 던진다.")
+        void fail_updateStoreDetail_storeNotFound() {
+
+            // given
+            Seller seller = sellerRepository.save(SellerFixture.defaultSeller());
+            em.flush();
+            em.clear();
+
+            UpdateStoreDetailRequest request = SellerStoreRequestFixture.defaultUpdateStoreDetailRequest();
+            MockMultipartFile mockFile = mockProfileImage();
+
+            // when & then
+            assertThatThrownBy(() -> sellerStoreFacade.updateStoreDetail(seller.getId(), request, mockFile))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(ex -> {
+                    BbangleException e = (BbangleException) ex;
+                    assertThat(e.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.STORE_NOT_FOUND);
                 });
         }
     }

--- a/src/test/java/com/bbangle/bbangle/store/seller/facade/SellerStoreFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/seller/facade/SellerStoreFacadeUnitTest.java
@@ -4,27 +4,32 @@ import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.DEFAULT_STOR
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
-import com.bbangle.bbangle.seller.domain.Seller;
-import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import com.bbangle.bbangle.fixture.store.domain.StoreNameRequestFixture;
 import com.bbangle.bbangle.fixture.store.seller.controller.dto.SellerStoreRequestFixture;
+import com.bbangle.bbangle.image.customer.service.S3Service;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import com.bbangle.bbangle.seller.seller.service.SellerService;
 import com.bbangle.bbangle.store.domain.Store;
-import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
-import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDTO;
 import com.bbangle.bbangle.store.domain.StoreNameRequest;
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreDetailRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreNameRequest;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDTO;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.SellerStoreDetail;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.StoreNameCheck;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreResponse.UpdateStoreNameResponse;
@@ -39,6 +44,7 @@ import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
 
 @DisplayName("[단위테스트] SellerStoreFacade")
 @ExtendWith(MockitoExtension.class)
@@ -55,6 +61,12 @@ class SellerStoreFacadeUnitTest {
 
     @Mock
     SellerStoreMapper sellerStoreMapper;
+
+    @Mock
+    S3Service s3Service;
+
+    @Mock
+    MultipartFile multipartFile;
 
     @Nested
     @DisplayName("checkStoreName() 테스트")
@@ -299,6 +311,148 @@ class SellerStoreFacadeUnitTest {
             verify(sellerStoreService).existsByStatusAndSellerId(seller, StoreApprovalStatus.PENDING);
             verify(sellerStoreService).findStoreByStoreName(request.newName());
             verify(sellerStoreMapper, never()).toUpdateStoreNameResponse(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStoreDetail() 테스트")
+    class UpdateStoreDetailTest {
+
+        @Test
+        @DisplayName("유효한 정보가 주어지는 경우 스토어 상세 정보 변경에 성공한다.")
+        void success_updateStoreDetail() {
+
+            // given
+            Long sellerId = 1L;
+            Store store = mock(Store.class);
+            Seller seller = mock(Seller.class);
+            UpdateStoreDetailRequest request = mock(UpdateStoreDetailRequest.class);
+            String profilePath = "s3/profile.png";
+
+            SellerStoreDetail sellerStoreDetail = mock(SellerStoreDetail.class);
+
+            given(sellerService.getSellerById(sellerId)).willReturn(seller);
+            given(seller.getId()).willReturn(sellerId);
+            given(seller.getStore()).willReturn(store);
+            given(s3Service.saveAndReturnWithCdn(anyString(), eq(multipartFile))).willReturn(profilePath);
+            given(sellerStoreService.updateStoreDetail(request, profilePath, store)).willReturn(store);
+            given(sellerStoreMapper.toSellerStoreDetail(store)).willReturn(sellerStoreDetail);
+
+            // when
+            SellerStoreDetail result = sellerStoreFacade.updateStoreDetail(sellerId, request, multipartFile);
+
+            // then
+            assertThat(result).isEqualTo(sellerStoreDetail);
+            verify(s3Service).saveAndReturnWithCdn(anyString(), eq(multipartFile));
+            verify(sellerStoreService).updateStoreDetail(request, profilePath, store);
+            verify(sellerStoreMapper).toSellerStoreDetail(store);
+            verify(s3Service, never()).deleteImage(any());
+        }
+
+        @Test
+        @DisplayName("업로드한 사진이 없을 경우 기존 프로필을 유지한다.")
+        void success_updateStoreDetail_withoutImage() {
+
+            // given
+            Long sellerId = 1L;
+            Store store = mock(Store.class);
+            Seller seller = mock(Seller.class);
+            UpdateStoreDetailRequest request = mock(UpdateStoreDetailRequest.class);
+
+            SellerStoreDetail sellerStoreDetail = mock(SellerStoreDetail.class);
+
+            given(sellerService.getSellerById(sellerId)).willReturn(seller);
+            given(seller.getStore()).willReturn(store);
+            given(sellerStoreService.updateStoreDetail(request, null, store)).willReturn(store);
+            given(sellerStoreMapper.toSellerStoreDetail(store)).willReturn(sellerStoreDetail);
+
+            // when
+            SellerStoreDetail result = sellerStoreFacade.updateStoreDetail(sellerId, request, null);
+
+            // then
+            assertThat(result).isEqualTo(sellerStoreDetail);
+            verify(sellerStoreService).updateStoreDetail(request, null, store);
+            verify(sellerStoreMapper).toSellerStoreDetail(store);
+            verify(s3Service, never()).saveAndReturnWithCdn(any(), any());
+            verify(s3Service, never()).deleteImage(any());
+        }
+
+        @Test
+        @DisplayName("스토어를 등록하지 않은 판매자 계정일 경우 예외를 던진다.")
+        void fail_updateStoreDetail_storeNotFound() {
+
+            // given
+            Long sellerId = 1L;
+            Seller seller = mock(Seller.class);
+            UpdateStoreDetailRequest request = mock(UpdateStoreDetailRequest.class);
+
+            given(sellerService.getSellerById(sellerId)).willReturn(seller);
+            given(seller.getStore()).willReturn(null);
+
+            // when & then
+            assertThatThrownBy(() -> sellerStoreFacade.updateStoreDetail(sellerId, request, multipartFile))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(ex -> {
+                    BbangleException e = (BbangleException) ex;
+                    assertThat(e.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.STORE_NOT_FOUND);
+                });
+            verifyNoInteractions(s3Service);
+        }
+
+        @Test
+        @DisplayName("스토어 상세 정보 수정 중 BbangleException 예외가 발생하면 S3 롤백 한다.")
+        void fail_rollback_s3_by_bbangleException() {
+
+            // given
+            Long sellerId = 1L;
+            Store store = mock(Store.class);
+            Seller seller = mock(Seller.class);
+            UpdateStoreDetailRequest request = mock(UpdateStoreDetailRequest.class);
+            String profilePath = "s3/profile.png";
+
+            given(sellerService.getSellerById(sellerId)).willReturn(seller);
+            given(seller.getId()).willReturn(sellerId);
+            given(seller.getStore()).willReturn(store);
+            given(s3Service.saveAndReturnWithCdn(anyString(), any())).willReturn(profilePath);
+            given(sellerStoreService.updateStoreDetail(any(), any(), any()))
+                .willThrow(new BbangleException(BbangleErrorCode._BAD_REQUEST));
+
+            // when & then
+            assertThatThrownBy(() -> sellerStoreFacade.updateStoreDetail(sellerId, request, multipartFile))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(ex -> {
+                    BbangleException e = (BbangleException) ex;
+                    assertThat(e.getBbangleErrorCode()).isEqualTo(BbangleErrorCode._BAD_REQUEST);
+                });
+            verify(s3Service).deleteImage(profilePath);
+        }
+
+        @Test
+        @DisplayName("스토어 상세 정보 수정 중 Exception 예외가 발생하면 S3 롤백 한다.")
+        void fail_rollback_s3_by_exception() {
+
+            // given
+            Long sellerId = 1L;
+            Store store = mock(Store.class);
+            Seller seller = mock(Seller.class);
+            UpdateStoreDetailRequest request = mock(UpdateStoreDetailRequest.class);
+            String profilePath = "s3/profile.png";
+
+            given(sellerService.getSellerById(sellerId)).willReturn(seller);
+            given(seller.getId()).willReturn(sellerId);
+            given(seller.getStore()).willReturn(store);
+            given(s3Service.saveAndReturnWithCdn(anyString(), any())).willReturn(profilePath);
+            given(sellerStoreService.updateStoreDetail(any(), any(), any()))
+                .willThrow(new RuntimeException());
+
+            // when & then
+            assertThatThrownBy(() -> sellerStoreFacade.updateStoreDetail(sellerId, request, multipartFile))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(ex -> {
+                    BbangleException e = (BbangleException) ex;
+                    assertThat(e.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.STORE_UPDATE_FAILED);
+                });
+            verify(s3Service).deleteImage(profilePath);
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/store/seller/service/SellerStoreServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/seller/service/SellerStoreServiceIntegrationTest.java
@@ -2,6 +2,9 @@ package com.bbangle.bbangle.store.seller.service;
 
 
 import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.DEFAULT_STORE_NAME;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_INTRODUCE;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_PROFILE;
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_SUBPHONE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bbangle.bbangle.common.page.CursorPagination;
@@ -17,6 +20,7 @@ import com.bbangle.bbangle.store.domain.StoreNameRequest;
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
 import com.bbangle.bbangle.store.repository.StoreNameRequestRepository;
 import com.bbangle.bbangle.store.repository.StoreRepository;
+import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreDetailRequest;
 import com.bbangle.bbangle.store.seller.controller.dto.StoreRequest.UpdateStoreNameRequest;
 import com.bbangle.bbangle.store.seller.service.model.SellerStoreInfo.StoreInfo;
 import jakarta.persistence.EntityManager;
@@ -27,6 +31,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -335,6 +342,70 @@ public class SellerStoreServiceIntegrationTest {
 
             // then
             assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStoreDetail() 테스트")
+    class UpdateStoreDetailTest {
+
+        static Stream<Arguments> updateParams() {
+            return Stream.of(
+                Arguments.of(NEW_SUBPHONE, NEW_INTRODUCE),
+                Arguments.of(NEW_SUBPHONE, null),
+                Arguments.of(null, NEW_INTRODUCE),
+                Arguments.of(null, null)
+            );
+        }
+
+        @ParameterizedTest
+        @DisplayName("스토어 상세 정보 업데이트에 성공한다.")
+        @MethodSource("updateParams")
+        void success_update_store_detail(String newSubPhone, String newIntroduce) {
+
+            // given
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            UpdateStoreDetailRequest request = SellerStoreRequestFixture.defaultUpdateStoreDetailRequest(newIntroduce, newSubPhone);
+
+            // when
+            sellerStoreService.updateStoreDetail(request, NEW_PROFILE, store);
+            em.flush();
+            em.clear();
+
+            // then
+            Store result = storeRepository.findById(store.getId()).orElseThrow();
+            assertThat(result.getProfile()).isEqualTo(NEW_PROFILE);
+            assertThat(result.getIntroduce()).isEqualTo(request.introduce());
+            assertThat(result.getPhoneNumberVO().getPhoneNumber()).isEqualTo(request.phoneNumber());
+            assertThat(result.getPhoneNumberVO().getSubPhoneNumber()).isEqualTo(request.subPhoneNumber());
+            assertThat(result.getEmailVO().getEmail()).isEqualTo(request.email());
+            assertThat(result.getOriginAddressLine()).isEqualTo(request.originAddress());
+            assertThat(result.getOriginAddressDetail()).isEqualTo(request.originAddressDetail());
+        }
+
+        @Test
+        @DisplayName("업로드한 프로필이 없을 경우 기존 프로필을 유지한다.")
+        void success_update_store_detail_notExists_profilePath() {
+
+            // given
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            UpdateStoreDetailRequest request = SellerStoreRequestFixture.defaultUpdateStoreDetailRequest();
+            String profile = store.getProfile();
+
+            // when
+            sellerStoreService.updateStoreDetail(request, null, store);
+            em.flush();
+            em.clear();
+
+            // then
+            Store result = storeRepository.findById(store.getId()).orElseThrow();
+            assertThat(result.getProfile()).isEqualTo(profile);
+            assertThat(result.getIntroduce()).isEqualTo(request.introduce());
+            assertThat(result.getPhoneNumberVO().getPhoneNumber()).isEqualTo(request.phoneNumber());
+            assertThat(result.getPhoneNumberVO().getSubPhoneNumber()).isEqualTo(request.subPhoneNumber());
+            assertThat(result.getEmailVO().getEmail()).isEqualTo(request.email());
+            assertThat(result.getOriginAddressLine()).isEqualTo(request.originAddress());
+            assertThat(result.getOriginAddressDetail()).isEqualTo(request.originAddressDetail());
         }
     }
 }


### PR DESCRIPTION
## Reviewer
|팀|이름|
|--------|-------|
|2팀|@kimbro97|
|3팀|@exjuu|
|3팀|@CUCU7103|

## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

- 연관된 이슈 : #631 
- [Notion 개발 일정](https://www.notion.so/sideproject-unione/2-_-_-2f0622e86d3d80b69f6fccd299b6967d?source=copy_link)
- [API 명세서](https://www.notion.so/sideproject-unione/328622e86d3d8036915cff67129849d9?v=2c6622e86d3d8157890d000cc857bdd2&source=copy_link)

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

- (판매자) 등록한 스토어 상세 정보 업데이트 API
  - 이미지 파일을 업로드 하지 않은 경우 기존의 스토어 프로필을 유지

<img width="728" height="227" alt="image" src="https://github.com/user-attachments/assets/080f4fde-5683-4f61-8716-213aeb7a25e1" />

<img width="359" height="118" alt="image" src="https://github.com/user-attachments/assets/8a5ff6fb-0a6b-4a3e-9d77-4eb4a90d7f97" />

<img width="682" height="256" alt="image" src="https://github.com/user-attachments/assets/d7a88e7b-a0d3-49a6-aeeb-e60ca25936e8" />



## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 스토어 상세 정보 업데이트 엔드포인트 추가(멀티파트로 프로필 이미지 업로드 지원)

* **변경 사항**
  * 스토어명 최소 길이 강화(1→3자)
  * 추가 연락처의 필수 제약 완화(빈값 허용)

* **개선 사항**
  * 프로필 이미지가 없는 경우 기존 프로필 보존 로직 적용
  * S3 업로드 실패 시 업로드된 이미지 롤백 및 오류 코드 추가(STORE_UPDATE_FAILED)

* **테스트**
  * 컨트롤러·서비스·통합·단위 테스트 보강 및 케이스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->