### PR TITLE
[Feature] (판매자) 반품 수거 운송장 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/claim/domain/ClaimDelivery.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ClaimDelivery.java
@@ -72,5 +72,9 @@ public class ClaimDelivery extends BaseEntity {
             ClaimShippingStatus.IN_TRANSIT
         );
     }
+    
+    public void updateInvoice(CourierCompany courierCode, String trackingNumber) {
+        this.shipping.modifyShippingInfo(courierCode.getDisplayName(), trackingNumber);
+    }
 
 }

--- a/src/main/java/com/bbangle/bbangle/claim/domain/ReturnRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ReturnRequest.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.claim.domain;
 
 import static com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus.APPROVED;
+import static com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus.PICKUP_SCHEDULED;
 import static com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus.REJECTED;
 import static com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus.REQUESTED;
 
@@ -67,5 +68,11 @@ public class ReturnRequest extends Claim {
     public void startReturnPickup() {
         this.status.validateTransition(ReturnRequestRequestStatus.PICKUP_SCHEDULED);
         this.status = ReturnRequestRequestStatus.PICKUP_SCHEDULED;
+    }
+    
+    public void validatePickupScheduled() {
+        if (this.status != PICKUP_SCHEDULED) {
+            throw new BbangleException(BbangleErrorCode.DELIVERY_MODIFY_NOT_ALLOWED);
+        }
     }
 }

--- a/src/main/java/com/bbangle/bbangle/claim/repository/ClaimDeliveryRepository.java
+++ b/src/main/java/com/bbangle/bbangle/claim/repository/ClaimDeliveryRepository.java
@@ -1,7 +1,12 @@
 package com.bbangle.bbangle.claim.repository;
 
 import com.bbangle.bbangle.claim.domain.ClaimDelivery;
