### PR TITLE
[Feature] (관리자) 판매자 회원가입 및 스토어 등록 거절 API

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -94,6 +94,7 @@ public enum BbangleErrorCode {
     AWS_S3_FILE_NOT_FOUND(-604, "URL에 파일이 존재하지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     STREAM_CLOSING_ERROR(-605, "Stream 파일 닫기에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
+    NOT_FOUND_REQUEST(-989, "해당 요청을 찾을 수 없습니다.", NOT_FOUND),
     REQUEST_IS_REJECTED(-990, "이미 거절된 요청입니다.", BAD_REQUEST),
     REQUEST_IS_APPROVED(-991, "이미 승인된 요청입니다.", BAD_REQUEST),
     REQUEST_IS_PENDING(-992, "승인 대기중인 요청입니다.", BAD_REQUEST),

--- a/src/main/java/com/bbangle/bbangle/seller/admin/controller/AdminSellerController.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/controller/AdminSellerController.java
@@ -3,13 +3,19 @@ package com.bbangle.bbangle.seller.admin.controller;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.AdminApiPath;
+import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerRequest;
 import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse.AdminSellerApplicationList;
+import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse.AdminSellerApplicationRejectList;
 import com.bbangle.bbangle.seller.admin.controller.swagger.AdminSellerApi;
 import com.bbangle.bbangle.seller.admin.facade.AdminSellerFacade;
+import com.bbangle.bbangle.seller.admin.service.AdminSellerService;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +28,7 @@ public class AdminSellerController implements AdminSellerApi {
 
     private final ResponseService responseService;
     private final AdminSellerFacade adminSellerFacade;
+    private final AdminSellerService adminSellerService;
 
     @Override
     @GetMapping()
@@ -30,6 +37,17 @@ public class AdminSellerController implements AdminSellerApi {
     ) {
         return responseService.getSingleResult(
             adminSellerFacade.getAdminSellerApplicationList(page)
+        );
+    }
+
+    // TODO : Test
+    @Override
+    @PatchMapping("/reject")
+    public SingleResult<AdminSellerApplicationRejectList> rejectSellerApplications(
+        @Valid @RequestBody AdminSellerRequest.StoreApplicationIds request
+    ) {
+        return responseService.getSingleResult(
+            adminSellerService.rejectStoreApplications(request.applicationIds())
         );
     }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/admin/controller/AdminSellerController.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/controller/AdminSellerController.java
@@ -40,7 +40,6 @@ public class AdminSellerController implements AdminSellerApi {
         );
     }
 
-    // TODO : Test
     @Override
     @PatchMapping("/reject")
     public SingleResult<AdminSellerApplicationRejectList> rejectSellerApplications(

--- a/src/main/java/com/bbangle/bbangle/seller/admin/controller/dto/AdminSellerRequest.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/controller/dto/AdminSellerRequest.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.seller.admin.controller.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.Builder;
 
@@ -12,6 +13,6 @@ public class AdminSellerRequest {
     public record StoreApplicationIds(
         @NotEmpty(message = "신청 Id 목록은 비어 있을 수 없습니다.")
         @Schema(description = "스토어 신청서 Id 목록", example = "[1]")
-        List<Long> applicationIds
+        List<@NotNull Long> applicationIds
     ) {}
 }

--- a/src/main/java/com/bbangle/bbangle/seller/admin/controller/dto/AdminSellerRequest.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/controller/dto/AdminSellerRequest.java
@@ -1,0 +1,17 @@
+package com.bbangle.bbangle.seller.admin.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import lombok.Builder;
+
+public class AdminSellerRequest {
+
+    @Builder
+    @Schema(description = "승인 또는 거절할 판매자의 스토어 등록 신청 목록 DTO")
+    public record StoreApplicationIds(
+        @NotEmpty(message = "신청 Id 목록은 비어 있을 수 없습니다.")
+        @Schema(description = "스토어 신청서 Id 목록", example = "[1]")
+        List<Long> applicationIds
+    ) {}
+}

--- a/src/main/java/com/bbangle/bbangle/seller/admin/controller/dto/AdminSellerResponse.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/controller/dto/AdminSellerResponse.java
@@ -51,10 +51,11 @@ public class AdminSellerResponse {
     @Schema(description = "판매자 스토어 등록 신청 거절 결과 목록 DTO")
     public record AdminSellerApplicationRejectList(
         @Schema(description = "거절 처리한 신청 Id 목록", example = "[1]") List<Long> successIds,
-        @Schema(description = "거절 실패한 신청 Id 목록", example = "1", nullable = true) List<FailDetail> failDetails
+        List<FailDetail> failDetails
     ) {
 
         @Builder
+        @Schema(description = "거절 처리 실패한 신청 상제 정보")
         public record FailDetail(
             @Schema(description = "거절 실패한 신청 Id", example = "1") long storeApplicationId,
             @Schema(description = "거절 실패한 상세 사유", example = "존재하지 않는 신청입니다.") String reason

--- a/src/main/java/com/bbangle/bbangle/seller/admin/controller/dto/AdminSellerResponse.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/controller/dto/AdminSellerResponse.java
@@ -46,4 +46,18 @@ public class AdminSellerResponse {
         @Schema(description = "이전 페이지 여부", example = "false") boolean hasPrevious,
         @Schema(description = "다음 페이지 여부", example = "false") boolean hasNext
     ) {}
+
+    @Builder
+    @Schema(description = "판매자 스토어 등록 신청 거절 결과 목록 DTO")
+    public record AdminSellerApplicationRejectList(
+        @Schema(description = "거절 처리한 신청 Id 목록", example = "[1]") List<Long> successIds,
+        @Schema(description = "거절 실패한 신청 Id 목록", example = "1", nullable = true) List<FailDetail> failDetails
+    ) {
+
+        @Builder
+        public record FailDetail(
+            @Schema(description = "거절 실패한 신청 Id", example = "1") long storeApplicationId,
+            @Schema(description = "거절 실패한 상세 사유", example = "존재하지 않는 신청입니다.") String reason
+        ) {}
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/admin/controller/swagger/AdminSellerApi.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/controller/swagger/AdminSellerApi.java
@@ -1,11 +1,14 @@
 package com.bbangle.bbangle.seller.admin.controller.swagger;
 
 import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerRequest;
 import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Admin Store", description = "(관리자) 판매자 관리 API")
@@ -20,5 +23,13 @@ public interface AdminSellerApi {
         @RequestParam(defaultValue = "1")
         @Min(1)
         int page
+    );
+
+    @Operation(
+        summary = "(관리자) 판매자 스토어 등록 요청 목록 거절",
+        description = "판매자의 스토어 등록 요청을 거절합니다."
+    )
+    SingleResult<AdminSellerResponse.AdminSellerApplicationRejectList> rejectSellerApplications(
+        @Valid @RequestBody AdminSellerRequest.StoreApplicationIds request
     );
 }

--- a/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerService.java
@@ -1,9 +1,19 @@
 package com.bbangle.bbangle.seller.admin.service;
 
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse;
+import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse.AdminSellerApplicationRejectList;
+import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse.AdminSellerApplicationRejectList.FailDetail;
 import com.bbangle.bbangle.seller.admin.service.model.AdminSellerInfo.SellerApplicationInfoList;
 import com.bbangle.bbangle.seller.admin.service.model.AdminSellerInfo.SellerApplicationInfoList.SellerApplicationInfo;
+import com.bbangle.bbangle.store.domain.StoreApplication;
 import com.bbangle.bbangle.store.repository.StoreApplicationRepository;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +39,54 @@ public class AdminSellerService {
             .totalElements(totalElements)
             .hasPrevious(page > 1)
             .hasNext(page < totalPages)
+            .build();
+    }
+
+    // TODO : Test
+    @Transactional
+    public AdminSellerResponse.AdminSellerApplicationRejectList rejectStoreApplications(List<Long> ids) {
+
+        List<Long> successIds = new ArrayList<>();
+        List<AdminSellerApplicationRejectList.FailDetail> failDetails = new ArrayList<>();
+
+        List<StoreApplication> applications = storeApplicationRepository.findAllWithSellerByIdIn(ids);
+
+        Map<Long, StoreApplication> map = applications.stream()
+            .collect(Collectors.toMap(StoreApplication::getId, Function.identity()));
+
+        for (Long id : ids) {
+            StoreApplication app = map.get(id);
+
+            if (app == null) {
+                failDetails.add(FailDetail.builder()
+                    .storeApplicationId(id)
+                    .reason(BbangleErrorCode.NOT_FOUND_REQUEST.getMessage())
+                    .build()
+                );
+                continue;
+            }
+
+            try {
+                app.reject();
+                successIds.add(id);
+            } catch (BbangleException e) {
+                failDetails.add(FailDetail.builder()
+                    .storeApplicationId(id)
+                    .reason(e.getMessage())
+                    .build()
+                );
+            } catch (Exception e) {
+                failDetails.add(FailDetail.builder()
+                    .storeApplicationId(id)
+                    .reason("알 수 없는 오류")
+                    .build()
+                );
+            }
+        }
+
+        return AdminSellerApplicationRejectList.builder()
+            .successIds(successIds)
+            .failDetails(failDetails)
             .build();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerService.java
@@ -42,7 +42,6 @@ public class AdminSellerService {
             .build();
     }
 
-    // TODO : Test
     @Transactional
     public AdminSellerResponse.AdminSellerApplicationRejectList rejectStoreApplications(List<Long> ids) {
 

--- a/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerService.java
@@ -15,9 +15,11 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminSellerService {
@@ -75,9 +77,10 @@ public class AdminSellerService {
                     .build()
                 );
             } catch (Exception e) {
+                log.error("스토어 등록 거절 처리 중 예기치 못한 오류 발생. id={}", id, e);
                 failDetails.add(FailDetail.builder()
                     .storeApplicationId(id)
-                    .reason("알 수 없는 오류")
+                    .reason(BbangleErrorCode.INTERNAL_SERVER_ERROR.getMessage())
                     .build()
                 );
             }

--- a/src/main/java/com/bbangle/bbangle/store/domain/StoreApplication.java
+++ b/src/main/java/com/bbangle/bbangle/store/domain/StoreApplication.java
@@ -126,7 +126,6 @@ public class StoreApplication extends BaseEntity {
         this.status = StoreApprovalStatus.APPROVE;
     }
 
-    // TODO : Test
     public void reject() {
         validateRejectable();
 

--- a/src/main/java/com/bbangle/bbangle/store/domain/StoreApplication.java
+++ b/src/main/java/com/bbangle/bbangle/store/domain/StoreApplication.java
@@ -1,7 +1,10 @@
 package com.bbangle.bbangle.store.domain;
 
 import com.bbangle.bbangle.common.domain.BaseEntity;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import com.bbangle.bbangle.store.domain.model.EmailVO;
 import com.bbangle.bbangle.store.domain.model.PhoneNumberVO;
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
@@ -123,8 +126,21 @@ public class StoreApplication extends BaseEntity {
         this.status = StoreApprovalStatus.APPROVE;
     }
 
-    // TODO : (관리자) 스토어 등록 거절 구현
+    // TODO : Test
     public void reject() {
+        validateRejectable();
+
         this.status = StoreApprovalStatus.REJECT;
+
+        if (this.seller.getCertificationStatus() != CertificationStatus.APPROVED) {
+            this.seller.updateStatus(CertificationStatus.REJECTED);
+        }
+    }
+
+    private void validateRejectable() {
+        if (this.status == StoreApprovalStatus.APPROVE &&
+            this.seller.getCertificationStatus() == CertificationStatus.APPROVED) {
+            throw new BbangleException(BbangleErrorCode.REQUEST_IS_APPROVED);
+        }
     }
 }

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreApplicationRepository.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreApplicationRepository.java
@@ -2,10 +2,15 @@ package com.bbangle.bbangle.store.repository;
 
 import com.bbangle.bbangle.store.domain.StoreApplication;
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreApplicationRepository
     extends JpaRepository<StoreApplication, Long>, StoreApplicationQueryDSLRepository {
 
     long countByStatus(StoreApprovalStatus status);
+
+    @EntityGraph(attributePaths = "seller")
+    List<StoreApplication> findAllWithSellerByIdIn(List<Long> ids);
 }

--- a/src/test/java/com/bbangle/bbangle/seller/admin/controller/AdminSellerControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/admin/controller/AdminSellerControllerTest.java
@@ -1,10 +1,12 @@
 package com.bbangle.bbangle.seller.admin.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -15,8 +17,12 @@ import com.bbangle.bbangle.config.security.AdminApiPath;
 import com.bbangle.bbangle.config.security.SecurityConfig;
 import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
 import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerRequest;
 import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse.AdminSellerApplicationList;
+import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse.AdminSellerApplicationRejectList;
 import com.bbangle.bbangle.seller.admin.facade.AdminSellerFacade;
+import com.bbangle.bbangle.seller.admin.service.AdminSellerService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,6 +32,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -46,8 +53,14 @@ class AdminSellerControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @MockBean
     private AdminSellerFacade adminSellerFacade;
+
+    @MockBean
+    private AdminSellerService adminSellerService;
 
     @SpyBean
     private ResponseService responseService;
@@ -117,6 +130,76 @@ class AdminSellerControllerTest {
                     .param("page", "0"))
                 .andExpect(status().isBadRequest());
             verify(adminSellerFacade, never()).getAdminSellerApplicationList(anyInt());
+        }
+    }
+
+    @Nested
+    @DisplayName("rejectSellerApplications() 테스트")
+    class RejectSellerApplicationsTest {
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("판매자의 스토어 등록 신청을 거절한다.")
+        void success_rejectSellerApplications() throws Exception {
+
+            // given
+            List<Long> ids = List.of(1L, 2L);
+
+            AdminSellerRequest.StoreApplicationIds request = new AdminSellerRequest.StoreApplicationIds(ids);
+
+            AdminSellerApplicationRejectList serviceResult = AdminSellerApplicationRejectList.builder()
+                .successIds(ids)
+                .failDetails(List.of())
+                .build();
+
+            given(adminSellerService.rejectStoreApplications(ids)).willReturn(serviceResult);
+
+            // when & then
+            mockMvc.perform(patch(AdminApiPath.PREFIX + "/sellers/reject")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.successIds").isArray())
+                .andExpect(jsonPath("$.result.successIds[0]").value(1L))
+                .andExpect(jsonPath("$.result.successIds[1]").value(2L))
+                .andExpect(jsonPath("$.result.failDetails").isEmpty());
+
+            verify(adminSellerService).rejectStoreApplications(ids);
+        }
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("Request가 없는 경우 예외를 반환한다.")
+        void fail_rejectSellerApplications_validation() throws Exception {
+
+            // given
+            String invalidJson = "{}";
+
+            // when & then
+            mockMvc.perform(patch(AdminApiPath.PREFIX + "/sellers/reject")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(invalidJson)
+                )
+                .andExpect(status().isBadRequest());
+
+            verify(adminSellerService, never()).rejectStoreApplications(any());
+        }
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("Request가 비어있는 리스트일 경우 예외를 반환한다.")
+        void rejectSellerApplications_empty_ids() throws Exception {
+
+            // given
+            AdminSellerRequest.StoreApplicationIds request = new AdminSellerRequest.StoreApplicationIds(List.of());
+
+            // when & then
+            mockMvc.perform(patch(AdminApiPath.PREFIX + "/sellers/reject")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+            verify(adminSellerService, never()).rejectStoreApplications(any());
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/seller/admin/service/AdminSellerServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/admin/service/AdminSellerServiceIntegrationTest.java
@@ -1,16 +1,22 @@
 package com.bbangle.bbangle.seller.admin.service;
 
+import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.DEFAULT_STORE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.fixture.seller.domain.AccountVerificationFixture;
 import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreApplicationFixture;
+import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse.AdminSellerApplicationRejectList;
 import com.bbangle.bbangle.seller.admin.service.model.AdminSellerInfo.SellerApplicationInfoList;
 import com.bbangle.bbangle.seller.admin.service.model.AdminSellerInfo.SellerApplicationInfoList.SellerApplicationInfo;
 import com.bbangle.bbangle.seller.domain.AccountVerification;
 import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
+import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.store.domain.StoreApplication;
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
+import com.bbangle.bbangle.store.repository.StoreApplicationRepository;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +38,12 @@ class AdminSellerServiceIntegrationTest {
 
     @Autowired
     private EntityManager em;
+
+    @Autowired
+    private StoreApplicationRepository storeApplicationRepository;
+
+    @Autowired
+    private SellerRepository sellerRepository;
 
     @Nested
     @DisplayName("getAdminSellerApplicationList() 테스트")
@@ -188,6 +200,110 @@ class AdminSellerServiceIntegrationTest {
             assertThat(result.sellerApplicationInfoList()).isEmpty();
             assertThat(result.hasNext()).isFalse();
             assertThat(result.hasPrevious()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("rejectStoreApplications() 테스트")
+    class RejectStoreApplicationsTest {
+
+        @Test
+        @DisplayName("모든 신청이 정상적으로 거절된다")
+        void success_rejectStoreApplications() {
+
+            // given
+            Seller seller1 = sellerRepository.save(SellerFixture.defaultSeller());
+            Seller seller2 = sellerRepository.save(SellerFixture.defaultSeller());
+            StoreApplication app1 = storeApplicationRepository.save(
+                StoreApplicationFixture.defaultStoreApplication(seller1, null)
+            );
+            StoreApplication app2 = storeApplicationRepository.save(
+                StoreApplicationFixture.defaultStoreApplication(seller2, null)
+            );
+            em.flush();
+            em.clear();
+
+            List<Long> ids = List.of(app1.getId(), app2.getId());
+
+            // when
+            AdminSellerApplicationRejectList result = adminSellerService.rejectStoreApplications(ids);
+            em.flush();
+            em.clear();
+
+            // then
+            assertThat(result.successIds()).containsExactlyInAnyOrderElementsOf(ids);
+            assertThat(result.failDetails()).isEmpty();
+
+            // DB 반영 확인 (핵심)
+            StoreApplication updated1 = storeApplicationRepository.findById(app1.getId()).orElseThrow();
+            StoreApplication updated2 = storeApplicationRepository.findById(app2.getId()).orElseThrow();
+
+            assertThat(updated1.getStatus()).isEqualTo(StoreApprovalStatus.REJECT);
+            assertThat(updated2.getStatus()).isEqualTo(StoreApprovalStatus.REJECT);
+
+            assertThat(updated1.getSeller().getCertificationStatus()).isEqualTo(CertificationStatus.REJECTED);
+            assertThat(updated2.getSeller().getCertificationStatus()).isEqualTo(CertificationStatus.REJECTED);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 신청의 ID는 실패로 처리된다")
+        void rejectStoreApplications_with_not_found() {
+
+            // given
+            Seller seller = sellerRepository.save(SellerFixture.defaultSeller());
+            StoreApplication app = storeApplicationRepository.save(
+                StoreApplicationFixture.defaultStoreApplication(seller, null)
+            );
+            em.flush();
+            em.clear();
+
+            List<Long> ids = List.of(app.getId(), 999L);
+
+            // when
+            AdminSellerApplicationRejectList result = adminSellerService.rejectStoreApplications(ids);
+            em.flush();
+            em.clear();
+
+            // then
+            assertThat(result.successIds()).containsExactly(app.getId());
+            assertThat(result.failDetails()).hasSize(1);
+
+            StoreApplication persisted = storeApplicationRepository.findById(app.getId()).orElseThrow();
+            assertThat(persisted.getStatus()).isEqualTo(StoreApprovalStatus.REJECT);
+            assertThat(persisted.getSeller().getCertificationStatus()).isEqualTo(CertificationStatus.REJECTED);
+
+            assertThat(result.failDetails().get(0).storeApplicationId()).isEqualTo(999L);
+        }
+
+        @Test
+        @DisplayName("이미 승인된 요청은 거절 시 실패 처리된다.")
+        void rejectStoreApplications_business_exception() {
+
+            // given
+            Seller seller = sellerRepository.save(SellerFixture.defaultSeller(CertificationStatus.APPROVED));
+            StoreApplication app = storeApplicationRepository.save(
+                StoreApplicationFixture.defaultStoreApplication(DEFAULT_STORE_NAME, seller, StoreApprovalStatus.APPROVE)
+            );
+            em.flush();
+            em.clear();
+
+            List<Long> ids = List.of(app.getId());
+
+            // when
+            AdminSellerApplicationRejectList result = adminSellerService.rejectStoreApplications(ids);
+            em.flush();
+            em.clear();
+
+            // then
+            assertThat(result.successIds()).isEmpty();
+            assertThat(result.failDetails()).hasSize(1);
+
+            assertThat(result.failDetails().get(0).reason()).isEqualTo(BbangleErrorCode.REQUEST_IS_APPROVED.getMessage());
+
+            // DB 상태 그대로 유지 확인
+            StoreApplication persisted = storeApplicationRepository.findById(app.getId()).orElseThrow();
+            assertThat(persisted.getStatus()).isEqualTo(StoreApprovalStatus.APPROVE);
+            assertThat(persisted.getSeller().getCertificationStatus()).isEqualTo(CertificationStatus.APPROVED);
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/seller/admin/service/AdminSellerServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/admin/service/AdminSellerServiceUnitTest.java
@@ -2,11 +2,16 @@ package com.bbangle.bbangle.seller.admin.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse.AdminSellerApplicationRejectList;
 import com.bbangle.bbangle.seller.admin.service.model.AdminSellerInfo.SellerApplicationInfoList;
 import com.bbangle.bbangle.seller.admin.service.model.AdminSellerInfo.SellerApplicationInfoList.SellerApplicationInfo;
+import com.bbangle.bbangle.store.domain.StoreApplication;
 import com.bbangle.bbangle.store.repository.StoreApplicationRepository;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -176,6 +181,128 @@ class AdminSellerServiceUnitTest {
             assertThat(result.totalPages()).isEqualTo(3);
             assertThat(result.hasPrevious()).isTrue();
             assertThat(result.hasNext()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("rejectStoreApplications() 테스트")
+    class RejectStoreApplicationsTest {
+
+        @Test
+        @DisplayName("모든 신청이 정상적으로 거절된다")
+        void success_rejectStoreApplications() {
+
+            // given
+            List<Long> ids = List.of(1L, 2L);
+
+            StoreApplication app1 = mock(StoreApplication.class);
+            StoreApplication app2 = mock(StoreApplication.class);
+
+            given(app1.getId()).willReturn(1L);
+            given(app2.getId()).willReturn(2L);
+            given(storeApplicationRepository.findAllWithSellerByIdIn(ids)).willReturn(List.of(app1, app2));
+
+            // when
+            AdminSellerApplicationRejectList result = adminSellerService.rejectStoreApplications(ids);
+
+            // then
+            assertThat(result.successIds()).containsExactlyInAnyOrder(1L, 2L);
+            assertThat(result.failDetails()).isEmpty();
+
+            verify(app1).reject();
+            verify(app2).reject();
+        }
+
+        @Test
+        @DisplayName("입력 순서대로 처리된다")
+        void success_rejectStoreApplications_order() {
+
+            // given
+            List<Long> ids = List.of(2L, 1L);
+
+            StoreApplication app1 = mock(StoreApplication.class);
+            StoreApplication app2 = mock(StoreApplication.class);
+
+            given(app1.getId()).willReturn(1L);
+            given(app2.getId()).willReturn(2L);
+            given(storeApplicationRepository.findAllWithSellerByIdIn(ids)).willReturn(List.of(app1, app2));
+
+            // when
+            AdminSellerApplicationRejectList result = adminSellerService.rejectStoreApplications(ids);
+
+            // then
+            assertThat(result.successIds()).containsExactly(2L, 1L);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 신청의 ID는 실패로 처리된다")
+        void rejectStoreApplications_with_not_found() {
+
+            // given
+            List<Long> ids = List.of(1L, 2L);
+
+            StoreApplication app1 = mock(StoreApplication.class);
+
+            given(app1.getId()).willReturn(1L);
+            given(storeApplicationRepository.findAllWithSellerByIdIn(ids)).willReturn(List.of(app1));
+
+            // when
+            AdminSellerApplicationRejectList result = adminSellerService.rejectStoreApplications(ids);
+
+            // then
+            assertThat(result.successIds()).contains(1L);
+            assertThat(result.failDetails()).hasSize(1);
+            assertThat(result.failDetails().get(0).storeApplicationId()).isEqualTo(2L);
+            assertThat(result.failDetails().get(0).reason()).isEqualTo(BbangleErrorCode.NOT_FOUND_REQUEST.getMessage());
+
+            verify(app1).reject();
+        }
+
+        @Test
+        @DisplayName("reject 중 비즈니스 예외 발생 시 실패로 처리된다")
+        void rejectStoreApplications_business_exception() {
+
+            // given
+            List<Long> ids = List.of(1L);
+
+            StoreApplication app = mock(StoreApplication.class);
+
+            given(app.getId()).willReturn(1L);
+            willThrow(new BbangleException(BbangleErrorCode.REQUEST_IS_APPROVED)).given(app).reject();
+            given(storeApplicationRepository.findAllWithSellerByIdIn(ids)).willReturn(List.of(app));
+
+            // when
+            AdminSellerApplicationRejectList result = adminSellerService.rejectStoreApplications(ids);
+
+            // then
+            assertThat(result.successIds()).isEmpty();
+            assertThat(result.failDetails()).hasSize(1);
+            assertThat(result.failDetails().get(0).reason()).isEqualTo(BbangleErrorCode.REQUEST_IS_APPROVED.getMessage());
+
+            verify(app).reject();
+        }
+
+        @Test
+        @DisplayName("알 수 없는 예외 발생 시 실패로 처리된다")
+        void rejectStoreApplications_unknown_exception() {
+
+            // given
+            List<Long> ids = List.of(1L);
+
+            StoreApplication app = mock(StoreApplication.class);
+
+            given(app.getId()).willReturn(1L);
+            willThrow(new RuntimeException()).given(app).reject();
+            given(storeApplicationRepository.findAllWithSellerByIdIn(ids)).willReturn(List.of(app));
+
+            // when
+            AdminSellerApplicationRejectList result = adminSellerService.rejectStoreApplications(ids);
+
+            // then
+            assertThat(result.failDetails()).hasSize(1);
+            assertThat(result.failDetails().get(0).reason()).isEqualTo("알 수 없는 오류");
+
+            verify(app).reject();
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/seller/admin/service/AdminSellerServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/admin/service/AdminSellerServiceUnitTest.java
@@ -300,7 +300,7 @@ class AdminSellerServiceUnitTest {
 
             // then
             assertThat(result.failDetails()).hasSize(1);
-            assertThat(result.failDetails().get(0).reason()).isEqualTo("알 수 없는 오류");
+            assertThat(result.failDetails().get(0).reason()).isEqualTo(BbangleErrorCode.INTERNAL_SERVER_ERROR.getMessage());
 
             verify(app).reject();
         }

--- a/src/test/java/com/bbangle/bbangle/store/domain/StoreApplicationTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/domain/StoreApplicationTest.java
@@ -9,12 +9,18 @@ import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.DEFAULT_PROF
 import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.DEFAULT_STORE_NAME;
 import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.DEFAULT_SUBPHONE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
+import com.bbangle.bbangle.fixture.store.domain.StoreApplicationFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
 import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("[단위 테스트] StoreApplication")
@@ -49,5 +55,56 @@ class StoreApplicationTest {
         assertThat(storeApplication.getOriginAddressDetail()).isEqualTo(DEFAULT_DETAIL_ADDRESS);
         assertThat(storeApplication.getSeller()).isEqualTo(seller);
         assertThat(storeApplication.getStore()).isEqualTo(store);
+    }
+
+    @Nested
+    @DisplayName("reject() 테스트")
+    class RejectTest {
+
+        @Test
+        @DisplayName("승인 대기 중인 요청을 거절한다.")
+        void success_reject() {
+            // given
+            Seller seller = SellerFixture.defaultSeller(CertificationStatus.PENDING);
+            StoreApplication application = StoreApplicationFixture.defaultStoreApplication(seller, null);
+
+            // when
+            application.reject();
+
+            // then
+            assertThat(application.getStatus()).isEqualTo(StoreApprovalStatus.REJECT);
+            assertThat(seller.getCertificationStatus()).isEqualTo(CertificationStatus.REJECTED);
+        }
+
+        @Test
+        @DisplayName("이미 승인된 판매자의 승인 대기중인 요청을 거절할 경우 해당 요청만 거절된 상태로 업데이트된다.")
+        void reject_already_approved_seller() {
+            // given
+            Seller seller = SellerFixture.defaultSeller(CertificationStatus.APPROVED);
+            StoreApplication application = StoreApplicationFixture.defaultStoreApplication(seller, null);
+
+            // when
+            application.reject();
+
+            // then
+            assertThat(application.getStatus()).isEqualTo(StoreApprovalStatus.REJECT);
+            assertThat(seller.getCertificationStatus()).isEqualTo(CertificationStatus.APPROVED);
+        }
+
+        @Test
+        @DisplayName("이미 승인된 요청을 거절할 경우 예외가 발생한다.")
+        void fail_reject_already_approved_application() {
+            // given
+            Seller seller = SellerFixture.defaultSeller(CertificationStatus.APPROVED);
+            StoreApplication application = StoreApplicationFixture.defaultStoreApplication(DEFAULT_STORE_NAME, seller, StoreApprovalStatus.APPROVE);
+
+            // when & then
+            assertThatThrownBy(application::reject)
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.REQUEST_IS_APPROVED);
+                });
+        }
     }
 }


### PR DESCRIPTION
## Reviewer
|팀|이름|
|--------|-------|
|2팀|@kimbro97|
|3팀|@exjuu|
|3팀|@CUCU7103|

## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

- 연관된 이슈 : #657 
- [Notion 개발 일정](https://www.notion.so/sideproject-unione/2-_-_-2f0622e86d3d8034845ec627aefe37c2?source=copy_link)
- [API 명세서](https://www.notion.so/sideproject-unione/345622e86d3d805ba44efb1df5fd94cd?v=2c6622e86d3d8157890d000cc857bdd2&source=copy_link)

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
- 판매자의 스토어 등록 신청을 거절하는 기능 추가
- 스토어 등록이 이미 승인된 상태인 경우 -> 처리 실패
- 스토어 등록이 승인된 상태가 아닌 경우 + 판매자 계정이 이미 회원가입 승인된 상태인 경우 -> 등록 신청만 거절로 처리

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

<img width="354" height="309" alt="image" src="https://github.com/user-attachments/assets/c59da370-36be-41c5-bddd-ca35b844128c" />
<img width="306" height="442" alt="image" src="https://github.com/user-attachments/assets/43aa8727-341b-49b5-817b-e1c176eef35c" />

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 판매자 매장 등록 신청을 일괄적으로 거절할 수 있는 새로운 API 엔드포인트 추가
* 거절 처리 결과에서 성공한 신청과 실패 상세 정보를 함께 반환
* 이미 승인된 신청에 대한 거절 시도 시 사전 검증으로 무결성 보호

## 테스트
* 신청 거절 기능에 대한 단위 및 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->