### PR TITLE
[Feat] 요일별 결제금액 및 평균 결제금액 조회 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/statistics/seller/controller/SellerPaymentStatisticsController.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/controller/SellerPaymentStatisticsController.java
@@ -6,6 +6,7 @@ import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
 import com.bbangle.bbangle.statistics.seller.controller.swagger.SellerPaymentStatisticsApi;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse;
+import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.service.SellerPaymentStatisticsService;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -52,6 +53,21 @@ public class SellerPaymentStatisticsController implements SellerPaymentStatistic
     ) {
         DailyPaymentCountResponse result =
             sellerPaymentStatisticsService.getDailyPaymentCount(sellerId, date, period);
+        return responseService.getSingleResult(result);
+    }
+
+    @Override
+    @GetMapping("/weekday")
+    public SingleResult<WeekdayPaymentAmountResponse> getWeekdayPaymentAmount(
+        @AuthenticationPrincipal Long sellerId,
+        @RequestParam(value = "date", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        Optional<LocalDate> date,
+        @RequestParam(value = "period", required = false)
+        Optional<StatisticsPeriod> period
+    ) {
+        WeekdayPaymentAmountResponse result =
+            sellerPaymentStatisticsService.getWeekdayPaymentAmount(sellerId, date, period);
         return responseService.getSingleResult(result);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/statistics/seller/controller/swagger/SellerPaymentStatisticsApi.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/controller/swagger/SellerPaymentStatisticsApi.java
@@ -4,6 +4,7 @@ import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse;
+import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,10 +22,20 @@ public interface SellerPaymentStatisticsApi {
     );
 
     @Operation(
-        summary = "판매자 결제자수 및 결제수 통계 조회",
-        description = "결제자수와 결제수를 일별, 주별, 월별 기준으로 조회합니다."
+        summary = "판매자 결제건수 및 결제수 통계 조회",
+        description = "결제건수와 결제수를 일별, 주별, 월별 기준으로 조회합니다."
     )
     SingleResult<DailyPaymentCountResponse> getDailyPaymentCount(
+        @Parameter(description = "판매자 ID") Long sellerId,
+        @Parameter(description = "기준 날짜 (yyyy-MM-dd), 미입력 시 오늘") Optional<LocalDate> date,
+        @Parameter(description = "조회 범위 (DAY, WEEK, MONTH), 미입력 시 DAY") Optional<StatisticsPeriod> period
+    );
+
+    @Operation(
+        summary = "판매자 요일별 결제 금액 및 평균 결제 금액 통계 조회",
+        description = "조회 기간의 데이터를 요일 기준으로 재집계하여 요일별 총 결제 금액과 평균 결제 금액을 조회합니다."
+    )
+    SingleResult<WeekdayPaymentAmountResponse> getWeekdayPaymentAmount(
         @Parameter(description = "판매자 ID") Long sellerId,
         @Parameter(description = "기준 날짜 (yyyy-MM-dd), 미입력 시 오늘") Optional<LocalDate> date,
         @Parameter(description = "조회 범위 (DAY, WEEK, MONTH), 미입력 시 DAY") Optional<StatisticsPeriod> period

--- a/src/main/java/com/bbangle/bbangle/statistics/seller/dto/WeekdayPaymentAmountResponse.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/dto/WeekdayPaymentAmountResponse.java
@@ -1,0 +1,20 @@
+package com.bbangle.bbangle.statistics.seller.dto;
+
+import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
+import java.time.LocalDate;
+import java.util.List;
+
+public record WeekdayPaymentAmountResponse(
+    LocalDate startDate,
+    LocalDate endDate,
+    StatisticsPeriod period,
+    List<WeekdayPaymentAmountItem> weekdayAmounts
+) {
+
+    public record WeekdayPaymentAmountItem(
+        Integer weekday,
+        Long amount,
+        Long averageAmount
+    ) {
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsService.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsService.java
@@ -12,7 +12,10 @@ import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse.DailyPaymentAmountItem;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse.DailyPaymentCountItem;
+import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse;
+import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse.WeekdayPaymentAmountItem;
 import java.math.BigDecimal;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -79,6 +82,41 @@ public class SellerPaymentStatisticsService {
             resolvedPeriod,
             averageAmount,
             items
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public WeekdayPaymentAmountResponse getWeekdayPaymentAmount(
+        Long sellerId,
+        Optional<LocalDate> date,
+        Optional<StatisticsPeriod> period
+    ) {
+        Seller seller = sellerRepository.findById(sellerId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.SELLER_NOT_FOUND));
+
+        StatisticsPeriod resolvedPeriod = StatisticsPeriod.from(period.orElse(StatisticsPeriod.DAY));
+        LocalDate targetDate = date.orElse(LocalDate.now());
+        DateRange range = resolvedPeriod.resolveDateRange(targetDate, BUCKET_COUNT);
+
+        List<SellerStatisticsDaily> rows =
+            sellerStatisticsRepository.findBySellerIdAndStatDateBetweenOrderByStatDateAsc(
+                seller.getId(),
+                range.startDate().atStartOfDay(),
+                range.endDate().atTime(LocalTime.MAX)
+            );
+
+        Map<LocalDate, SellerStatisticsDaily> statisticsByDate = rows.stream()
+            .collect(Collectors.toMap(
+                row -> row.getStatDate().toLocalDate(),
+                Function.identity(),
+                (first, second) -> first
+            ));
+
+        return new WeekdayPaymentAmountResponse(
+            range.startDate(),
+            range.endDate(),
+            resolvedPeriod,
+            buildWeekdayItems(range, statisticsByDate)
         );
     }
 
@@ -192,6 +230,36 @@ public class SellerPaymentStatisticsService {
 
             items.add(new DailyPaymentCountItem(bucketStart, buyerCount, paymentCount));
             cursor = period.nextBucketStart(cursor);
+        }
+
+        return items;
+    }
+
+    private List<WeekdayPaymentAmountItem> buildWeekdayItems(
+        DateRange range,
+        Map<LocalDate, SellerStatisticsDaily> statisticsByDate
+    ) {
+        List<WeekdayPaymentAmountItem> items = new ArrayList<>();
+
+        for (int weekday = DayOfWeek.MONDAY.getValue(); weekday <= DayOfWeek.SUNDAY.getValue(); weekday++) {
+            final int currentWeekday = weekday;
+            List<LocalDate> matchingDates = range.startDate()
+                .datesUntil(range.endDate().plusDays(1))
+                .filter(date -> date.getDayOfWeek().getValue() == currentWeekday)
+                .toList();
+
+            long amount = matchingDates.stream()
+                .map(statisticsByDate::get)
+                .filter(row -> row != null && row.getTotalAmount() != null)
+                .map(SellerStatisticsDaily::getTotalAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .longValue();
+
+            long averageAmount = matchingDates.isEmpty()
+                ? 0L
+                : Math.round((double) amount / matchingDates.size());
+
+            items.add(new WeekdayPaymentAmountItem(currentWeekday, amount, averageAmount));
         }
 
         return items;

--- a/src/test/java/com/bbangle/bbangle/statistics/seller/controller/SellerPaymentStatisticsControllerSliceTest.java
+++ b/src/test/java/com/bbangle/bbangle/statistics/seller/controller/SellerPaymentStatisticsControllerSliceTest.java
@@ -14,6 +14,8 @@ import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse.DailyPaymentAmountItem;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse.DailyPaymentCountItem;
+import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse;
+import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse.WeekdayPaymentAmountItem;
 import com.bbangle.bbangle.statistics.seller.service.SellerPaymentStatisticsService;
 import java.time.LocalDate;
 import java.util.List;
@@ -28,7 +30,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @ActiveProfiles("test")
-@DisplayName("[Controller] SellerPaymentStatisticsController")
+@DisplayName("[컨트롤러] SellerPaymentStatisticsController")
 @Import({
     TestSlackAdaptorConfig.class,
     ResponseService.class
@@ -44,7 +46,7 @@ class SellerPaymentStatisticsControllerSliceTest {
     private SellerPaymentStatisticsService sellerPaymentStatisticsService;
 
     @Test
-    @DisplayName("returns payment amount statistics")
+    @DisplayName("결제 금액 통계를 반환한다")
     void getDailyPaymentAmount_success() throws Exception {
         DailyPaymentAmountResponse response = new DailyPaymentAmountResponse(
             LocalDate.of(2026, 3, 1),
@@ -82,7 +84,7 @@ class SellerPaymentStatisticsControllerSliceTest {
     }
 
     @Test
-    @DisplayName("returns payment count statistics")
+    @DisplayName("결제 건수 통계를 반환한다")
     void getDailyPaymentCount_success() throws Exception {
         DailyPaymentCountResponse response = new DailyPaymentCountResponse(
             LocalDate.of(2026, 3, 1),
@@ -119,5 +121,45 @@ class SellerPaymentStatisticsControllerSliceTest {
             .andExpect(jsonPath("$.result.dailyCounts[0].paymentCount").value(2))
             .andExpect(jsonPath("$.result.dailyCounts[2].buyerCount").value(1))
             .andExpect(jsonPath("$.result.dailyCounts[2].paymentCount").value(1));
+    }
+
+    @Test
+    @DisplayName("요일별 결제 금액 통계를 반환한다")
+    void getWeekdayPaymentAmount_success() throws Exception {
+        WeekdayPaymentAmountResponse response = new WeekdayPaymentAmountResponse(
+            LocalDate.of(2026, 3, 1),
+            LocalDate.of(2026, 3, 7),
+            StatisticsPeriod.DAY,
+            List.of(
+                new WeekdayPaymentAmountItem(1, 1000L, 1000L),
+                new WeekdayPaymentAmountItem(2, 2000L, 2000L),
+                new WeekdayPaymentAmountItem(3, 3000L, 3000L),
+                new WeekdayPaymentAmountItem(4, 4000L, 4000L),
+                new WeekdayPaymentAmountItem(5, 5000L, 5000L),
+                new WeekdayPaymentAmountItem(6, 6000L, 6000L),
+                new WeekdayPaymentAmountItem(7, 7000L, 7000L)
+            )
+        );
+
+        given(sellerPaymentStatisticsService.getWeekdayPaymentAmount(any(), any(), any()))
+            .willReturn(response);
+
+        mvc.perform(get("/api/v1/seller/payments/statistics/weekday")
+                .param("date", "2026-03-07")
+                .param("period", "DAY"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
+            .andExpect(jsonPath("$.result.startDate").value("2026-03-01"))
+            .andExpect(jsonPath("$.result.endDate").value("2026-03-07"))
+            .andExpect(jsonPath("$.result.period").value("DAY"))
+            .andExpect(jsonPath("$.result.weekdayAmounts.length()").value(7))
+            .andExpect(jsonPath("$.result.weekdayAmounts[0].weekday").value(1))
+            .andExpect(jsonPath("$.result.weekdayAmounts[0].amount").value(1000))
+            .andExpect(jsonPath("$.result.weekdayAmounts[0].averageAmount").value(1000))
+            .andExpect(jsonPath("$.result.weekdayAmounts[6].weekday").value(7))
+            .andExpect(jsonPath("$.result.weekdayAmounts[6].amount").value(7000))
+            .andExpect(jsonPath("$.result.weekdayAmounts[6].averageAmount").value(7000));
     }
 }

--- a/src/test/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsServiceIntegrationTest.java
@@ -9,6 +9,7 @@ import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
 import com.bbangle.bbangle.statistics.repository.SellerStatisticsRepository;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse;
+import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -19,7 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-@DisplayName("[IntegrationTest] SellerPaymentStatisticsService")
+@DisplayName("[통합 테스트] SellerPaymentStatisticsService")
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
@@ -35,7 +36,7 @@ class SellerPaymentStatisticsServiceIntegrationTest {
     private SellerStatisticsRepository sellerStatisticsRepository;
 
     @Test
-    @DisplayName("aggregates weekly payment counts into seven buckets")
+    @DisplayName("주간 결제 건수를 7개 구간으로 집계한다")
     void getDailyPaymentCount_weeklyBuckets() {
         Seller seller = sellerRepository.saveAndFlush(SellerFixture.defaultSeller());
 
@@ -78,5 +79,59 @@ class SellerPaymentStatisticsServiceIntegrationTest {
         assertThat(result.dailyCounts().get(6).date()).isEqualTo(LocalDate.of(2026, 3, 16));
         assertThat(result.dailyCounts().get(6).buyerCount()).isEqualTo(3L);
         assertThat(result.dailyCounts().get(6).paymentCount()).isEqualTo(4L);
+    }
+
+    @Test
+    @DisplayName("결제 금액을 요일별로 집계한다")
+    void getWeekdayPaymentAmount_weeklyBuckets() {
+        Seller seller = sellerRepository.saveAndFlush(SellerFixture.defaultSeller());
+
+        sellerStatisticsRepository.saveAndFlush(SellerStatisticsDailyFixture.create(
+            seller,
+            LocalDateTime.of(2026, 2, 2, 0, 0),
+            0,
+            0,
+            1000
+        ));
+        sellerStatisticsRepository.saveAndFlush(SellerStatisticsDailyFixture.create(
+            seller,
+            LocalDateTime.of(2026, 2, 5, 0, 0),
+            0,
+            0,
+            2000
+        ));
+        sellerStatisticsRepository.saveAndFlush(SellerStatisticsDailyFixture.create(
+            seller,
+            LocalDateTime.of(2026, 3, 16, 0, 0),
+            0,
+            0,
+            3000
+        ));
+        sellerStatisticsRepository.saveAndFlush(SellerStatisticsDailyFixture.create(
+            seller,
+            LocalDateTime.of(2026, 3, 20, 0, 0),
+            0,
+            0,
+            7000
+        ));
+
+        WeekdayPaymentAmountResponse result = sellerPaymentStatisticsService.getWeekdayPaymentAmount(
+            seller.getId(),
+            Optional.of(LocalDate.of(2026, 3, 16)),
+            Optional.of(StatisticsPeriod.WEEK)
+        );
+
+        assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 2, 2));
+        assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, 3, 22));
+        assertThat(result.weekdayAmounts()).hasSize(7);
+        assertThat(result.weekdayAmounts().get(0).weekday()).isEqualTo(1);
+        assertThat(result.weekdayAmounts().get(0).amount()).isEqualTo(4000L);
+        assertThat(result.weekdayAmounts().get(0).averageAmount()).isEqualTo(571L);
+        assertThat(result.weekdayAmounts().get(3).weekday()).isEqualTo(4);
+        assertThat(result.weekdayAmounts().get(3).amount()).isEqualTo(2000L);
+        assertThat(result.weekdayAmounts().get(3).averageAmount()).isEqualTo(286L);
+        assertThat(result.weekdayAmounts().get(4).weekday()).isEqualTo(5);
+        assertThat(result.weekdayAmounts().get(4).amount()).isEqualTo(7000L);
+        assertThat(result.weekdayAmounts().get(4).averageAmount()).isEqualTo(1000L);
     }
 }

--- a/src/test/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsServiceUnitTest.java
@@ -15,6 +15,7 @@ import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
 import com.bbangle.bbangle.statistics.repository.SellerStatisticsRepository;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse;
+import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -27,7 +28,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@DisplayName("[UnitTest] SellerPaymentStatisticsService")
+@DisplayName("[단위 테스트] SellerPaymentStatisticsService")
 @ExtendWith(MockitoExtension.class)
 class SellerPaymentStatisticsServiceUnitTest {
 
@@ -41,7 +42,7 @@ class SellerPaymentStatisticsServiceUnitTest {
     private SellerStatisticsRepository sellerStatisticsRepository;
 
     @Test
-    @DisplayName("fills missing day buckets with zero for payment amount")
+    @DisplayName("결제 금액 조회 시 비어 있는 일자 구간은 0으로 채운다")
     void getDailyPaymentAmount_fillMissingDatesWithZero() {
         Long sellerId = 1L;
         LocalDate targetDate = LocalDate.of(2026, 3, 7);
@@ -81,7 +82,7 @@ class SellerPaymentStatisticsServiceUnitTest {
     }
 
     @Test
-    @DisplayName("aggregates weekly payment amount buckets")
+    @DisplayName("주간 결제 금액 구간을 집계한다")
     void getDailyPaymentAmount_weeklyBuckets() {
         Long sellerId = 1L;
         LocalDate targetDate = LocalDate.of(2026, 3, 16);
@@ -124,7 +125,7 @@ class SellerPaymentStatisticsServiceUnitTest {
     }
 
     @Test
-    @DisplayName("aggregates monthly payment amount buckets")
+    @DisplayName("월간 결제 금액 구간을 집계한다")
     void getDailyPaymentAmount_monthlyBuckets() {
         Long sellerId = 1L;
         LocalDate targetDate = LocalDate.of(2026, 3, 10);
@@ -167,7 +168,7 @@ class SellerPaymentStatisticsServiceUnitTest {
     }
 
     @Test
-    @DisplayName("uses DAY as the default period for payment amount")
+    @DisplayName("결제 금액 조회 시 기본 기간은 DAY를 사용한다")
     void getDailyPaymentAmount_defaultPeriodIsDay() {
         Long sellerId = 1L;
         LocalDate targetDate = LocalDate.of(2026, 3, 7);
@@ -187,7 +188,64 @@ class SellerPaymentStatisticsServiceUnitTest {
     }
 
     @Test
-    @DisplayName("aggregates weekly buyer and payment counts")
+    @DisplayName("결제 금액을 요일별로 집계하고 요일 평균 금액을 계산한다")
+    void getWeekdayPaymentAmount_success() {
+        Long sellerId = 1L;
+        LocalDate targetDate = LocalDate.of(2026, 3, 16);
+
+        givenExistingSeller(sellerId);
+
+        SellerStatisticsDaily monday1 = mockStatisticsDaily(
+            LocalDateTime.of(2026, 2, 2, 10, 0),
+            1000L,
+            0,
+            0
+        );
+        SellerStatisticsDaily monday2 = mockStatisticsDaily(
+            LocalDateTime.of(2026, 3, 16, 10, 0),
+            3000L,
+            0,
+            0
+        );
+        SellerStatisticsDaily thursday = mockStatisticsDaily(
+            LocalDateTime.of(2026, 2, 5, 10, 0),
+            2000L,
+            0,
+            0
+        );
+        SellerStatisticsDaily friday = mockStatisticsDaily(
+            LocalDateTime.of(2026, 3, 20, 10, 0),
+            7000L,
+            0,
+            0
+        );
+
+        given(sellerStatisticsRepository.findBySellerIdAndStatDateBetweenOrderByStatDateAsc(
+            eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(List.of(monday1, monday2, thursday, friday));
+
+        WeekdayPaymentAmountResponse result = sut.getWeekdayPaymentAmount(
+            sellerId, Optional.of(targetDate), Optional.of(StatisticsPeriod.WEEK));
+
+        assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 2, 2));
+        assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, 3, 22));
+        assertThat(result.period()).isEqualTo(StatisticsPeriod.WEEK);
+        assertThat(result.weekdayAmounts()).hasSize(7);
+        assertThat(result.weekdayAmounts().get(0).weekday()).isEqualTo(1);
+        assertThat(result.weekdayAmounts().get(0).amount()).isEqualTo(4000L);
+        assertThat(result.weekdayAmounts().get(0).averageAmount()).isEqualTo(571L);
+        assertThat(result.weekdayAmounts().get(3).weekday()).isEqualTo(4);
+        assertThat(result.weekdayAmounts().get(3).amount()).isEqualTo(2000L);
+        assertThat(result.weekdayAmounts().get(3).averageAmount()).isEqualTo(286L);
+        assertThat(result.weekdayAmounts().get(4).weekday()).isEqualTo(5);
+        assertThat(result.weekdayAmounts().get(4).amount()).isEqualTo(7000L);
+        assertThat(result.weekdayAmounts().get(4).averageAmount()).isEqualTo(1000L);
+        assertThat(result.weekdayAmounts().get(6).amount()).isEqualTo(0L);
+        assertThat(result.weekdayAmounts().get(6).averageAmount()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("주간 구매자 수와 결제 건수를 집계한다")
     void getDailyPaymentCount_weeklyBuckets() {
         Long sellerId = 1L;
         LocalDate targetDate = LocalDate.of(2026, 3, 16);
@@ -233,7 +291,7 @@ class SellerPaymentStatisticsServiceUnitTest {
     }
 
     @Test
-    @DisplayName("fills missing day buckets with zero for payment count")
+    @DisplayName("결제 건수 조회 시 비어 있는 일자 구간은 0으로 채운다")
     void getDailyPaymentCount_fillMissingDatesWithZero() {
         Long sellerId = 1L;
         LocalDate targetDate = LocalDate.of(2026, 3, 7);
@@ -272,7 +330,7 @@ class SellerPaymentStatisticsServiceUnitTest {
     }
 
     @Test
-    @DisplayName("throws SELLER_NOT_FOUND when seller does not exist")
+    @DisplayName("판매자가 없으면 SELLER_NOT_FOUND 예외를 던진다")
     void getDailyPaymentAmount_sellerNotFound() {
         Long sellerId = 999L;
         given(sellerRepository.findById(sellerId)).willReturn(Optional.empty());


### PR DESCRIPTION
## History
리뷰어 : @mono0801 @kimbro97

## 🚀 Major Changes & Explanations
  - 판매자 요일별 결제 금액 통계 조회 기능 추가했습니다.
  - 기간 내 결제 데이터를 요일별로 집계해 총 금액과 평균 금액 반환합니다.
 
## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 요일별 결제 금액 통계 조회 기능이 추가되었습니다. 선택한 기간의 데이터를 요일별로 재집계하여 요일별 총 결제 금액과 평균 결제 금액을 확인할 수 있습니다.

* **Documentation**
  * 결제 통계 API의 용어가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->