### PR TITLE
[Feat] (판매자) 충전금 출금 신청 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,6 +237,7 @@ src/main/resources/docker/
 
 ### claude ###
 .claude/
+CLAUDE.md
 
 ### worktrees ###
 .worktrees/

--- a/src/main/java/com/bbangle/bbangle/charge/domain/ChargeWithdrawalRequest.java
+++ b/src/main/java/com/bbangle/bbangle/charge/domain/ChargeWithdrawalRequest.java
@@ -55,6 +55,10 @@ public class ChargeWithdrawalRequest extends BaseEntity {
     @Column(columnDefinition = "tinyint", nullable = false)
     private Boolean success;
 
+    @Comment("출금 실패 이유")
+    @Column(columnDefinition = "VARCHAR(255)")
+    private String failureReason;
+
     @Builder
     private ChargeWithdrawalRequest(
         Seller seller,
@@ -62,19 +66,21 @@ public class ChargeWithdrawalRequest extends BaseEntity {
         String bankName,
         String accountHolder,
         String accountNumber,
-        Boolean success) {
+        Boolean success,
+        String failureReason) {
         this.seller = seller;
         this.withdrawalAmount = withdrawalAmount;
         this.bankName = bankName;
         this.accountHolder = accountHolder;
         this.accountNumber = accountNumber;
         this.success = success;
+        this.failureReason = failureReason;
     }
 
     /**
-     * 출금 신청 생성
+     * 출금 신청 성공 생성
      */
-    public static ChargeWithdrawalRequest create(
+    public static ChargeWithdrawalRequest createSuccess(
         Seller seller,
         BigDecimal withdrawalAmount,
         String bankName,
@@ -86,14 +92,28 @@ public class ChargeWithdrawalRequest extends BaseEntity {
             .bankName(bankName)
             .accountHolder(accountHolder)
             .accountNumber(accountNumber)
-            .success(false)
+            .success(true)
             .build();
     }
 
     /**
-     * 출금 처리 결과 설정
+     * 출금 신청 실패 생성
      */
-    public void setWithdrawalResult(boolean success) {
-        this.success = success;
+    public static ChargeWithdrawalRequest createFailure(
+        Seller seller,
+        BigDecimal withdrawalAmount,
+        String bankName,
+        String accountHolder,
+        String accountNumber,
+        String failureReason) {
+        return ChargeWithdrawalRequest.builder()
+            .seller(seller)
+            .withdrawalAmount(withdrawalAmount)
+            .bankName(bankName)
+            .accountHolder(accountHolder)
+            .accountNumber(accountNumber)
+            .success(false)
+            .failureReason(failureReason)
+            .build();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/charge/repository/ChargeBalanceRepository.java
+++ b/src/main/java/com/bbangle/bbangle/charge/repository/ChargeBalanceRepository.java
@@ -1,10 +1,18 @@
 package com.bbangle.bbangle.charge.repository;
 
 import com.bbangle.bbangle.charge.domain.ChargeBalance;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChargeBalanceRepository extends JpaRepository<ChargeBalance, Long> {
 
   Optional<ChargeBalance> findBySellerId(Long sellerId);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT cb FROM ChargeBalance cb WHERE cb.seller.id = :sellerId")
+  Optional<ChargeBalance> findBySellerIdWithLock(@Param("sellerId") Long sellerId);
 }

--- a/src/main/java/com/bbangle/bbangle/charge/seller/controller/SellerChargeController.java
+++ b/src/main/java/com/bbangle/bbangle/charge/seller/controller/SellerChargeController.java
@@ -1,11 +1,14 @@
 package com.bbangle.bbangle.charge.seller.controller;
 
+import com.bbangle.bbangle.charge.seller.controller.dto.request.WithdrawalRequest;
 import com.bbangle.bbangle.charge.seller.controller.dto.response.ChargeBalanceResponse;
 import com.bbangle.bbangle.charge.seller.controller.swagger.SellerChargeApi;
 import com.bbangle.bbangle.charge.seller.service.SellerChargeService;
+import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.SellerApiPath;
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -14,6 +17,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,5 +49,16 @@ public class SellerChargeController implements SellerChargeApi {
             pageable
         );
         return responseService.getSingleResult(response);
+    }
+
+    @Override
+    @PostMapping("/charge-balance/withdrawal")
+    public CommonResult requestWithdrawal(
+        @AuthenticationPrincipal Long sellerId,
+        @RequestHeader("X-Transaction-Id") String transactionId,
+        @Valid @RequestBody WithdrawalRequest request
+    ) {
+        chargeService.requestWithdrawal(request.toCommand(sellerId, transactionId));
+        return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/charge/seller/controller/dto/request/WithdrawalRequest.java
+++ b/src/main/java/com/bbangle/bbangle/charge/seller/controller/dto/request/WithdrawalRequest.java
@@ -1,0 +1,46 @@
+package com.bbangle.bbangle.charge.seller.controller.dto.request;
+
+import com.bbangle.bbangle.charge.seller.service.model.SellerChargeCommand.WithdrawalCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+@Schema(description = "충전금 출금 신청 요청 DTO")
+public record WithdrawalRequest(
+
+    @Schema(description = "출금 신청 금액 (0 초과 ~ 현재 잔액 이하)", example = "50000")
+    @NotNull(message = "출금 신청 금액은 필수입니다.")
+    @DecimalMin(value = "0.01", message = "출금 금액은 0보다 커야 합니다.")
+    BigDecimal withdrawalAmount,
+
+    @Schema(description = "은행명", example = "국민은행")
+    @NotBlank(message = "은행명은 필수입니다.")
+    @Size(max = 30, message = "은행명은 30자 이하여야 합니다.")
+    String bankName,
+
+    @Schema(description = "예금주", example = "홍길동")
+    @NotBlank(message = "예금주는 필수입니다.")
+    @Size(max = 30, message = "예금주명은 30자 이하여야 합니다.")
+    String accountHolder,
+
+    @Schema(description = "계좌번호 (숫자만, 최대 20자)", example = "123456789012")
+    @NotBlank(message = "계좌번호는 필수입니다.")
+    @Pattern(regexp = "\\d{1,20}", message = "계좌번호는 숫자만, 최대 20자여야 합니다.")
+    String accountNumber
+) {
+
+    public WithdrawalCommand toCommand(Long sellerId, String transactionId) {
+        return WithdrawalCommand.builder()
+            .sellerId(sellerId)
+            .transactionId(transactionId)
+            .withdrawalAmount(withdrawalAmount)
+            .bankName(bankName)
+            .accountHolder(accountHolder)
+            .accountNumber(accountNumber)
+            .build();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/charge/seller/controller/swagger/SellerChargeApi.java
+++ b/src/main/java/com/bbangle/bbangle/charge/seller/controller/swagger/SellerChargeApi.java
@@ -1,6 +1,8 @@
 package com.bbangle.bbangle.charge.seller.controller.swagger;
 
+import com.bbangle.bbangle.charge.seller.controller.dto.request.WithdrawalRequest;
 import com.bbangle.bbangle.charge.seller.controller.dto.response.ChargeBalanceResponse;
+import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -34,5 +36,24 @@ public interface SellerChargeApi {
         LocalDate endDate,
 
         @ParameterObject Pageable pageable
+    );
+
+    @Operation(
+        summary = "(판매자) 충전금 출금 신청",
+        description = "판매자가 보유한 충전금을 지정 계좌로 출금 신청합니다. "
+            + "신청 즉시 잔액에서 차감되며, X-Transaction-Id 헤더로 중복 요청을 방지합니다."
+    )
+    CommonResult requestWithdrawal(
+        @Parameter(hidden = true)
+        Long sellerId,
+
+        @Parameter(
+            description = "중복 요청 방지용 고유 거래 ID (UUID, 요청 시 생성)",
+            example = "550e8400-e29b-41d4-a716-446655440000",
+            required = true
+        )
+        String transactionId,
+
+        WithdrawalRequest request
     );
 }

--- a/src/main/java/com/bbangle/bbangle/charge/seller/service/SellerChargeService.java
+++ b/src/main/java/com/bbangle/bbangle/charge/seller/service/SellerChargeService.java
@@ -70,6 +70,7 @@ public class SellerChargeService {
         return new ChargeBalanceResponse(chargeBalance.getBalance(), pageResponse);
     }
 
+    // TODO: 계좌이체 외부 API 연동 필요.
     @Transactional
     public void requestWithdrawal(WithdrawalCommand command) {
         preventDuplicateRequest(command.transactionId(), command.sellerId());

--- a/src/main/java/com/bbangle/bbangle/charge/seller/service/SellerChargeService.java
+++ b/src/main/java/com/bbangle/bbangle/charge/seller/service/SellerChargeService.java
@@ -2,17 +2,25 @@ package com.bbangle.bbangle.charge.seller.service;
 
 import com.bbangle.bbangle.charge.domain.ChargeBalance;
 import com.bbangle.bbangle.charge.domain.ChargeHistory;
+import com.bbangle.bbangle.charge.domain.ChargeWithdrawalRequest;
+import com.bbangle.bbangle.charge.domain.enums.ChargeTransactionStatus;
 import com.bbangle.bbangle.charge.repository.ChargeBalanceRepository;
 import com.bbangle.bbangle.charge.repository.ChargeHistoryRepository;
+import com.bbangle.bbangle.charge.repository.ChargeWithdrawalRequestRepository;
 import com.bbangle.bbangle.charge.seller.controller.dto.response.ChargeBalanceResponse;
 import com.bbangle.bbangle.charge.seller.controller.dto.response.ChargeBalanceResponse.ChargeTransactionResponse;
+import com.bbangle.bbangle.charge.seller.service.model.SellerChargeCommand.WithdrawalCommand;
 import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.seller.domain.Seller;
+import java.time.Duration;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,8 +28,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SellerChargeService {
 
+    private static final String WITHDRAWAL_REDIS_KEY_PREFIX = "seller:charge:withdrawal:";
+    private static final Duration WITHDRAWAL_REDIS_TTL = Duration.ofMinutes(5);
+
     private final ChargeBalanceRepository chargeBalanceRepository;
     private final ChargeHistoryRepository chargeHistoryRepository;
+    private final ChargeWithdrawalRequestRepository chargeWithdrawalRequestRepository;
+    @Qualifier("defaultRedisTemplate")
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Transactional(readOnly = true)
     public ChargeBalanceResponse getChargeBalance(
@@ -54,6 +68,63 @@ public class SellerChargeService {
 
         BbanglePageResponse<ChargeTransactionResponse> pageResponse = BbanglePageResponse.of(content);
         return new ChargeBalanceResponse(chargeBalance.getBalance(), pageResponse);
+    }
+
+    @Transactional
+    public void requestWithdrawal(WithdrawalCommand command) {
+        preventDuplicateRequest(command.transactionId(), command.sellerId());
+
+        ChargeBalance chargeBalance = chargeBalanceRepository.findBySellerIdWithLock(command.sellerId())
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.CHARGE_BALANCE_NOT_FOUND));
+
+        Seller seller = chargeBalance.getSeller();
+
+        if (!chargeBalance.isSufficientBalance(command.withdrawalAmount())) {
+            chargeWithdrawalRequestRepository.save(
+                ChargeWithdrawalRequest.createFailure(
+                    seller,
+                    command.withdrawalAmount(),
+                    command.bankName(),
+                    command.accountHolder(),
+                    command.accountNumber(),
+                    "잔액부족"
+                )
+            );
+            throw new BbangleException(BbangleErrorCode.CHARGE_WITHDRAWAL_INSUFFICIENT_BALANCE);
+        }
+
+        chargeBalance.withdraw(command.withdrawalAmount());
+
+        ChargeWithdrawalRequest withdrawalRequest = chargeWithdrawalRequestRepository.save(
+            ChargeWithdrawalRequest.createSuccess(
+                seller,
+                command.withdrawalAmount(),
+                command.bankName(),
+                command.accountHolder(),
+                command.accountNumber()
+            )
+        );
+
+        chargeHistoryRepository.save(
+            ChargeHistory.fromWithdrawal(
+                seller,
+                command.withdrawalAmount(),
+                chargeBalance.getBalance(),
+                ChargeTransactionStatus.COMPLETED,
+                LocalDate.now(),
+                withdrawalRequest.getId()
+            )
+        );
+    }
+
+    private void preventDuplicateRequest(String transactionId, Long sellerId) {
+        String redisKey = WITHDRAWAL_REDIS_KEY_PREFIX + transactionId;
+        boolean isNew = Boolean.TRUE.equals(
+            redisTemplate.opsForValue().setIfAbsent(redisKey, String.valueOf(sellerId), WITHDRAWAL_REDIS_TTL)
+        );
+        if (!isNew) {
+            throw new BbangleException(BbangleErrorCode.CHARGE_WITHDRAWAL_DUPLICATED);
+        }
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/charge/seller/service/model/SellerChargeCommand.java
+++ b/src/main/java/com/bbangle/bbangle/charge/seller/service/model/SellerChargeCommand.java
@@ -1,0 +1,27 @@
+package com.bbangle.bbangle.charge.seller.service.model;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+
+/**
+ * 판매자 충전금 관련 커맨드(Command) 객체 모음.
+ * Controller에서 Service 계층으로 요청 정보를 전달하는 불변 값 객체(record)입니다.
+ */
+public class SellerChargeCommand {
+
+    /**
+     * 충전금 출금 신청 커맨드.
+     * 판매자가 보유한 충전금을 지정 계좌로 출금 신청할 때 사용합니다.
+     */
+    @Builder
+    public record WithdrawalCommand(
+        Long sellerId,
+        String transactionId,
+        BigDecimal withdrawalAmount,
+        String bankName,
+        String accountHolder,
+        String accountNumber
+    ) {
+
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -183,10 +183,10 @@ public enum BbangleErrorCode {
     SETTLEMENT_DATE_RANGE_EXCEEDED(-805, "조회 기간은 최대 1개월까지 가능합니다.", BAD_REQUEST),
     SETTLEMENT_DATE_REQUIRED(-806, "엑셀 다운로드 시 조회 시작일과 종료일은 필수입니다.", BAD_REQUEST),
 
-    // Charge Error(801 ~ 810)
-    CHARGE_BALANCE_NOT_FOUND(-801, "충전금 잔액 정보를 찾을 수 없습니다.", NOT_FOUND),
-    CHARGE_WITHDRAWAL_DUPLICATED(-802, "동일한 출금 요청이 처리 중입니다. 잠시 후 다시 시도해주세요.", CONFLICT),
-    CHARGE_WITHDRAWAL_INSUFFICIENT_BALANCE(-803, "충전금 잔액이 부족합니다.", BAD_REQUEST),
+    // Charge Error(821 ~ 830)
+    CHARGE_BALANCE_NOT_FOUND(-821, "충전금 잔액 정보를 찾을 수 없습니다.", NOT_FOUND),
+    CHARGE_WITHDRAWAL_DUPLICATED(-822, "동일한 출금 요청이 처리 중입니다. 잠시 후 다시 시도해주세요.", CONFLICT),
+    CHARGE_WITHDRAWAL_INSUFFICIENT_BALANCE(-823, "충전금 잔액이 부족합니다.", BAD_REQUEST),
 
     // Statistics Error(811~820)
     INVALID_STATISTICS_PERIOD(-811, "유효하지 않은 통계 기간입니다.", BAD_REQUEST),

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -185,6 +185,8 @@ public enum BbangleErrorCode {
 
     // Charge Error(801 ~ 810)
     CHARGE_BALANCE_NOT_FOUND(-801, "충전금 잔액 정보를 찾을 수 없습니다.", NOT_FOUND),
+    CHARGE_WITHDRAWAL_DUPLICATED(-802, "동일한 출금 요청이 처리 중입니다. 잠시 후 다시 시도해주세요.", CONFLICT),
+    CHARGE_WITHDRAWAL_INSUFFICIENT_BALANCE(-803, "충전금 잔액이 부족합니다.", BAD_REQUEST),
 
     // Statistics Error(811~820)
     INVALID_STATISTICS_PERIOD(-811, "유효하지 않은 통계 기간입니다.", BAD_REQUEST),

--- a/src/main/java/com/bbangle/bbangle/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/bbangle/bbangle/exception/GlobalControllerAdvice.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -71,6 +72,17 @@ public class GlobalControllerAdvice implements ErrorApi {
         CommonResult methodArgumentNotValidExceptionResult = responseService
             .getMethodArgumentNotValidExceptionResult(ex);
         return new ResponseEntity<>(methodArgumentNotValidExceptionResult, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<CommonResult> handleMissingRequestHeaderException(
+        MissingRequestHeaderException ex
+    ) {
+        log.error(ex.getMessage(), ex);
+        return new ResponseEntity<>(
+            responseService.getFailResult(ex.getLocalizedMessage(), -1),
+            HttpStatus.BAD_REQUEST
+        );
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/main/resources/flyway/V50__app.sql
+++ b/src/main/resources/flyway/V50__app.sql
@@ -1,3 +1,0 @@
-CREATE INDEX idx_store_application_status_created_id ON store_application (status, created_at, id);
-CREATE INDEX idx_account_verification_seller_verified_id ON account_verifications (seller_id, verified, id DESC);
-CREATE INDEX idx_store_application_seller_id ON store_application (seller_id);

--- a/src/main/resources/flyway/V50__app.sql
+++ b/src/main/resources/flyway/V50__app.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_store_application_status_created_id ON store_application (status, created_at, id);
+CREATE INDEX idx_account_verification_seller_verified_id ON account_verifications (seller_id, verified, id DESC);
+CREATE INDEX idx_store_application_seller_id ON store_application (seller_id);

--- a/src/main/resources/flyway/V53__app.sql
+++ b/src/main/resources/flyway/V53__app.sql
@@ -1,0 +1,2 @@
+ALTER TABLE charge_withdrawal_request
+    ADD COLUMN failure_reason VARCHAR(255) COMMENT '출금 실패 이유' AFTER success;

--- a/src/test/java/com/bbangle/bbangle/charge/seller/controller/SellerChargeControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/charge/seller/controller/SellerChargeControllerTest.java
@@ -2,12 +2,16 @@ package com.bbangle.bbangle.charge.seller.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bbangle.bbangle.charge.domain.enums.ChargeCategory;
 import com.bbangle.bbangle.charge.domain.enums.ChargeTransactionStatus;
+import com.bbangle.bbangle.charge.seller.controller.dto.request.WithdrawalRequest;
 import com.bbangle.bbangle.charge.seller.controller.dto.response.ChargeBalanceResponse;
 import com.bbangle.bbangle.charge.seller.controller.dto.response.ChargeBalanceResponse.ChargeTransactionResponse;
 import com.bbangle.bbangle.charge.seller.service.SellerChargeService;
@@ -32,6 +36,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -55,8 +60,13 @@ class SellerChargeControllerTest {
     @MockBean
     private SellerChargeService chargeService;
 
+    @Autowired
+    private JsonDataEncoder jsonDataEncoder;
+
     private static final Long TEST_SELLER_ID = 1L;
     private static final String BASE_URL = SellerApiPath.PREFIX + "/charge-balance";
+    private static final String WITHDRAWAL_URL = BASE_URL + "/withdrawal";
+    private static final String TEST_TRANSACTION_ID = "550e8400-e29b-41d4-a716-446655440000";
 
     @Nested
     @DisplayName("충전금 현황 조회")
@@ -205,7 +215,7 @@ class SellerChargeControllerTest {
         }
 
         @Test
-        @DisplayName("다양한 거래 구분 조회 (ACCUMULATE, DEDUCT)")
+        @DisplayName("다양한 거래 구분 조회 (ACCUMULATE, DEDUCT) - status 함께 검증")
         @WithMockUser(roles = "SELLER")
         void testGetChargeBalanceWithDifferentCategories() throws Exception {
             // Given
@@ -245,6 +255,158 @@ class SellerChargeControllerTest {
                 .andExpect(jsonPath("$.result.pageResponse.content[0].category").value("ACCUMULATE"))
                 .andExpect(jsonPath("$.result.pageResponse.content[1].category").value("DEDUCT"))
                 .andExpect(jsonPath("$.result.pageResponse.content[1].status").value("PENDING"));
+        }
+    }
+
+    @Nested
+    @DisplayName("충전금 출금 신청")
+    class RequestWithdrawal {
+
+        @Test
+        @DisplayName("출금 신청 성공")
+        @WithMockUser(roles = "SELLER")
+        void requestWithdrawal_success() throws Exception {
+            // Given
+            WithdrawalRequest request = new WithdrawalRequest(
+                new BigDecimal("50000"), "국민은행", "홍길동", "123456789012");
+
+            willDoNothing().given(chargeService).requestWithdrawal(any());
+
+            // When & Then
+            mockMvc.perform(post(WITHDRAWAL_URL)
+                    .header("X-Transaction-Id", TEST_TRANSACTION_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonDataEncoder.encode(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.message").value("SUCCESS"));
+        }
+
+        @Test
+        @DisplayName("실패 - X-Transaction-Id 헤더 누락")
+        @WithMockUser(roles = "SELLER")
+        void requestWithdrawal_missingTransactionIdHeader_badRequest() throws Exception {
+            // Given
+            WithdrawalRequest request = new WithdrawalRequest(
+                new BigDecimal("50000"), "국민은행", "홍길동", "123456789012");
+
+            // When & Then
+            mockMvc.perform(post(WITHDRAWAL_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonDataEncoder.encode(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - 출금 금액 누락")
+        @WithMockUser(roles = "SELLER")
+        void requestWithdrawal_missingWithdrawalAmount_badRequest() throws Exception {
+            // Given
+            WithdrawalRequest request = new WithdrawalRequest(
+                null, "국민은행", "홍길동", "123456789012");
+
+            // When & Then
+            mockMvc.perform(post(WITHDRAWAL_URL)
+                    .header("X-Transaction-Id", TEST_TRANSACTION_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonDataEncoder.encode(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - 출금 금액 0 이하")
+        @WithMockUser(roles = "SELLER")
+        void requestWithdrawal_zeroWithdrawalAmount_badRequest() throws Exception {
+            // Given
+            WithdrawalRequest request = new WithdrawalRequest(
+                BigDecimal.ZERO, "국민은행", "홍길동", "123456789012");
+
+            // When & Then
+            mockMvc.perform(post(WITHDRAWAL_URL)
+                    .header("X-Transaction-Id", TEST_TRANSACTION_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonDataEncoder.encode(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - 계좌번호에 문자 포함")
+        @WithMockUser(roles = "SELLER")
+        void requestWithdrawal_invalidAccountNumber_badRequest() throws Exception {
+            // Given
+            WithdrawalRequest request = new WithdrawalRequest(
+                new BigDecimal("50000"), "국민은행", "홍길동", "12345-6789");
+
+            // When & Then
+            mockMvc.perform(post(WITHDRAWAL_URL)
+                    .header("X-Transaction-Id", TEST_TRANSACTION_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonDataEncoder.encode(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("실패 - 중복 요청 (동일 transactionId)")
+        @WithMockUser(roles = "SELLER")
+        void requestWithdrawal_duplicateTransactionId_conflict() throws Exception {
+            // Given
+            WithdrawalRequest request = new WithdrawalRequest(
+                new BigDecimal("50000"), "국민은행", "홍길동", "123456789012");
+
+            willThrow(new BbangleException(BbangleErrorCode.CHARGE_WITHDRAWAL_DUPLICATED))
+                .given(chargeService).requestWithdrawal(any());
+
+            // When & Then
+            mockMvc.perform(post(WITHDRAWAL_URL)
+                    .header("X-Transaction-Id", TEST_TRANSACTION_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonDataEncoder.encode(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(-802))
+                .andExpect(jsonPath("$.message").value("동일한 출금 요청이 처리 중입니다. 잠시 후 다시 시도해주세요."));
+        }
+
+        @Test
+        @DisplayName("실패 - 잔액 부족")
+        @WithMockUser(roles = "SELLER")
+        void requestWithdrawal_insufficientBalance_badRequest() throws Exception {
+            // Given
+            WithdrawalRequest request = new WithdrawalRequest(
+                new BigDecimal("999999999"), "국민은행", "홍길동", "123456789012");
+
+            willThrow(new BbangleException(BbangleErrorCode.CHARGE_WITHDRAWAL_INSUFFICIENT_BALANCE))
+                .given(chargeService).requestWithdrawal(any());
+
+            // When & Then
+            mockMvc.perform(post(WITHDRAWAL_URL)
+                    .header("X-Transaction-Id", TEST_TRANSACTION_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonDataEncoder.encode(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(-803))
+                .andExpect(jsonPath("$.message").value("충전금 잔액이 부족합니다."));
+        }
+
+        @Test
+        @DisplayName("실패 - 인증 없이 접근")
+        void requestWithdrawal_unauthorized() throws Exception {
+            // Given
+            WithdrawalRequest request = new WithdrawalRequest(
+                new BigDecimal("50000"), "국민은행", "홍길동", "123456789012");
+
+            // When & Then
+            mockMvc.perform(post(WITHDRAWAL_URL)
+                    .header("X-Transaction-Id", TEST_TRANSACTION_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonDataEncoder.encode(request)))
+                .andExpect(status().isUnauthorized());
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/charge/seller/service/SellerChargeServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/charge/seller/service/SellerChargeServiceUnitTest.java
@@ -4,22 +4,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 import com.bbangle.bbangle.charge.domain.ChargeBalance;
 import com.bbangle.bbangle.charge.domain.ChargeHistory;
+import com.bbangle.bbangle.charge.domain.ChargeWithdrawalRequest;
 import com.bbangle.bbangle.charge.domain.enums.ChargeCategory;
 import com.bbangle.bbangle.charge.domain.enums.ChargeTransactionStatus;
 import com.bbangle.bbangle.charge.repository.ChargeBalanceRepository;
 import com.bbangle.bbangle.charge.repository.ChargeHistoryRepository;
+import com.bbangle.bbangle.charge.repository.ChargeWithdrawalRequestRepository;
 import com.bbangle.bbangle.charge.seller.controller.dto.response.ChargeBalanceResponse;
 import com.bbangle.bbangle.charge.seller.controller.dto.response.ChargeBalanceResponse.ChargeTransactionResponse;
+import com.bbangle.bbangle.charge.seller.service.model.SellerChargeCommand.WithdrawalCommand;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.charge.domain.ChargeBalanceFixture;
 import com.bbangle.bbangle.fixture.charge.domain.ChargeHistoryFixture;
 import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
 import com.bbangle.bbangle.seller.domain.Seller;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +35,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,6 +44,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("[단위 테스트] SellerChargeService")
 @ExtendWith(MockitoExtension.class)
@@ -45,10 +57,17 @@ class SellerChargeServiceUnitTest {
     @Mock
     private ChargeHistoryRepository chargeHistoryRepository;
 
+    @Mock
+    private ChargeWithdrawalRequestRepository chargeWithdrawalRequestRepository;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private RedisTemplate<String, Object> redisTemplate;
+
     @InjectMocks
     private SellerChargeService chargeService;
 
     private static final Long TEST_SELLER_ID = 1L;
+    private static final String TEST_TRANSACTION_ID = "550e8400-e29b-41d4-a716-446655440000";
 
     @Nested
     @DisplayName("충전금 현황 조회")
@@ -304,4 +323,188 @@ class SellerChargeServiceUnitTest {
             assertThat(response.pageResponse().totalPages()).isEqualTo(10);
         }
     }
+
+    @Nested
+    @DisplayName("충전금 출금 신청")
+    class RequestWithdrawal {
+
+        @Test
+        @DisplayName("출금 성공 - 잔액 차감, 출금 이력 및 거래 내역 저장")
+        void requestWithdrawal_success() {
+            // Given
+            Seller seller = SellerFixture.withId(SellerFixture.defaultSeller(), TEST_SELLER_ID);
+            ChargeBalance chargeBalance = ChargeBalanceFixture.createWithBalance(seller, new BigDecimal("100000"));
+            WithdrawalCommand command = createCommand(new BigDecimal("50000"));
+
+            ChargeWithdrawalRequest savedRequest = ChargeWithdrawalRequest.createSuccess(
+                seller, command.withdrawalAmount(), command.bankName(),
+                command.accountHolder(), command.accountNumber());
+            ReflectionTestUtils.setField(savedRequest, "id", 1L);
+
+            given(redisTemplate.opsForValue().setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(
+                true);
+            given(chargeBalanceRepository.findBySellerIdWithLock(TEST_SELLER_ID))
+                .willReturn(Optional.of(chargeBalance));
+            given(chargeWithdrawalRequestRepository.save(any())).willReturn(savedRequest);
+
+            // When
+            chargeService.requestWithdrawal(command);
+
+            // Then
+            assertThat(chargeBalance.getBalance()).isEqualByComparingTo(new BigDecimal("50000"));
+
+            ArgumentCaptor<ChargeWithdrawalRequest> withdrawalCaptor =
+                ArgumentCaptor.forClass(ChargeWithdrawalRequest.class);
+            then(chargeWithdrawalRequestRepository).should().save(withdrawalCaptor.capture());
+            assertThat(withdrawalCaptor.getValue().getSuccess()).isTrue();
+            assertThat(withdrawalCaptor.getValue().getFailureReason()).isNull();
+
+            ArgumentCaptor<ChargeHistory> historyCaptor =
+                ArgumentCaptor.forClass(ChargeHistory.class);
+            then(chargeHistoryRepository).should().save(historyCaptor.capture());
+            assertThat(historyCaptor.getValue().getCategory()).isEqualTo(ChargeCategory.DEDUCT);
+            assertThat(historyCaptor.getValue().getAmount()).isEqualByComparingTo(new BigDecimal("50000"));
+            assertThat(historyCaptor.getValue().getBalanceAfter()).isEqualByComparingTo(new BigDecimal("50000"));
+            assertThat(historyCaptor.getValue().getStatus()).isEqualTo(ChargeTransactionStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("중복 요청 - 동일 transactionId 재요청 시 예외 발생")
+        void requestWithdrawal_duplicateTransactionId_throwsDuplicated() {
+            // Given
+            WithdrawalCommand command = createCommand(new BigDecimal("50000"));
+
+            given(redisTemplate.opsForValue().setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willReturn(false);
+
+            // When & Then
+            assertThatThrownBy(() -> chargeService.requestWithdrawal(command))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CHARGE_WITHDRAWAL_DUPLICATED);
+
+            then(chargeBalanceRepository).should(never()).findBySellerIdWithLock(anyLong());
+        }
+
+        @Test
+        @DisplayName("충전금 잔액 정보 없음 - 예외 발생")
+        void requestWithdrawal_chargeBalanceNotFound_throwsException() {
+            // Given
+            WithdrawalCommand command = createCommand(new BigDecimal("50000"));
+
+            given(redisTemplate.opsForValue().setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willReturn(true);
+            given(chargeBalanceRepository.findBySellerIdWithLock(TEST_SELLER_ID))
+                .willReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> chargeService.requestWithdrawal(command))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CHARGE_BALANCE_NOT_FOUND);
+
+            then(chargeWithdrawalRequestRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("잔액 부족 - 실패 이력 저장 후 예외 발생")
+        void requestWithdrawal_insufficientBalance_savesFailureAndThrowsException() {
+            // Given
+            Seller seller = SellerFixture.withId(SellerFixture.defaultSeller(), TEST_SELLER_ID);
+            ChargeBalance chargeBalance = ChargeBalanceFixture.createWithBalance(seller, new BigDecimal("10000"));
+            WithdrawalCommand command = createCommand(new BigDecimal("50000"));
+
+            ChargeWithdrawalRequest failedRequest = ChargeWithdrawalRequest.createFailure(
+                seller, command.withdrawalAmount(), command.bankName(),
+                command.accountHolder(), command.accountNumber(), "잔액부족");
+            ReflectionTestUtils.setField(failedRequest, "id", 1L);
+
+            given(redisTemplate.opsForValue().setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willReturn(true);
+            given(chargeBalanceRepository.findBySellerIdWithLock(TEST_SELLER_ID))
+                .willReturn(Optional.of(chargeBalance));
+            given(chargeWithdrawalRequestRepository.save(any())).willReturn(failedRequest);
+
+            // When & Then
+            assertThatThrownBy(() -> chargeService.requestWithdrawal(command))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CHARGE_WITHDRAWAL_INSUFFICIENT_BALANCE);
+
+            ArgumentCaptor<ChargeWithdrawalRequest> captor =
+                ArgumentCaptor.forClass(ChargeWithdrawalRequest.class);
+            then(chargeWithdrawalRequestRepository).should().save(captor.capture());
+            assertThat(captor.getValue().getSuccess()).isFalse();
+            assertThat(captor.getValue().getFailureReason()).isEqualTo("잔액부족");
+
+            then(chargeHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("잔액 부족 - 잔액은 차감되지 않음")
+        void requestWithdrawal_insufficientBalance_balanceNotChanged() {
+            // Given
+            Seller seller = SellerFixture.withId(SellerFixture.defaultSeller(), TEST_SELLER_ID);
+            BigDecimal originalBalance = new BigDecimal("10000");
+            ChargeBalance chargeBalance = ChargeBalanceFixture.createWithBalance(seller, originalBalance);
+            WithdrawalCommand command = createCommand(new BigDecimal("50000"));
+
+            given(redisTemplate.opsForValue().setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willReturn(true);
+            given(chargeBalanceRepository.findBySellerIdWithLock(TEST_SELLER_ID))
+                .willReturn(Optional.of(chargeBalance));
+
+            // When & Then
+            assertThatThrownBy(() -> chargeService.requestWithdrawal(command))
+                .isInstanceOf(BbangleException.class);
+
+            assertThat(chargeBalance.getBalance()).isEqualByComparingTo(originalBalance);
+        }
+
+        @Test
+        @DisplayName("Redis 키에 sellerId가 값으로 저장됨")
+        void requestWithdrawal_redisKeyContainsSellerIdAsValue() {
+            // Given
+            Seller seller = SellerFixture.withId(SellerFixture.defaultSeller(), TEST_SELLER_ID);
+            ChargeBalance chargeBalance = ChargeBalanceFixture.createWithBalance(seller, new BigDecimal("100000"));
+            WithdrawalCommand command = createCommand(new BigDecimal("50000"));
+
+            ChargeWithdrawalRequest savedRequest = ChargeWithdrawalRequest.createSuccess(
+                seller, command.withdrawalAmount(), command.bankName(),
+                command.accountHolder(), command.accountNumber());
+            ReflectionTestUtils.setField(savedRequest, "id", 1L);
+
+            given(redisTemplate.opsForValue().setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willReturn(true);
+            given(chargeBalanceRepository.findBySellerIdWithLock(TEST_SELLER_ID))
+                .willReturn(Optional.of(chargeBalance));
+            given(chargeWithdrawalRequestRepository.save(any())).willReturn(savedRequest);
+
+            // When
+            chargeService.requestWithdrawal(command);
+
+            // Then
+            ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<String> valueCaptor = ArgumentCaptor.forClass(String.class);
+            then(redisTemplate.opsForValue()).should()
+                .setIfAbsent(keyCaptor.capture(), valueCaptor.capture(), any(Duration.class));
+
+            assertThat(keyCaptor.getValue())
+                .isEqualTo("seller:charge:withdrawal:" + TEST_TRANSACTION_ID);
+            assertThat(valueCaptor.getValue())
+                .isEqualTo(String.valueOf(TEST_SELLER_ID));
+        }
+
+        private WithdrawalCommand createCommand(BigDecimal withdrawalAmount) {
+            return WithdrawalCommand.builder()
+                .sellerId(TEST_SELLER_ID)
+                .transactionId(TEST_TRANSACTION_ID)
+                .withdrawalAmount(withdrawalAmount)
+                .bankName("국민은행")
+                .accountHolder("홍길동")
+                .accountNumber("123456789012")
+                .build();
+        }
+    }
+    
 }


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->

## 🚀 Major Changes & Explanations

* [feat] (판매자) 충전금 출금 신청 API 구현 (`POST /api/v1/seller/charge-balance/withdrawal`)
  - `WithdrawalRequest` DTO 추가 (요청 바디 유효성 검사 포함)
  - `SellerChargeCommand.WithdrawalCommand` 추가
  - `SellerChargeApi` Swagger 인터페이스에 출금 엔드포인트 정의
  - `SellerChargeController`에 출금 엔드포인트 구현
  - `SellerChargeService.requestWithdrawal()` 구현
    - Redis `setIfAbsent` (Atomic) 으로 중복 요청 방지 (`X-Transaction-Id` 헤더 기반)
    - `ChargeBalance` 비관적 락(`PESSIMISTIC_WRITE`) 조회로 동시성 제어
    - 잔액 충분: `ChargeWithdrawalRequest(success=true)` 저장 → 잔액 차감 → `ChargeHistory` 저장
    - 잔액 부족: `ChargeWithdrawalRequest(success=false, failureReason=잔액부족)` 저장 → 예외

* [chore] Flyway V50 추가
  - `charge_withdrawal_request` 테이블에 `failure_reason` 컬럼 추가

* [feat] `ChargeWithdrawalRequest` 엔티티 수정
  - `failureReason` 필드 추가
  - `create()` → `createSuccess()` / `createFailure(failureReason)` 분리
  - `ChargeBalanceRepository`에 비관적 락 조회 메서드 `findBySellerIdWithLock()` 추가

* [feat] 에러 코드 추가
  - `-802` `CHARGE_WITHDRAWAL_DUPLICATED` : 중복 출금 요청
  - `-803` `CHARGE_WITHDRAWAL_INSUFFICIENT_BALANCE` : 잔액 부족

* [feat] `GlobalControllerAdvice`에 `MissingRequestHeaderException` 핸들러 추가 (400 반환)

* [test] `SellerChargeServiceUnitTest` - `RequestWithdrawal` 케이스 추가
  - 출금 성공 / 중복 요청 / 잔액 정보 없음 / 잔액 부족 / Redis 키·값 형식 검증

* [test] `SellerChargeControllerTest` - `RequestWithdrawal` 케이스 추가
  - 출금 성공 / 헤더 누락 / validation 실패(금액·계좌번호) / 중복 요청 / 잔액 부족 / 미인증

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->

## 💡 ETC

- Redis key 구조: `seller:charge:withdrawal:{transactionId}` / value: `{sellerId}` / TTL: 5분
- `X-Transaction-Id` 헤더는 화면 진입 시가 아닌 **요청 시** UUID를 생성하여 전달
- `RedisRepositoryImpl` 미사용 — `RedisTemplate` 직접 사용 (`setIfAbsent` atomic 보장)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 판매자가 은행 계좌 정보를 통해 충전금 출금을 요청할 수 있는 기능 추가
  * 중복 출금 요청 방지 기능 추가
  * 출금 실패 사유 기록 기능 추가

* **버그 수정**
  * 출금 요청 시 X-Transaction-Id 헤더 누락에 대한 명확한 에러 처리 추가

* **테스트**
  * 출금 요청 관련 통합 테스트 및 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->