### PR TITLE
Revert "[Fix] dev 환경 Swagger 그룹화 미반영 수정 (#667)"

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -114,6 +114,7 @@ slack:
 springdoc:
   swagger-ui:
     config-url: ${SWAGGER_CONFIG_URL}
+    url: ${SWAGGER_URL}
 
 app:
   cookie:


### PR DESCRIPTION
## History

* Reverts #667

## 🚀 Major Changes & Explanations

* [fix] #667 롤백
  - `application-dev.yml`에서 제거했던 `springdoc.swagger-ui.url` 설정 복원

## 📷 Test Image

## 💡 ETC