### PR TITLE
[Feature] (어드민) 셀러 서류 다운로드 API 작업

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -126,6 +126,7 @@ public enum BbangleErrorCode {
     PRODUCT_NOT_FOUND(-716, "존재하지 않는 상품입니다.", NOT_FOUND),
     MISSING_BOARD_THUMBNAIL(-717, "썸네일 이미지는 필수입니다. 새 파일 또는 기존 URL을 제공해주세요.", BAD_REQUEST),
     NOT_REGISTERED_STORE(-718, "스토어를 등록하지 않은 계정입니다.", NOT_FOUND),
+    SELLER_DOCUMENT_NOT_FOUND(-719, "판매자의 서류가 존재하지 않습니다.", NOT_FOUND),
 
     // Store Error (721~740)
     INVALID_STORE(-721, "유효하지 않은 스토어 객체입니다.", BAD_REQUEST),

--- a/src/main/java/com/bbangle/bbangle/seller/admin/controller/AdminSellerController.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/controller/AdminSellerController.java
@@ -3,16 +3,25 @@ package com.bbangle.bbangle.seller.admin.controller;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.AdminApiPath;
+import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerDocumentDownloadRequest;
 import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse.AdminSellerApplicationList;
 import com.bbangle.bbangle.seller.admin.controller.swagger.AdminSellerApi;
 import com.bbangle.bbangle.seller.admin.facade.AdminSellerFacade;
+import com.bbangle.bbangle.seller.admin.service.AdminSellerDocumentService;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @Validated
 @RestController
@@ -22,6 +31,7 @@ public class AdminSellerController implements AdminSellerApi {
 
     private final ResponseService responseService;
     private final AdminSellerFacade adminSellerFacade;
+    private final AdminSellerDocumentService adminSellerDocumentService;
 
     @Override
     @GetMapping()
@@ -31,5 +41,19 @@ public class AdminSellerController implements AdminSellerApi {
         return responseService.getSingleResult(
             adminSellerFacade.getAdminSellerApplicationList(page)
         );
+    }
+
+    @Override
+    @PostMapping("/documents/download")
+    public ResponseEntity<StreamingResponseBody> downloadSellerDocuments(
+        @RequestBody @Valid AdminSellerDocumentDownloadRequest request
+    ) {
+        StreamingResponseBody body = out ->
+            adminSellerDocumentService.downloadSellerDocuments(request.sellerIds(), out);
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"documents.zip\"")
+            .contentType(MediaType.parseMediaType("application/zip"))
+            .body(body);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/admin/controller/dto/AdminSellerDocumentDownloadRequest.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/controller/dto/AdminSellerDocumentDownloadRequest.java
@@ -2,12 +2,14 @@ package com.bbangle.bbangle.seller.admin.controller.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 @Schema(description = "판매자 서류 ZIP 다운로드 요청 DTO")
 public record AdminSellerDocumentDownloadRequest(
     @Schema(description = "서류를 다운로드할 판매자 ID 목록", example = "[1, 2, 3]")
     @NotEmpty
+    @Size(max = 50, message = "한 번에 최대 50명까지 다운로드할 수 있습니다.")
     List<Long> sellerIds
 ) {
 }

--- a/src/main/java/com/bbangle/bbangle/seller/admin/controller/dto/AdminSellerDocumentDownloadRequest.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/controller/dto/AdminSellerDocumentDownloadRequest.java
@@ -1,0 +1,13 @@
+package com.bbangle.bbangle.seller.admin.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+@Schema(description = "판매자 서류 ZIP 다운로드 요청 DTO")
+public record AdminSellerDocumentDownloadRequest(
+    @Schema(description = "서류를 다운로드할 판매자 ID 목록", example = "[1, 2, 3]")
+    @NotEmpty
+    List<Long> sellerIds
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/seller/admin/controller/swagger/AdminSellerApi.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/controller/swagger/AdminSellerApi.java
@@ -1,12 +1,17 @@
 package com.bbangle.bbangle.seller.admin.controller.swagger;
 
 import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerDocumentDownloadRequest;
 import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @Tag(name = "Admin Store", description = "(관리자) 판매자 관리 API")
 public interface AdminSellerApi {
@@ -20,5 +25,13 @@ public interface AdminSellerApi {
         @RequestParam(defaultValue = "1")
         @Min(1)
         int page
+    );
+
+    @Operation(
+        summary = "(관리자) 판매자 서류 ZIP 다운로드",
+        description = "선택된 판매자들의 서류를 스토어명 디렉토리 구조로 ZIP 파일로 다운로드합니다."
+    )
+    ResponseEntity<StreamingResponseBody> downloadSellerDocuments(
+        @RequestBody @Valid AdminSellerDocumentDownloadRequest request
     );
 }

--- a/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerDocumentService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerDocumentService.java
@@ -41,7 +41,7 @@ public class AdminSellerDocumentService {
                 zipOut.closeEntry();
             }
         } catch (IOException e) {
-            throw new BbangleException(STREAM_CLOSING_ERROR);
+            throw new BbangleException(STREAM_CLOSING_ERROR, e);
         }
     }
 }

