### PR TITLE
[Fix] (테스트) 에러 코드 불일치 및 Board saleStatus 누락 수정

### DIFF
--- a/src/test/java/com/bbangle/bbangle/charge/seller/controller/SellerChargeControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/charge/seller/controller/SellerChargeControllerTest.java
@@ -200,7 +200,7 @@ class SellerChargeControllerTest {
                     .param("size", "20"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.code").value(-801))
+                .andExpect(jsonPath("$.code").value(-821))
                 .andExpect(jsonPath("$.message").value("충전금 잔액 정보를 찾을 수 없습니다."));
         }
 
@@ -368,7 +368,7 @@ class SellerChargeControllerTest {
                     .content(jsonDataEncoder.encode(request)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.code").value(-802))
+                .andExpect(jsonPath("$.code").value(-822))
                 .andExpect(jsonPath("$.message").value("동일한 출금 요청이 처리 중입니다. 잠시 후 다시 시도해주세요."));
         }
 
@@ -390,7 +390,7 @@ class SellerChargeControllerTest {
                     .content(jsonDataEncoder.encode(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.code").value(-803))
+                .andExpect(jsonPath("$.code").value(-823))
                 .andExpect(jsonPath("$.message").value("충전금 잔액이 부족합니다."));
         }
 

--- a/src/test/java/com/bbangle/bbangle/order/repository/OrderDSLRepositoryImplTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/repository/OrderDSLRepositoryImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bbangle.bbangle.TestContainersConfig;
 import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.SaleStatus;
 import com.bbangle.bbangle.board.domain.Product;
 import com.bbangle.bbangle.board.repository.BoardRepository;
 import com.bbangle.bbangle.board.repository.ProductRepository;
@@ -76,6 +77,7 @@ class OrderDSLRepositoryImplTest {
         board = Board.builder()
             .store(store)
             .title("테스트 게시글")
+            .saleStatus(SaleStatus.ON_SALE)
             .build();
         boardRepository.save(board);
     }


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->

## 🚀 Major Changes & Explanations

* [fix] SellerChargeControllerTest 에러 코드 기댓값 수정
  - `BbangleErrorCode`의 실제 값(-821/-822/-823)과 테스트 기댓값(-801/-802/-803) 불일치 수정
  - 영향 케이스: `CHARGE_BALANCE_NOT_FOUND`, `CHARGE_WITHDRAWAL_DUPLICATED`, `CHARGE_WITHDRAWAL_INSUFFICIENT_BALANCE`

* [fix] OrderDSLRepositoryImplTest Board 생성 시 `saleStatus` 필드 추가
  - `sale_status` 컬럼이 NOT NULL 제약이 있어 `setUp()`에서 Board 저장 시 `DataIntegrityViolationException` 발생
  - 빌더에 `.saleStatus(SaleStatus.ON_SALE)` 추가하여 전체 11개 테스트 정상화

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 오류 응답 코드 검증 테스트가 업데이트되었습니다.
  * 테스트 설정에서 판매 상태가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->