### PR TITLE
[feat] 반품 처리 진행 (완료) API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/claim/domain/ReturnRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ReturnRequest.java
@@ -73,7 +73,8 @@ public class ReturnRequest extends Claim {
     public void processReturn() {
         this.status.validateTransition(ReturnRequestRequestStatus.COMPLETED);
         this.status = ReturnRequestRequestStatus.COMPLETED;
-    
+    }
+
     public void validatePickupScheduled() {
         if (this.status != PICKUP_SCHEDULED) {
             throw new BbangleException(BbangleErrorCode.DELIVERY_MODIFY_NOT_ALLOWED);

--- a/src/main/java/com/bbangle/bbangle/claim/domain/ReturnRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ReturnRequest.java
@@ -68,4 +68,9 @@ public class ReturnRequest extends Claim {
         this.status.validateTransition(ReturnRequestRequestStatus.PICKUP_SCHEDULED);
         this.status = ReturnRequestRequestStatus.PICKUP_SCHEDULED;
     }
+
+    public void processReturn() {
+        this.status.validateTransition(ReturnRequestRequestStatus.COMPLETED);
+        this.status = ReturnRequestRequestStatus.COMPLETED;
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerReturnController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerReturnController.java
@@ -35,6 +35,15 @@ public class SellerReturnController implements SellerReturnApi {
         return responseService.getSuccessResult();
     }
 
+    @PostMapping("/{returnId}/process")
+    public CommonResult processReturn(
+        @PathVariable Long returnId,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        sellerReturnService.processReturn(returnId, sellerId);
+        return responseService.getSuccessResult();
+    }
+
     @PatchMapping("/{returnId}/invoice")
     public CommonResult registerReturnInvoice(
         @PathVariable Long returnId,

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerReturnApi.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerReturnApi.java
@@ -20,6 +20,15 @@ public interface SellerReturnApi {
     );
 
     @Operation(
+        summary = "반품 최종 처리 (환불 확정)",
+        description = "검수 완료(INSPECTION_APPROVED) 상태의 반품을 최종 승인하여 COMPLETED로 변경하고 환불을 확정한다."
+    )
+    CommonResult processReturn(
+        @Parameter(description = "반품 요청 ID") Long returnId,
+        @Parameter(hidden = true) Long sellerId
+    );
+
+    @Operation(
         summary = "반품 운송장 입력",
         description = "반품 승인(APPROVED) 상태의 클레임에 택배사 코드와 운송장 번호를 등록하고, 상태를 반품 수거 예정(PICKUP_SCHEDULED)으로 변경한다."
     )

--- a/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerReturnService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerReturnService.java
@@ -116,6 +116,23 @@ public class SellerReturnService {
     }
 
     @Transactional
+    public void processReturn(Long returnId, Long sellerId) {
+        if (!claimRepository.existsClaimRequestBySeller(returnId, sellerId)) {
+            throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+        }
+
+        ReturnRequest returnRequest = returnRequestRepository.findWithLockById(returnId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.CLAIM_NOT_FOUND));
+
+        returnRequest.processReturn();
+
+        OrderItem orderItem = returnRequest.getOrderItem();
+        orderItem.returnComplete();
+
+        orderItemHistoryRepository.save(OrderItemHistory.create(orderItem));
+    }
+
+    @Transactional
     public void registerReturnInvoice(Long returnId, Long sellerId, CourierCompany courierCode, String trackingNumber) {
         if (!claimRepository.existsClaimRequestBySeller(returnId, sellerId)) {
             throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -171,4 +171,11 @@ public class OrderItem extends BaseEntity {
         }
         this.orderStatus = OrderStatus.CANCEL_REJECTED;
     }
+
+    public void returnComplete() {
+        if (orderStatus != OrderStatus.RETURN_APPROVED) {
+            throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
+        }
+        this.orderStatus = OrderStatus.RETURN_COMPLETED;
+    }
 }


### PR DESCRIPTION
## History
- 리뷰어 : 경민님, 종수님
- 연관된 이슈 : #514 

## 🚀 Major Changes & Explanations
- Endpoint: POST /api/v1/seller/returns/{returnId}/process
- 상태 전이: INSPECTION_APPROVED -> COMPLETED
- 반품 완료 처리와 동시에 OrderItemHistory 테이블에 변경 내역을 실시간 기록
- 기록 항목: 변경된 상태(COMPLETED), 처리 주체(sellerId), 처리 일시, 처리 사유("판매자 반품 최종 승인")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 셀러가 반품 요청을 최종 처리하고 환불 완료를 확정할 수 있는 기능이 추가되었습니다.
  * 처리 시 셀러 권한 검증이 수행되고, 연관된 주문 항목의 상태가 자동으로 "반품 완료"로 갱신되며 히스토리가 기록됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->