--- a/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerDocumentService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerDocumentService.java
@@ -1,0 +1,47 @@
+package com.bbangle.bbangle.seller.admin.service;
+
+import static com.bbangle.bbangle.exception.BbangleErrorCode.SELLER_DOCUMENT_NOT_FOUND;
+import static com.bbangle.bbangle.exception.BbangleErrorCode.STREAM_CLOSING_ERROR;
+
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.seller.admin.service.model.SellerDocumentDownloadInfo;
+import com.bbangle.bbangle.seller.repository.SellerDocumentRepository;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminSellerDocumentService {
+
+    private final SellerDocumentRepository sellerDocumentRepository;
+
+    @Transactional(readOnly = true)
+    public void downloadSellerDocuments(List<Long> sellerIds, OutputStream outputStream) {
+        List<SellerDocumentDownloadInfo> documents =
+            sellerDocumentRepository.findDocumentsBySellerIds(sellerIds);
+
+        if (documents.isEmpty()) {
+            throw new BbangleException(SELLER_DOCUMENT_NOT_FOUND);
+        }
+
+        try (ZipOutputStream zipOut = new ZipOutputStream(outputStream)) {
+            for (SellerDocumentDownloadInfo doc : documents) {
+                zipOut.putNextEntry(new ZipEntry(doc.zipEntryPath()));
+                try (InputStream in = new URL(doc.url()).openStream()) {
+                    in.transferTo(zipOut);
+                }
+                zipOut.closeEntry();
+            }
+        } catch (IOException e) {
+            throw new BbangleException(STREAM_CLOSING_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerDocumentService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerDocumentService.java
@@ -15,7 +15,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,7 +22,6 @@ public class AdminSellerDocumentService {
 
     private final SellerDocumentRepository sellerDocumentRepository;
 
-    @Transactional(readOnly = true)
     public void downloadSellerDocuments(List<Long> sellerIds, OutputStream outputStream) {
         List<SellerDocumentDownloadInfo> documents =
             sellerDocumentRepository.findDocumentsBySellerIds(sellerIds);

--- a/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerDocumentService.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/service/AdminSellerDocumentService.java
@@ -6,11 +6,15 @@ import static com.bbangle.bbangle.exception.BbangleErrorCode.STREAM_CLOSING_ERRO
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.admin.service.model.SellerDocumentDownloadInfo;
 import com.bbangle.bbangle.seller.repository.SellerDocumentRepository;
+import com.bbangle.bbangle.util.FileNameUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.net.URLConnection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +23,9 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class AdminSellerDocumentService {
+
+    private static final int CONNECT_TIMEOUT_MILLIS = 5_000;
+    private static final int READ_TIMEOUT_MILLIS = 10_000;
 
     private final SellerDocumentRepository sellerDocumentRepository;
 
@@ -30,10 +37,17 @@ public class AdminSellerDocumentService {
             throw new BbangleException(SELLER_DOCUMENT_NOT_FOUND);
         }
 
+        Set<String> usedEntryPaths = new HashSet<>();
         try (ZipOutputStream zipOut = new ZipOutputStream(outputStream)) {
             for (SellerDocumentDownloadInfo doc : documents) {
-                zipOut.putNextEntry(new ZipEntry(doc.zipEntryPath()));
-                try (InputStream in = new URL(doc.url()).openStream()) {
+                String entryPath = FileNameUtil.resolveUniquePath(doc.zipEntryPath(), usedEntryPaths);
+                usedEntryPaths.add(entryPath);
+
+                zipOut.putNextEntry(new ZipEntry(entryPath));
+                URLConnection connection = new URL(doc.url()).openConnection();
+                connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
+                connection.setReadTimeout(READ_TIMEOUT_MILLIS);
+                try (InputStream in = connection.getInputStream()) {
                     in.transferTo(zipOut);
                 }
                 zipOut.closeEntry();

--- a/src/main/java/com/bbangle/bbangle/seller/admin/service/model/SellerDocumentDownloadInfo.java
+++ b/src/main/java/com/bbangle/bbangle/seller/admin/service/model/SellerDocumentDownloadInfo.java
@@ -1,0 +1,20 @@
+package com.bbangle.bbangle.seller.admin.service.model;
+
+import com.bbangle.bbangle.seller.domain.model.DocumentType;
+
+public record SellerDocumentDownloadInfo(
+    String storeName,
+    String url,
+    DocumentType documentType,
+    String originalFileName
+) {
+
+    public String zipFileName() {
+        String extension = originalFileName.substring(originalFileName.lastIndexOf('.'));
+        return documentType.getKoreanName() + extension;
+    }
+
+    public String zipEntryPath() {
+        return storeName + "/" + zipFileName();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/seller/domain/SellerDocument.java
+++ b/src/main/java/com/bbangle/bbangle/seller/domain/SellerDocument.java
@@ -67,6 +67,11 @@ public class SellerDocument extends BaseEntity {
         this.status = status;
     }
 
+    public String getZipFileName() {
+        String extension = name.substring(name.lastIndexOf('.'));
+        return type.getKoreanName() + extension;
+    }
+
     public static SellerDocument create(String name, String url, String type, Seller seller) {
         createValidate(name, url, type, seller);
         return SellerDocument.builder()

--- a/src/main/java/com/bbangle/bbangle/seller/domain/model/DocumentType.java
+++ b/src/main/java/com/bbangle/bbangle/seller/domain/model/DocumentType.java
@@ -8,19 +8,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum DocumentType {
 
-    // TODO : 각 문서 형식을 이해하기 쉽게 주석 추가
-
-    // 사업자등록증
-    BUSINESS_REGISTRATION_CERTIFICATE("Business Registration Certificate"),
-    // 통신판매업신고증
-    MAIL_ORDER_SALES_REPORT("Mail Order Sales Report"),
-    // 즉석식품제조가공업등록증
+    BUSINESS_REGISTRATION_CERTIFICATE("Business Registration Certificate", "사업자등록증"),
+    MAIL_ORDER_SALES_REPORT("Mail Order Sales Report", "통신판매업신고증"),
     INSTANT_FOOD_MANUFACTURING_PROCESSING_REGISTRATION(
-        "Instant Food Manufacturing Processing Registration"),
-    // 통장사본
-    BANKBOOK_COPY("Bankbook Copy");
+        "Instant Food Manufacturing Processing Registration", "즉석식품제조가공업등록증"),
+    BANKBOOK_COPY("Bankbook Copy", "통장사본");
 
     private final String description;
+    private final String koreanName;
 
 
     public static DocumentType fromDescription(String desc) {

--- a/src/main/java/com/bbangle/bbangle/seller/repository/SellerDocumentQueryDslRepository.java
+++ b/src/main/java/com/bbangle/bbangle/seller/repository/SellerDocumentQueryDslRepository.java
@@ -1,0 +1,9 @@
+package com.bbangle.bbangle.seller.repository;
+
+import com.bbangle.bbangle.seller.admin.service.model.SellerDocumentDownloadInfo;
+import java.util.List;
+
+public interface SellerDocumentQueryDslRepository {
+
+    List<SellerDocumentDownloadInfo> findDocumentsBySellerIds(List<Long> sellerIds);
+}

--- a/src/main/java/com/bbangle/bbangle/seller/repository/SellerDocumentQueryDslRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/seller/repository/SellerDocumentQueryDslRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.bbangle.bbangle.seller.repository;
+
+import static com.bbangle.bbangle.seller.domain.QSeller.seller;
+import static com.bbangle.bbangle.seller.domain.QSellerDocument.sellerDocument;
+import static com.bbangle.bbangle.store.domain.QStore.store;
+
+import com.bbangle.bbangle.seller.admin.service.model.SellerDocumentDownloadInfo;
+import com.bbangle.bbangle.seller.domain.model.DocumentType;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SellerDocumentQueryDslRepositoryImpl implements SellerDocumentQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<SellerDocumentDownloadInfo> findDocumentsBySellerIds(List<Long> sellerIds) {
+        return queryFactory
+            .select(Projections.constructor(
+                SellerDocumentDownloadInfo.class,
+                store.name,
+                sellerDocument.url,
+                sellerDocument.type,
+                sellerDocument.name
+            ))
+            .from(sellerDocument)
+            .join(sellerDocument.seller, seller)
+            .join(seller.store, store)
+            .where(seller.id.in(sellerIds))
+            .fetch();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/seller/repository/SellerDocumentRepository.java
+++ b/src/main/java/com/bbangle/bbangle/seller/repository/SellerDocumentRepository.java
@@ -3,5 +3,6 @@ package com.bbangle.bbangle.seller.repository;
 import com.bbangle.bbangle.seller.domain.SellerDocument;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SellerDocumentRepository extends JpaRepository<SellerDocument, Long> {
+public interface SellerDocumentRepository
+    extends JpaRepository<SellerDocument, Long>, SellerDocumentQueryDslRepository {
 }

--- a/src/main/java/com/bbangle/bbangle/util/FileNameUtil.java
+++ b/src/main/java/com/bbangle/bbangle/util/FileNameUtil.java
@@ -1,0 +1,27 @@
+package com.bbangle.bbangle.util;
+
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FileNameUtil {
+
+    public static String resolveUniquePath(String path, Set<String> usedPaths) {
+        if (!usedPaths.contains(path)) {
+            return path;
+        }
+
+        String baseName = path.substring(0, path.lastIndexOf('.'));
+        String extension = path.substring(path.lastIndexOf('.'));
+
+        int suffix = 2;
+        String candidate;
+        do {
+            candidate = baseName + "(" + suffix + ")" + extension;
+            suffix++;
+        } while (usedPaths.contains(candidate));
+
+        return candidate;
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/seller/admin/controller/AdminSellerControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/admin/controller/AdminSellerControllerTest.java
@@ -26,6 +26,7 @@ import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse.Admin
 import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse.AdminSellerApplicationList;
 import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerResponse.AdminSellerApplicationRejectList;
 import com.bbangle.bbangle.seller.admin.facade.AdminSellerFacade;
+import com.bbangle.bbangle.seller.admin.service.AdminSellerDocumentService;
 import com.bbangle.bbangle.seller.admin.service.AdminSellerService;
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -67,6 +68,9 @@ class AdminSellerControllerTest {
 
     @MockBean
     private AdminSellerService adminSellerService;
+
+    @MockBean
+    private AdminSellerDocumentService adminSellerDocumentService;
 
     @SpyBean
     private ResponseService responseService;
@@ -255,14 +259,14 @@ class AdminSellerControllerTest {
 
             // given
             String request = """
-            [
-              {
-                "applicationId": null,
-                "sellerName": "홍길동",
-                "identifier": "12345"
-              }
-            ]
-            """;
+                [
+                  {
+                    "applicationId": null,
+                    "sellerName": "홍길동",
+                    "identifier": "12345"
+                  }
+                ]
+                """;
 
             // when & then
             mockMvc.perform(put(AdminApiPath.PREFIX + "/sellers/approve")
@@ -279,14 +283,14 @@ class AdminSellerControllerTest {
 
             // given
             String request = """
-            [
-              {
-                "applicationId": 1,
-                "sellerName": "",
-                "identifier": "12345"
-              }
-            ]
-            """;
+                [
+                  {
+                    "applicationId": 1,
+                    "sellerName": "",
+                    "identifier": "12345"
+                  }
+                ]
+                """;
 
             // when & then
             mockMvc.perform(put(AdminApiPath.PREFIX + "/sellers/approve")
@@ -303,20 +307,20 @@ class AdminSellerControllerTest {
 
             // given
             String request = """
-            [
-              {
-                "applicationId": 1,
-                "sellerName": "홍길동",
-                "identifier": ""
-              }
-            ]
-            """;
+                [
+                  {
+                    "applicationId": 1,
+                    "sellerName": "홍길동",
+                    "identifier": ""
+                  }
+                ]
+                """;
 
             // when & then
             mockMvc.perform(
-                put(AdminApiPath.PREFIX + "/sellers/approve")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(request))
+                    put(AdminApiPath.PREFIX + "/sellers/approve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
                 .andExpect(status().isBadRequest());
             verify(adminSellerFacade, never()).approveStoreApplications(anyList());
         }

--- a/src/test/java/com/bbangle/bbangle/seller/admin/service/AdminSellerDocumentServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/admin/service/AdminSellerDocumentServiceIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.bbangle.bbangle.seller.admin.service;
+
+import static com.bbangle.bbangle.exception.BbangleErrorCode.SELLER_DOCUMENT_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
+import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.domain.SellerDocument;
+import com.bbangle.bbangle.store.domain.Store;
+import jakarta.persistence.EntityManager;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[통합 테스트] AdminSellerDocumentService")
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class AdminSellerDocumentServiceIntegrationTest {
+
+    @Autowired
+    private AdminSellerDocumentService adminSellerDocumentService;
+
+    @Autowired
+    private EntityManager em;
+
+    private Store createStore(String name) {
+        Store store = StoreFixture.defaultStore(name);
+        em.persist(store);
+        return store;
+    }
+
+    private Seller createSeller(Store store) {
+        Seller seller = SellerFixture.defaultSeller(store);
+        em.persist(seller);
+        return seller;
+    }
+
+    private void createDocument(Seller seller, String type, String fileName, String url) {
+        SellerDocument doc = SellerDocument.create(fileName, url, type, seller);
+        em.persist(doc);
+    }
+
+    @Nested
+    @DisplayName("downloadSellerDocuments() 테스트")
+    class DownloadSellerDocumentsTest {
+
+        @Test
+        @DisplayName("서류가 없는 판매자 ID만 요청하면 예외가 발생한다")
+        void fail_when_seller_has_no_documents() {
+            // given
+            Store store = createStore("빵그리의 오븐");
+            Seller seller = createSeller(store);
+            em.flush();
+            em.clear();
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminSellerDocumentService.downloadSellerDocuments(
+                    List.of(seller.getId()), new ByteArrayOutputStream()
+                )
+            )
+                .isInstanceOf(BbangleException.class)
+                .hasMessageContaining(SELLER_DOCUMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 sellerId만 요청하면 예외가 발생한다")
+        void fail_when_seller_not_exist() {
+            // given
+            List<Long> nonExistentIds = List.of(99999L);
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminSellerDocumentService.downloadSellerDocuments(
+                    nonExistentIds, new ByteArrayOutputStream()
+                )
+            )
+                .isInstanceOf(BbangleException.class)
+                .hasMessageContaining(SELLER_DOCUMENT_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/seller/admin/service/AdminSellerDocumentServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/admin/service/AdminSellerDocumentServiceUnitTest.java
@@ -1,0 +1,67 @@
+package com.bbangle.bbangle.seller.admin.service;
+
+import static com.bbangle.bbangle.exception.BbangleErrorCode.SELLER_DOCUMENT_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.seller.admin.service.model.SellerDocumentDownloadInfo;
+import com.bbangle.bbangle.seller.domain.model.DocumentType;
+import com.bbangle.bbangle.seller.repository.SellerDocumentRepository;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[단위 테스트] AdminSellerDocumentService")
+@ExtendWith(MockitoExtension.class)
+class AdminSellerDocumentServiceUnitTest {
+
+    @InjectMocks
+    private AdminSellerDocumentService adminSellerDocumentService;
+
+    @Mock
+    private SellerDocumentRepository sellerDocumentRepository;
+
+    @Nested
+    @DisplayName("downloadSellerDocuments() 테스트")
+    class DownloadSellerDocumentsTest {
+
+        @Test
+        @DisplayName("서류가 존재하지 않으면 예외가 발생한다")
+        void fail_when_no_documents_found() {
+            // given
+            List<Long> sellerIds = List.of(1L, 2L);
+            given(sellerDocumentRepository.findDocumentsBySellerIds(sellerIds))
+                .willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminSellerDocumentService.downloadSellerDocuments(sellerIds, new ByteArrayOutputStream())
+            )
+                .isInstanceOf(BbangleException.class)
+                .hasMessageContaining(SELLER_DOCUMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("sellerIds가 빈 리스트면 예외가 발생한다")
+        void fail_when_seller_ids_empty() {
+            // given
+            List<Long> sellerIds = List.of();
+            given(sellerDocumentRepository.findDocumentsBySellerIds(sellerIds))
+                .willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() ->
+                adminSellerDocumentService.downloadSellerDocuments(sellerIds, new ByteArrayOutputStream())
+            )
+                .isInstanceOf(BbangleException.class)
+                .hasMessageContaining(SELLER_DOCUMENT_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/seller/domain/SellerDocumentTest.java
+++ b/src/test/java/com/bbangle/bbangle/seller/domain/SellerDocumentTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
@@ -250,6 +251,28 @@ public class SellerDocumentTest {
         assertThatThrownBy(() -> SellerDocument.create(fileName, url, type, seller))
             .isInstanceOf(BbangleException.class)
             .hasMessageContaining(BbangleErrorCode.INVALID_DOCUMENT_FILE_EXTENSION.getMessage());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "BUSINESS_REGISTRATION_CERTIFICATE, original.pdf, 사업자등록증.pdf",
+        "MAIL_ORDER_SALES_REPORT, upload.jpg, 통신판매업신고증.jpg",
+        "INSTANT_FOOD_MANUFACTURING_PROCESSING_REGISTRATION, file.png, 즉석식품제조가공업등록증.png",
+        "BANKBOOK_COPY, doc.jpeg, 통장사본.jpeg"
+    })
+    @DisplayName("서류 타입별 한글 파일명으로 ZIP 파일명을 반환한다")
+    void getZipFileName_returns_korean_name_with_original_extension(
+        String type, String originalName, String expectedZipName
+    ) {
+        // arrange
+        String url = "https://s3.amazonaws.com/bbangle/documents/" + originalName;
+        SellerDocument document = SellerDocument.create(originalName, url, type, seller);
+
+        // act
+        String zipFileName = document.getZipFileName();
+
+        // assert
+        assertThat(zipFileName).isEqualTo(expectedZipName);
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/util/FileNameUtilTest.java
+++ b/src/test/java/com/bbangle/bbangle/util/FileNameUtilTest.java
@@ -1,0 +1,54 @@
+package com.bbangle.bbangle.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[단위 테스트] FileNameUtil")
+class FileNameUtilTest {
+
+    @Test
+    @DisplayName("사용된 적 없는 경로면 그대로 반환한다")
+    void return_same_path_when_not_used() {
+        // arrange
+        Set<String> usedPaths = new HashSet<>();
+
+        // act
+        String result = FileNameUtil.resolveUniquePath("store/사업자등록증.pdf", usedPaths);
+
+        // assert
+        assertThat(result).isEqualTo("store/사업자등록증.pdf");
+    }
+
+    @Test
+    @DisplayName("이미 사용된 경로면 (2) 접미사를 붙인다")
+    void append_suffix_when_path_already_used() {
+        // arrange
+        Set<String> usedPaths = new HashSet<>(Set.of("store/사업자등록증.pdf"));
+
+        // act
+        String result = FileNameUtil.resolveUniquePath("store/사업자등록증.pdf", usedPaths);
+
+        // assert
+        assertThat(result).isEqualTo("store/사업자등록증(2).pdf");
+    }
+
+    @Test
+    @DisplayName("(2)까지 사용 중이면 (3) 접미사를 붙인다")
+    void append_incrementing_suffix_when_candidates_already_used() {
+        // arrange
+        Set<String> usedPaths = new HashSet<>(Set.of(
+            "store/사업자등록증.pdf",
+            "store/사업자등록증(2).pdf"
+        ));
+
+        // act
+        String result = FileNameUtil.resolveUniquePath("store/사업자등록증.pdf", usedPaths);
+
+        // assert
+        assertThat(result).isEqualTo("store/사업자등록증(3).pdf");
+    }
+}


### PR DESCRIPTION
  - 리뷰어 : @CUCU7103 @exjuu                                                                                                                                                                                                            
  - 연관된 이슈 : #670                                                                                                                                                                                                                   
                                                                                                                                                                                                                                         
  🚀 Major Changes & Explanations                                                                                                                                                                                                        
                  
  판매자 서류 ZIP 다운로드 API 구현 (POST /api/v1/admin/sellers/documents/download)                                                                                                                                                      
  - 어드민이 여러 판매자의 서류를 한 번에 ZIP으로 다운로드할 수 있는 기능 구현
  - 요청 바디로 sellerIds 목록을 받아 해당 판매자들의 서류를 조회 후 스트리밍 방식으로 압축 전송                                                                                                                                         
  - 조회된 서류가 없을 경우 SELLER_DOCUMENT_NOT_FOUND(-719) 예외 반환                           
  - 대용량 파일 다운로드 시 메모리 부담을 줄이기 위해 StreamingResponseBody로 응답 스트리밍 처리                                                                                                                                         
                                                                                                                                                                                                                                         
  ZIP 내부 디렉토리 구조                                                                                                                                                                                                                 
  documents.zip                                                                                                                                                                                                                          
  ├── 빵그리베이커리/                                                                                                                                                                                                                    
  │   ├── 사업자등록증.pdf
  │   ├── 통신판매업신고증.jpg                                                                                                                                                                                                           
  │   ├── 즉석식품제조가공업등록증.png
  │   └── 통장사본.pdf                                                                                                                                                                                                                   
  └── 달콤한과자점/                                                                                                                                                                                                                      
      ├── 사업자등록증.pdf
      └── 통장사본.jpg                                                                                                                                                                                                                   
  - 판매자별로 스토어명 디렉토리 하위에 서류가 묶임
  - 파일명은 원본 파일명이 아닌 DocumentType의 한글명으로 변환 (예: 사업자등록증.pdf)
  - 서류가 없는 판매자는 ZIP에 포함되지 않음                                                                                                                                                                                             
                                                                                                                                                                                                                                         
  SellerDocumentQueryDslRepository 신규 구현                                                                                                                                                                                             
  - sellerIds 목록으로 서류 URL, 문서 타입, 원본 파일명, 스토어명을 한 번의 쿼리로 조회                                                                                                                                                  
  - seller → store 조인을 통해 스토어명을 함께 fetch                                                                                                                                                                                     
                                                                                                                                                                                                                                         
  SellerDocumentDownloadInfo 서비스 모델 추가                                                                                                                                                                                            
  - ZIP 파일 내 경로(zipEntryPath)를 도메인 규칙에 따라 생성하는 책임을 레코드 내부에 캡슐화
                                                                                                                                                                                                                                         
  DocumentType 한글명 추가
  - koreanName 필드 추가로 ZIP 내 파일명을 한글 서류명으로 표현 (예: 사업자등록증.pdf)    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 판매자 서류 일괄 다운로드: 여러 판매자를 선택해 ZIP 파일로 한 번에 다운로드할 수 있으며, 매장명별 폴더 구조로 정리됩니다.
  * 문서 파일명에 문서 유형(한글명)과 원본 확장자가 반영되며, ZIP 내부 경로 중복을 자동으로 방지합니다.
* **변경 사항**
  * 다운로드 요청은 판매자 ID 목록이 비어있지 않고 한 번에 최대 50명까지 가능합니다.
* **버그 수정**
  * 해당 판매자에 서류가 없을 경우 명확한 “서류가 존재하지 않습니다” 오류로 안내됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->