### PR TITLE
[Fix] dev 환경 springdoc 설정 제거

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -111,11 +111,6 @@ fcm:
 slack:
   webhook-url: ${SLACK_WEBHOOK_URL}
 
-springdoc:
-  swagger-ui:
-    config-url: ${SWAGGER_CONFIG_URL}
-    url: ${SWAGGER_URL}
-
 app:
   cookie:
     domain: ${COOKIE_DOMAIN}


### PR DESCRIPTION
## History

* Resolves #667
* Reverts #668

## 🚀 Major Changes & Explanations

* [fix] `application-dev.yml`에서 `springdoc` 블록 전체 제거
  - `springdoc.swagger-ui.url` 설정이 Swagger UI로 하여금 단일 스펙 URL만 로드하게 강제하여 PR #666에서 추가한 `GroupedOpenApi` 그룹화가 dev 환경에서 동작하지 않는 원인이었음
  - `springdoc.swagger-ui.config-url` 또한 제거하여 springdoc 기본값(`/v3/api-docs/swagger-config`) 사용
  - 설정 제거 후 Admin, Seller, Customer, Auth, Public 그룹 드롭다운이 정상 표시됨

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->