### PR TITLE
[Fix] SecurityFilterChain에 CORS 설정 추가하여 preflight 요청 403 해결

### DIFF
--- a/src/main/java/com/bbangle/bbangle/config/security/SecurityConfig.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
@@ -36,6 +37,7 @@ public class SecurityConfig {
     public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
         http
             .securityMatcher("/**")
+            .cors(Customizer.withDefaults())
             .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
             .csrf(AbstractHttpConfigurer::disable)
             .addFilterBefore(
@@ -69,6 +71,7 @@ public class SecurityConfig {
     public SecurityFilterChain localApiFilterChain(HttpSecurity http) throws Exception {
         http
             .securityMatcher("/**")
+            .cors(Customizer.withDefaults())
             .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
             .csrf(AbstractHttpConfigurer::disable)
             .addFilterBefore(


### PR DESCRIPTION
---

## History

- Spring Security에서 .cors() 설정이 누락되어 403 오류 발생

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

```
                                                                                                                                                                                                                                                                                              
요청이 서버에 도착하면 Spring Security 필터가 먼저 가로챕니다:                                                                                                                                                                                                                                 
   
프론트 요청 (OPTIONS preflight)                                                                                                                                                                                                                                                                
    ↓                                                                                                                                                                                                                                                                                            
[Spring Security FilterChain]  ← 여기서 먼저 판단                                                                                                                                                                                                                                              
    ↓                                                                                                                                                                                                                                                                                            
[Spring MVC (CorsConfig.java)]  ← Security에서 막히면 여기까지 안 옴                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                 
.cors() 설정이 없으면 Security가  preflight OPTIONS 요청을 403으로 차단합니다. 
CorsConfig.java에 아무리 잘 설정해도 도달 자체가 안 되는 문제 발생

```

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 엔드포인트에 CORS(교차 출처 리소스 공유) 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->