+import com.bbangle.bbangle.claim.domain.constant.ClaimDeliveryType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClaimDeliveryRepository extends JpaRepository<ClaimDelivery, Long> {
+
+    Optional<ClaimDelivery> findByClaimIdAndDeliveryType(Long claimId, ClaimDeliveryType deliveryType);
+
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerReturnController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerReturnController.java
@@ -2,9 +2,12 @@ package com.bbangle.bbangle.claim.seller.controller;
 
 import com.bbangle.bbangle.claim.seller.controller.dto.RegisterReturnInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ReturnDecisionRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.UpdateReturnInvoiceRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.UpdateReturnInvoiceResponse;
 import com.bbangle.bbangle.claim.seller.controller.swagger.SellerReturnApi;
 import com.bbangle.bbangle.claim.seller.service.SellerReturnService;
 import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.SellerApiPath;
 import jakarta.validation.Valid;
@@ -13,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,6 +47,18 @@ public class SellerReturnController implements SellerReturnApi {
     ) {
         sellerReturnService.registerReturnInvoice(returnId, sellerId, request.courierCode(), request.trackingNumber());
         return responseService.getSuccessResult();
+    }
+
+    @PutMapping("/{returnId}/invoice")
+    public SingleResult<UpdateReturnInvoiceResponse> updateReturnInvoice(
+        @PathVariable Long returnId,
+        @Valid @RequestBody UpdateReturnInvoiceRequest request,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        UpdateReturnInvoiceResponse response = sellerReturnService.updateReturnInvoice(
+            returnId, sellerId, request.courierCode(), request.trackingNumber()
+        );
+        return responseService.getSingleResult(response);
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/UpdateReturnInvoiceRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/UpdateReturnInvoiceRequest.java
@@ -1,0 +1,29 @@
+package com.bbangle.bbangle.claim.seller.controller.dto;
+
+import com.bbangle.bbangle.order.domain.model.CourierCompany;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "반품 수거 운송장 수정 요청 DTO")
+public record UpdateReturnInvoiceRequest(
+
+    @Schema(description = "택배사 코드", example = "CJ_LOGISTICS")
+    @NotNull(message = "택배사 코드는 필수입니다.")
+    CourierCompany courierCode,
+
+    @Schema(description = "운송장 번호 (10~14자리 숫자)", example = "1234567890")
+    @NotBlank(message = "운송장 번호는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{10,14}$", message = "운송장 번호는 10~14자리 숫자여야 합니다.")
+    String trackingNumber
+
+) {
+
+    @Schema(hidden = true)
+    @AssertTrue(message = "유효한 택배사 코드를 입력해야 합니다. NONE은 허용되지 않습니다.")
+    public boolean isCourierCodeValid() {
+        return courierCode != null && courierCode != CourierCompany.NONE;
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/UpdateReturnInvoiceResponse.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/UpdateReturnInvoiceResponse.java
@@ -1,0 +1,27 @@
+package com.bbangle.bbangle.claim.seller.controller.dto;
+
+import com.bbangle.bbangle.claim.domain.ClaimDelivery;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "반품 수거 운송장 수정 응답 DTO")
+public record UpdateReturnInvoiceResponse(
+
+    @Schema(description = "반품 요청 ID", example = "1")
+    Long returnId,
+
+    @Schema(description = "택배사 명", example = "CJ대한통운")
+    String courierName,
+
+    @Schema(description = "운송장 번호", example = "1234567890")
+    String trackingNumber
+
+) {
+
+    public static UpdateReturnInvoiceResponse of(Long returnId, ClaimDelivery delivery) {
+        return new UpdateReturnInvoiceResponse(
+            returnId,
+            delivery.getShipping().getCourierName(),
+            delivery.getShipping().getTrackingNumber()
+        );
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerReturnApi.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerReturnApi.java
@@ -2,7 +2,10 @@ package com.bbangle.bbangle.claim.seller.controller.swagger;
 
 import com.bbangle.bbangle.claim.seller.controller.dto.RegisterReturnInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ReturnDecisionRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.UpdateReturnInvoiceRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.UpdateReturnInvoiceResponse;
 import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.dto.SingleResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,6 +29,17 @@ public interface SellerReturnApi {
     CommonResult registerReturnInvoice(
         @Parameter(description = "반품 요청 ID") Long returnId,
         RegisterReturnInvoiceRequest request,
+        @Parameter(hidden = true) Long sellerId
+    );
+
+    @Operation(
+        summary = "반품 수거 운송장 수정",
+        description = "수거 예정(PICKUP_SCHEDULED) 상태일 때만 택배사 코드와 운송장 번호를 수정할 수 있다. "
+            + "수거가 시작(PICKED_UP)된 이후에는 물류 흐름이 시작된 것으로 간주하여 수정이 차단된다."
+    )
+    SingleResult<UpdateReturnInvoiceResponse> updateReturnInvoice(
+        @Parameter(description = "반품 요청 ID") Long returnId,
+        UpdateReturnInvoiceRequest request,
         @Parameter(hidden = true) Long sellerId
     );
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerReturnService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerReturnService.java
@@ -2,11 +2,13 @@ package com.bbangle.bbangle.claim.seller.service;
 
 import com.bbangle.bbangle.claim.domain.ClaimDelivery;
 import com.bbangle.bbangle.claim.domain.ReturnRequest;
+import com.bbangle.bbangle.claim.domain.constant.ClaimDeliveryType;
 import com.bbangle.bbangle.claim.domain.constant.DecisionType;
 import com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus;
 import com.bbangle.bbangle.claim.repository.ClaimDeliveryRepository;
 import com.bbangle.bbangle.claim.repository.ClaimRepository;
 import com.bbangle.bbangle.claim.repository.ReturnRequestRepository;
+import com.bbangle.bbangle.claim.seller.controller.dto.UpdateReturnInvoiceResponse;
 import com.bbangle.bbangle.claim.seller.service.model.ReturnCreateCommand;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
@@ -128,6 +130,28 @@ public class SellerReturnService {
 
         ClaimDelivery claimDelivery = ClaimDelivery.createReturnPickup(returnRequest, courierCode, trackingNumber);
         claimDeliveryRepository.save(claimDelivery);
+    }
+
+    @Transactional
+    public UpdateReturnInvoiceResponse updateReturnInvoice(
+        Long returnId, Long sellerId, CourierCompany courierCode, String trackingNumber
+    ) {
+        if (!claimRepository.existsClaimRequestBySeller(returnId, sellerId)) {
+            throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+        }
+
+        ReturnRequest returnRequest = returnRequestRepository.findWithLockById(returnId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.CLAIM_NOT_FOUND));
+
+        returnRequest.validatePickupScheduled();
+
+        ClaimDelivery claimDelivery = claimDeliveryRepository
+            .findByClaimIdAndDeliveryType(returnId, ClaimDeliveryType.RETURN_PICKUP)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.DELIVERY_NOT_FOUND));
+
+        claimDelivery.updateInvoice(courierCode, trackingNumber);
+
+        return UpdateReturnInvoiceResponse.of(returnId, claimDelivery);
     }
 
     private Long getStoreIdOrThrow(Long sellerId) {

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerReturnUpdateInvoiceServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerReturnUpdateInvoiceServiceUnitTest.java
@@ -1,0 +1,215 @@
+package com.bbangle.bbangle.claim.seller.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.bbangle.bbangle.claim.domain.ClaimDelivery;
+import com.bbangle.bbangle.claim.domain.ReturnRequest;
+import com.bbangle.bbangle.claim.domain.constant.ClaimDeliveryType;
+import com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus;
+import com.bbangle.bbangle.claim.repository.ClaimDeliveryRepository;
+import com.bbangle.bbangle.claim.repository.ClaimRepository;
+import com.bbangle.bbangle.claim.repository.ReturnRequestRepository;
+import com.bbangle.bbangle.claim.seller.controller.dto.UpdateReturnInvoiceResponse;
+import com.bbangle.bbangle.delivery.domain.Shipping;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.claim.ReturnRequestFixture;
+import com.bbangle.bbangle.fixture.order.OrderItemFixture;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.CourierCompany;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[단위 테스트] SellerReturnService.updateReturnInvoice()")
+@ExtendWith(MockitoExtension.class)
+class SellerReturnUpdateInvoiceServiceUnitTest {
+
+    @InjectMocks
+    private SellerReturnService sut;
+
+    @Mock
+    private ReturnRequestRepository returnRequestRepository;
+
+    @Mock
+    private ClaimDeliveryRepository claimDeliveryRepository;
+
+    @Mock
+    private ClaimRepository claimRepository;
+
+    @Mock
+    private OrderItemHistoryRepository orderItemHistoryRepository;
+
+    private static final Long RETURN_ID = 1L;
+    private static final Long SELLER_ID = 10L;
+    private static final CourierCompany NEW_COURIER = CourierCompany.LOTTE;
+    private static final String NEW_TRACKING_NUMBER = "9876543210";
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("PICKUP_SCHEDULED 상태에서 운송장을 수정하면 갱신된 택배사와 운송장 번호가 반환된다")
+        void updateReturnInvoice_success_when_pickup_scheduled() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_REQUESTED);
+            ReturnRequest returnRequest = ReturnRequestFixture.pickupScheduled(orderItem);
+
+            ClaimDelivery mockDelivery = mock(ClaimDelivery.class);
+            Shipping mockShipping = mock(Shipping.class);
+            given(mockDelivery.getShipping()).willReturn(mockShipping);
+            given(mockShipping.getCourierName()).willReturn(NEW_COURIER.getDisplayName());
+            given(mockShipping.getTrackingNumber()).willReturn(NEW_TRACKING_NUMBER);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+            given(claimDeliveryRepository.findByClaimIdAndDeliveryType(RETURN_ID, ClaimDeliveryType.RETURN_PICKUP))
+                .willReturn(Optional.of(mockDelivery));
+
+            // when
+            UpdateReturnInvoiceResponse response =
+                sut.updateReturnInvoice(RETURN_ID, SELLER_ID, NEW_COURIER, NEW_TRACKING_NUMBER);
+
+            // then
+            then(mockDelivery).should(times(1)).updateInvoice(NEW_COURIER, NEW_TRACKING_NUMBER);
+            assertThat(response.returnId()).isEqualTo(RETURN_ID);
+            assertThat(response.courierName()).isEqualTo(NEW_COURIER.getDisplayName());
+            assertThat(response.trackingNumber()).isEqualTo(NEW_TRACKING_NUMBER);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 — 권한 및 존재 검증")
+    class AuthAndNotFoundFailures {
+
+        @Test
+        @DisplayName("판매자 소유권 검증 실패 시 SELLER_CLAIM_MISMATCH 예외가 발생하고 이후 로직은 실행되지 않는다")
+        void updateReturnInvoice_fails_when_seller_mismatch() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateReturnInvoice(RETURN_ID, SELLER_ID, NEW_COURIER, NEW_TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+
+            then(returnRequestRepository).should(never()).findWithLockById(any());
+            then(claimDeliveryRepository).should(never()).findByClaimIdAndDeliveryType(any(), any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 returnId로 요청하면 CLAIM_NOT_FOUND 예외가 발생한다")
+        void updateReturnInvoice_fails_when_claim_not_found() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateReturnInvoice(RETURN_ID, SELLER_ID, NEW_COURIER, NEW_TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_NOT_FOUND);
+
+            then(claimDeliveryRepository).should(never()).findByClaimIdAndDeliveryType(any(), any());
+        }
+
+        @Test
+        @DisplayName("PICKUP_SCHEDULED이지만 ClaimDelivery 레코드가 없으면 DELIVERY_NOT_FOUND 예외가 발생한다")
+        void updateReturnInvoice_fails_when_delivery_not_found() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_REQUESTED);
+            ReturnRequest returnRequest = ReturnRequestFixture.pickupScheduled(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+            given(claimDeliveryRepository.findByClaimIdAndDeliveryType(RETURN_ID, ClaimDeliveryType.RETURN_PICKUP))
+                .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateReturnInvoice(RETURN_ID, SELLER_ID, NEW_COURIER, NEW_TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.DELIVERY_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 — 상태 검증")
+    class StatusValidationFailures {
+
+        @Test
+        @DisplayName("PICKED_UP 이후 상태에서 수정을 시도하면 DELIVERY_MODIFY_NOT_ALLOWED 예외가 발생한다")
+        void updateReturnInvoice_fails_when_already_picked_up() {
+            // given — 수거가 완료된 상태
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_REQUESTED);
+            ReturnRequest returnRequest = ReturnRequestFixture.withStatus(
+                ReturnRequestRequestStatus.PICKED_UP, orderItem
+            );
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateReturnInvoice(RETURN_ID, SELLER_ID, NEW_COURIER, NEW_TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.DELIVERY_MODIFY_NOT_ALLOWED);
+
+            then(claimDeliveryRepository).should(never()).findByClaimIdAndDeliveryType(any(), any());
+        }
+
+        @Test
+        @DisplayName("INSPECTING 상태에서 수정을 시도하면 DELIVERY_MODIFY_NOT_ALLOWED 예외가 발생한다")
+        void updateReturnInvoice_fails_when_inspecting() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_REQUESTED);
+            ReturnRequest returnRequest = ReturnRequestFixture.withStatus(
+                ReturnRequestRequestStatus.INSPECTING, orderItem
+            );
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateReturnInvoice(RETURN_ID, SELLER_ID, NEW_COURIER, NEW_TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.DELIVERY_MODIFY_NOT_ALLOWED);
+
+            then(claimDeliveryRepository).should(never()).findByClaimIdAndDeliveryType(any(), any());
+        }
+
+        @Test
+        @DisplayName("APPROVED 상태(수거 등록 전)에서 수정을 시도하면 DELIVERY_MODIFY_NOT_ALLOWED 예외가 발생한다")
+        void updateReturnInvoice_fails_when_approved() {
+            // given — 아직 운송장이 등록되지 않은 단계
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_APPROVED);
+            ReturnRequest returnRequest = ReturnRequestFixture.approved(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateReturnInvoice(RETURN_ID, SELLER_ID, NEW_COURIER, NEW_TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.DELIVERY_MODIFY_NOT_ALLOWED);
+        }
+    }
+}


### PR DESCRIPTION
## History
- 리뷰어 : 경민님, 종수님
- 연관된 이슈 : #513 

## 🚀 Major Changes & Explanations
- 반품 수거 예약(PICKUP_SCHEDULED) 단계에서 판매자가 실수로 입력한 운송장 번호나 택배사 정보를 수정할 수 있는 기능을 추가
- 수정 가능 상태 범위: 현재 물류 흐름이 시작되기 직전인 PICKUP_SCHEDULED까지만 수정을 허용하도록 설계
- 동시성 제어: Pessimistic Lock(비관적 락)을 사용하여 운송장 수정 중 상태 변경 경합 방지

## 💡 ETC

- 수정 가능 상태 범위: 현재 물류 흐름이 시작되기 직전인 PICKUP_SCHEDULED까지만 수정을 허용하도록 설계
PICKED_UP 이후 단계에서도 수정이 필요할지 여쭤보기
- Lock 적용 범위: 서비스 레이어에서 findWithLockById를 사용하는 방식 어떻게 생각하시는지 여쭤보기

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 반품 픽업 배송 정보 업데이트 기능 추가: 판매자가 픽업 예약 상태인 반품 배송의 배송사 및 추적번호를 업데이트할 수 있는 새로운 기능 추가

* **테스트**
  * 반품 배송 정보 업데이트 기능에 대한 단위 테스트 추가(정상 작동, 권한 검증, 상태 검증 등)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->