### PR TITLE
[Fix] dev 환경 Swagger 그룹화 미반영 수정

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -114,7 +114,6 @@ slack:
 springdoc:
   swagger-ui:
     config-url: ${SWAGGER_CONFIG_URL}
-    url: ${SWAGGER_URL}
 
 app:
   cookie:


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->

## 🚀 Major Changes & Explanations

* [fix] `application-dev.yml`에서 `springdoc.swagger-ui.url` 설정 제거
  - `springdoc.swagger-ui.url`이 명시적으로 설정되면 Swagger UI가 해당 단일 스펙 URL만 로드하여 `GroupedOpenApi` 그룹 드롭다운을 무시하는 문제
  - PR #666에서 추가한 `GroupedOpenApi` 그룹화가 dev 환경에서 반영되지 않는 원인이었음
  - `url` 속성 제거 시 Swagger UI가 기본값(`/v3/api-docs/swagger-config`)을 사용하여 모든 그룹(Admin, Seller, Customer, Auth, Public)이 정상 표시됨
  - `config-url`은 환경변수(`SWAGGER_CONFIG_URL`)로 유지

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 환경의 설정을 간소화하여 Swagger UI 구성 관리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->