### PR TITLE
[Feat] 일별 환불율 조회 API 구현완료 및 주석 상세

### DIFF
--- a/src/main/java/com/bbangle/bbangle/statistics/seller/controller/SellerPaymentStatisticsController.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/controller/SellerPaymentStatisticsController.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.statistics.seller.controller;
 
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.SellerApiPath;
 import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
 import com.bbangle.bbangle.statistics.seller.controller.swagger.SellerPaymentStatisticsApi;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse;
@@ -21,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/seller/payments/statistics")
+@RequestMapping(SellerApiPath.PREFIX + "/payments/statistics")
 public class SellerPaymentStatisticsController implements SellerPaymentStatisticsApi {
 
     private final ResponseService responseService;

--- a/src/main/java/com/bbangle/bbangle/statistics/seller/controller/SellerPaymentStatisticsController.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/controller/SellerPaymentStatisticsController.java
@@ -6,6 +6,7 @@ import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
 import com.bbangle.bbangle.statistics.seller.controller.swagger.SellerPaymentStatisticsApi;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse;
+import com.bbangle.bbangle.statistics.seller.dto.DailyRefundRateResponse;
 import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.service.SellerPaymentStatisticsService;
 import java.time.LocalDate;
@@ -68,6 +69,21 @@ public class SellerPaymentStatisticsController implements SellerPaymentStatistic
     ) {
         WeekdayPaymentAmountResponse result =
             sellerPaymentStatisticsService.getWeekdayPaymentAmount(sellerId, date, period);
+        return responseService.getSingleResult(result);
+    }
+
+    @Override
+    @GetMapping("/daily-refund-rate")
+    public SingleResult<DailyRefundRateResponse> getDailyRefundRate(
+        @AuthenticationPrincipal Long sellerId,
+        @RequestParam(value = "date", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        Optional<LocalDate> date,
+        @RequestParam(value = "period", required = false)
+        Optional<StatisticsPeriod> period
+    ) {
+        DailyRefundRateResponse result =
+            sellerPaymentStatisticsService.getDailyRefundRate(sellerId, date, period);
         return responseService.getSingleResult(result);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/statistics/seller/controller/swagger/SellerPaymentStatisticsApi.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/controller/swagger/SellerPaymentStatisticsApi.java
@@ -4,6 +4,7 @@ import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse;
+import com.bbangle.bbangle.statistics.seller.dto.DailyRefundRateResponse;
 import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -22,8 +23,8 @@ public interface SellerPaymentStatisticsApi {
     );
 
     @Operation(
-        summary = "판매자 결제건수 및 결제수 통계 조회",
-        description = "결제건수와 결제수를 일별, 주별, 월별 기준으로 조회합니다."
+        summary = "판매자 결제 건수 및 결제자 수 통계 조회",
+        description = "결제 건수와 결제자 수를 일별, 주별, 월별 기준으로 조회합니다."
     )
     SingleResult<DailyPaymentCountResponse> getDailyPaymentCount(
         @Parameter(description = "판매자 ID") Long sellerId,
@@ -33,9 +34,19 @@ public interface SellerPaymentStatisticsApi {
 
     @Operation(
         summary = "판매자 요일별 결제 금액 및 평균 결제 금액 통계 조회",
-        description = "조회 기간의 데이터를 요일 기준으로 재집계하여 요일별 총 결제 금액과 평균 결제 금액을 조회합니다."
+        description = "조회 기간 데이터를 요일 기준으로 수집해 요일별 총 결제 금액과 평균 결제 금액을 조회합니다."
     )
     SingleResult<WeekdayPaymentAmountResponse> getWeekdayPaymentAmount(
+        @Parameter(description = "판매자 ID") Long sellerId,
+        @Parameter(description = "기준 날짜 (yyyy-MM-dd), 미입력 시 오늘") Optional<LocalDate> date,
+        @Parameter(description = "조회 범위 (DAY, WEEK, MONTH), 미입력 시 DAY") Optional<StatisticsPeriod> period
+    );
+
+    @Operation(
+        summary = "판매자 환불율 통계 조회",
+        description = "환불 처리일 기준으로 일별, 주별, 월별 환불 금액과 환불율을 조회합니다."
+    )
+    SingleResult<DailyRefundRateResponse> getDailyRefundRate(
         @Parameter(description = "판매자 ID") Long sellerId,
         @Parameter(description = "기준 날짜 (yyyy-MM-dd), 미입력 시 오늘") Optional<LocalDate> date,
         @Parameter(description = "조회 범위 (DAY, WEEK, MONTH), 미입력 시 DAY") Optional<StatisticsPeriod> period

--- a/src/main/java/com/bbangle/bbangle/statistics/seller/dto/DailyPaymentAmountResponse.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/dto/DailyPaymentAmountResponse.java
@@ -2,20 +2,42 @@ package com.bbangle.bbangle.statistics.seller.dto;
 
 import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
 
+/**
+ * 판매자 결제금액 통계 응답 DTO.
+ * 일별 적재 데이터를 조회 화면의 버킷 단위로 합산한 결과를 담습니다.
+ */
+@Schema(description = "판매자 결제금액 통계 응답")
 public record DailyPaymentAmountResponse(
+    @Schema(description = "조회 시작일", example = "2026-03-01")
     LocalDate startDate,
+
+    @Schema(description = "조회 종료일", example = "2026-03-07")
     LocalDate endDate,
+
+    @Schema(description = "집계 단위", example = "DAY")
     StatisticsPeriod period,
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "버킷 평균 결제금액", example = "1429", nullable = true)
     Long averageAmount,
+
+    @Schema(description = "버킷별 결제금액 목록")
     List<DailyPaymentAmountItem> dailyAmounts
 ) {
 
+    /**
+     * 하나의 버킷(일/주/월 시작일 기준)에 대한 결제금액 항목.
+     */
+    @Schema(description = "버킷별 결제금액 항목")
     public record DailyPaymentAmountItem(
+        @Schema(description = "버킷 시작일", example = "2026-03-01")
         LocalDate date,
+
+        @Schema(description = "결제금액 합계", example = "12000")
         Long amount
     ) {
     }

--- a/src/main/java/com/bbangle/bbangle/statistics/seller/dto/DailyPaymentCountResponse.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/dto/DailyPaymentCountResponse.java
@@ -2,23 +2,49 @@ package com.bbangle.bbangle.statistics.seller.dto;
 
 import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
 
+/**
+ * 판매자 결제건수/구매자수 통계 응답 DTO.
+ * 주문 수와 구매자 수를 같은 버킷 기준으로 누적한 결과를 담습니다.
+ */
+@Schema(description = "판매자 결제건수 및 구매자수 통계 응답")
 public record DailyPaymentCountResponse(
+    @Schema(description = "조회 시작일", example = "2026-03-01")
     LocalDate startDate,
+
+    @Schema(description = "조회 종료일", example = "2026-03-07")
     LocalDate endDate,
+
+    @Schema(description = "집계 단위", example = "DAY")
     StatisticsPeriod period,
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "버킷 평균 구매자수", example = "1", nullable = true)
     Long averageBuyerCount,
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "버킷 평균 결제건수", example = "1", nullable = true)
     Long averagePaymentCount,
+
+    @Schema(description = "버킷별 결제건수/구매자수 목록")
     List<DailyPaymentCountItem> dailyCounts
 ) {
 
+    /**
+     * 하나의 버킷(일/주/월 시작일 기준)에 대한 구매자수/결제건수 항목.
+     */
+    @Schema(description = "버킷별 결제건수/구매자수 항목")
     public record DailyPaymentCountItem(
+        @Schema(description = "버킷 시작일", example = "2026-03-01")
         LocalDate date,
+
+        @Schema(description = "구매자수 합계", example = "1")
         Long buyerCount,
+
+        @Schema(description = "결제건수 합계", example = "2")
         Long paymentCount
     ) {
     }

--- a/src/main/java/com/bbangle/bbangle/statistics/seller/dto/DailyRefundRateResponse.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/dto/DailyRefundRateResponse.java
@@ -21,9 +21,6 @@ public record DailyRefundRateResponse(
     @Schema(description = "집계 단위", example = "DAY")
     StatisticsPeriod period,
 
-    @Schema(description = "버킷 평균 환불율(%)", example = "35.42", nullable = true)
-    BigDecimal averageRefundRate,
-
     @Schema(description = "버킷별 환불 통계 목록")
     List<DailyRefundRateItem> dailyRefundRates
 ) {

--- a/src/main/java/com/bbangle/bbangle/statistics/seller/dto/DailyRefundRateResponse.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/dto/DailyRefundRateResponse.java
@@ -1,0 +1,49 @@
+package com.bbangle.bbangle.statistics.seller.dto;
+
+import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 판매자 환불율 통계 응답 DTO.
+ * 일별 적재 데이터를 기준으로 화면 버킷(DAY/WEEK/MONTH) 단위 응답을 구성합니다.
+ */
+@Schema(description = "판매자 환불율 통계 응답")
+public record DailyRefundRateResponse(
+    @Schema(description = "조회 시작일", example = "2026-03-01")
+    LocalDate startDate,
+
+    @Schema(description = "조회 종료일", example = "2026-03-07")
+    LocalDate endDate,
+
+    @Schema(description = "집계 단위", example = "DAY")
+    StatisticsPeriod period,
+
+    @Schema(description = "버킷 평균 환불율(%)", example = "35.42", nullable = true)
+    BigDecimal averageRefundRate,
+
+    @Schema(description = "버킷별 환불 통계 목록")
+    List<DailyRefundRateItem> dailyRefundRates
+) {
+
+    /**
+     * 하나의 버킷(일/주/월 시작일 기준)에 대한 환불 통계 항목.
+     */
+    @Schema(description = "버킷별 환불 통계 항목")
+    public record DailyRefundRateItem(
+        @Schema(description = "버킷 시작일", example = "2026-03-01")
+        LocalDate date,
+
+        @Schema(description = "결제금액 합계", example = "12000")
+        long paymentAmount,
+
+        @Schema(description = "환불금액 합계", example = "3000")
+        long refundAmount,
+
+        @Schema(description = "결제금액 대비 환불율(%)", example = "25.00")
+        BigDecimal refundRate
+    ) {
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/statistics/seller/dto/WeekdayPaymentAmountResponse.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/dto/WeekdayPaymentAmountResponse.java
@@ -1,19 +1,41 @@
 package com.bbangle.bbangle.statistics.seller.dto;
 
 import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
 
+/**
+ * 판매자 요일별 결제금액 통계 응답 DTO.
+ * 조회 기간의 일별 데이터를 월~일 요일 기준으로 재분류한 결과를 담습니다.
+ */
+@Schema(description = "판매자 요일별 결제금액 통계 응답")
 public record WeekdayPaymentAmountResponse(
+    @Schema(description = "조회 시작일", example = "2026-03-01")
     LocalDate startDate,
+
+    @Schema(description = "조회 종료일", example = "2026-03-07")
     LocalDate endDate,
+
+    @Schema(description = "집계 단위", example = "DAY")
     StatisticsPeriod period,
+
+    @Schema(description = "요일별 결제금액 목록")
     List<WeekdayPaymentAmountItem> weekdayAmounts
 ) {
 
+    /**
+     * 하나의 요일에 대한 결제금액 통계 항목.
+     */
+    @Schema(description = "요일별 결제금액 항목")
     public record WeekdayPaymentAmountItem(
+        @Schema(description = "요일 번호(월=1, 일=7)", example = "1")
         Integer weekday,
+
+        @Schema(description = "해당 요일 총 결제금액", example = "4000")
         Long amount,
+
+        @Schema(description = "해당 요일 평균 결제금액", example = "571")
         Long averageAmount
     ) {
     }

--- a/src/main/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsService.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsService.java
@@ -12,9 +12,12 @@ import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse.DailyPaymentAmountItem;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse.DailyPaymentCountItem;
+import com.bbangle.bbangle.statistics.seller.dto.DailyRefundRateResponse;
+import com.bbangle.bbangle.statistics.seller.dto.DailyRefundRateResponse.DailyRefundRateItem;
 import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse.WeekdayPaymentAmountItem;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -34,10 +37,14 @@ public class SellerPaymentStatisticsService {
 
     // 통계 응답은 항상 7개 버킷(일/주/월)으로 고정합니다.
     private static final int BUCKET_COUNT = 7;
+    private static final BigDecimal ONE_HUNDRED = BigDecimal.valueOf(100);
 
     private final SellerRepository sellerRepository;
     private final SellerStatisticsRepository sellerStatisticsRepository;
 
+    /**
+     * 판매자 결제금액 통계를 조회합니다. 일별 적재 데이터를 조회한 뒤 요청한 기간 단위(DAY/WEEK/MONTH)에 맞게 7개 버킷으로 다시 합산합니다.
+     */
     @Transactional(readOnly = true)
     public DailyPaymentAmountResponse getDailyPaymentAmount(
         Long sellerId,
@@ -85,6 +92,9 @@ public class SellerPaymentStatisticsService {
         );
     }
 
+    /**
+     * 판매자 요일별 결제금액 통계를 조회합니다. 조회 기간의 일별 데이터를 월~일 요일 기준으로 재분류해 총 결제금액과 평균 결제금액을 계산합니다.
+     */
     @Transactional(readOnly = true)
     public WeekdayPaymentAmountResponse getWeekdayPaymentAmount(
         Long sellerId,
@@ -120,6 +130,9 @@ public class SellerPaymentStatisticsService {
         );
     }
 
+    /**
+     * 판매자 결제건수 및 구매자수 통계를 조회합니다. 일별 적재된 주문 수와 구매자 수를 요청한 기간 단위 버킷으로 누적해 응답합니다.
+     */
     @Transactional(readOnly = true)
     public DailyPaymentCountResponse getDailyPaymentCount(
         Long sellerId,
@@ -176,6 +189,55 @@ public class SellerPaymentStatisticsService {
         );
     }
 
+    /**
+     * 판매자 환불율 통계를 조회합니다. 일별 적재 데이터에서 결제금액과 환불금액을 합산한 뒤 버킷별 환불율을 다시 계산해 응답합니다.
+     */
+    @Transactional(readOnly = true)
+    public DailyRefundRateResponse getDailyRefundRate(
+        Long sellerId,
+        Optional<LocalDate> date,
+        Optional<StatisticsPeriod> period
+    ) {
+        // 환불율은 적재된 일별 환불율을 그대로 쓰지 않고,
+        // 버킷별 결제금액 합계와 환불금액 합계로 다시 계산합니다.
+        Seller seller = sellerRepository.findById(sellerId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.SELLER_NOT_FOUND));
+
+        StatisticsPeriod resolvedPeriod = StatisticsPeriod.from(period.orElse(StatisticsPeriod.DAY));
+        LocalDate targetDate = date.orElse(LocalDate.now());
+        DateRange range = resolvedPeriod.resolveDateRange(targetDate, BUCKET_COUNT);
+
+        List<SellerStatisticsDaily> rows =
+            sellerStatisticsRepository.findBySellerIdAndStatDateBetweenOrderByStatDateAsc(
+                seller.getId(),
+                range.startDate().atStartOfDay(),
+                range.endDate().atTime(LocalTime.MAX)
+            );
+
+        Map<LocalDate, SellerStatisticsDaily> statisticsByDate = rows.stream()
+            .collect(Collectors.toMap(
+                row -> row.getStatDate().toLocalDate(),
+                Function.identity(),
+                (first, second) -> first
+            ));
+
+        List<DailyRefundRateItem> items = buildRefundRateItems(range, resolvedPeriod, statisticsByDate);
+        BigDecimal averageRefundRate = resolvedPeriod == StatisticsPeriod.DAY
+            ? null
+            : calculateAverageRefundRate(items);
+
+        return new DailyRefundRateResponse(
+            range.startDate(),
+            range.endDate(),
+            resolvedPeriod,
+            averageRefundRate,
+            items
+        );
+    }
+
+    /**
+     * 기간 버킷별 결제금액 합계를 계산합니다.
+     */
     private List<DailyPaymentAmountItem> buildItems(
         DateRange range,
         StatisticsPeriod period,
@@ -203,6 +265,9 @@ public class SellerPaymentStatisticsService {
         return items;
     }
 
+    /**
+     * 기간 버킷별 구매자수와 결제건수를 각각 누적합니다.
+     */
     private List<DailyPaymentCountItem> buildCountItems(
         DateRange range,
         StatisticsPeriod period,
@@ -235,6 +300,9 @@ public class SellerPaymentStatisticsService {
         return items;
     }
 
+    /**
+     * 조회 기간의 데이터를 요일 기준으로 묶어 총 결제금액과 평균 결제금액을 계산합니다.
+     */
     private List<WeekdayPaymentAmountItem> buildWeekdayItems(
         DateRange range,
         Map<LocalDate, SellerStatisticsDaily> statisticsByDate
@@ -263,5 +331,76 @@ public class SellerPaymentStatisticsService {
         }
 
         return items;
+    }
+
+    /**
+     * 기간 버킷별 결제금액/환불금액 합계와 환불율을 계산합니다. 환불율은 적재된 일별 환불율이 아니라 합산 금액 기준으로 다시 계산합니다.
+     */
+    private List<DailyRefundRateItem> buildRefundRateItems(
+        DateRange range,
+        StatisticsPeriod period,
+        Map<LocalDate, SellerStatisticsDaily> statisticsByDate
+    ) {
+        // refund_rate 컬럼은 참고용으로 두고, 응답용 비율은 합산 금액 기준으로 다시 계산합니다.
+        List<DailyRefundRateItem> items = new ArrayList<>();
+        LocalDate cursor = range.startDate();
+
+        for (int i = 0; i < BUCKET_COUNT; i++) {
+            LocalDate bucketStart = cursor;
+            LocalDate bucketEnd = period.resolveBucketEnd(bucketStart);
+
+            long paymentAmount = bucketStart.datesUntil(bucketEnd.plusDays(1))
+                .map(statisticsByDate::get)
+                .filter(row -> row != null && row.getTotalAmount() != null)
+                .map(SellerStatisticsDaily::getTotalAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .longValue();
+
+            long refundAmount = bucketStart.datesUntil(bucketEnd.plusDays(1))
+                .map(statisticsByDate::get)
+                .filter(row -> row != null && row.getRefundAmount() != null)
+                .map(SellerStatisticsDaily::getRefundAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .longValue();
+
+            items.add(new DailyRefundRateItem(
+                bucketStart,
+                paymentAmount,
+                refundAmount,
+                calculateRefundRate(paymentAmount, refundAmount)
+            ));
+            cursor = period.nextBucketStart(cursor);
+        }
+
+        return items;
+    }
+
+    /**
+     * 버킷별 환불율의 산술 평균을 계산합니다.
+     */
+    private BigDecimal calculateAverageRefundRate(List<DailyRefundRateItem> items) {
+        // 주/월 조회의 평균 환불율은 각 버킷 환불율의 평균으로 제공합니다.
+        if (items.isEmpty()) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        return items.stream()
+            .map(DailyRefundRateItem::refundRate)
+            .reduce(BigDecimal.ZERO, BigDecimal::add)
+            .divide(BigDecimal.valueOf(items.size()), 2, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * 결제금액 대비 환불금액 비율을 계산합니다.
+     */
+    private BigDecimal calculateRefundRate(long paymentAmount, long refundAmount) {
+        // 분모가 0이면 환불율은 0으로 간주합니다.
+        if (paymentAmount <= 0L || refundAmount <= 0L) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        return BigDecimal.valueOf(refundAmount)
+            .multiply(ONE_HUNDRED)
+            .divide(BigDecimal.valueOf(paymentAmount), 2, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsService.java
+++ b/src/main/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsService.java
@@ -43,7 +43,8 @@ public class SellerPaymentStatisticsService {
     private final SellerStatisticsRepository sellerStatisticsRepository;
 
     /**
-     * 판매자 결제금액 통계를 조회합니다. 일별 적재 데이터를 조회한 뒤 요청한 기간 단위(DAY/WEEK/MONTH)에 맞게 7개 버킷으로 다시 합산합니다.
+     * 판매자 결제금액 통계를 조회합니다.
+     * 일별 적재 데이터를 조회한 뒤 요청된 기간 단위(DAY/WEEK/MONTH)에 맞게 7개 버킷으로 다시 합산합니다.
      */
     @Transactional(readOnly = true)
     public DailyPaymentAmountResponse getDailyPaymentAmount(
@@ -93,7 +94,8 @@ public class SellerPaymentStatisticsService {
     }
 
     /**
-     * 판매자 요일별 결제금액 통계를 조회합니다. 조회 기간의 일별 데이터를 월~일 요일 기준으로 재분류해 총 결제금액과 평균 결제금액을 계산합니다.
+     * 판매자 요일별 결제금액 통계를 조회합니다.
+     * 조회 기간의 일별 데이터를 모아 월~일 요일 기준으로 재분류한 뒤 총 결제금액과 평균 결제금액을 계산합니다.
      */
     @Transactional(readOnly = true)
     public WeekdayPaymentAmountResponse getWeekdayPaymentAmount(
@@ -131,7 +133,8 @@ public class SellerPaymentStatisticsService {
     }
 
     /**
-     * 판매자 결제건수 및 구매자수 통계를 조회합니다. 일별 적재된 주문 수와 구매자 수를 요청한 기간 단위 버킷으로 누적해 응답합니다.
+     * 판매자 결제건수 및 구매자수 통계를 조회합니다.
+     * 일별 적재된 주문 수와 구매자 수를 요청된 기간 버킷 단위로 누적해 응답합니다.
      */
     @Transactional(readOnly = true)
     public DailyPaymentCountResponse getDailyPaymentCount(
@@ -146,7 +149,7 @@ public class SellerPaymentStatisticsService {
         LocalDate targetDate = date.orElse(LocalDate.now());
         DateRange range = resolvedPeriod.resolveDateRange(targetDate, BUCKET_COUNT);
 
-        // 조회 구간의 일별 통계만 가져와 이후 버킷 단위로 다시 합산합니다.
+        // 조회 구간의 일별 통계만 가져온 이후 버킷 단위로 다시 합산합니다.
         List<SellerStatisticsDaily> rows =
             sellerStatisticsRepository.findBySellerIdAndStatDateBetweenOrderByStatDateAsc(
                 seller.getId(),
@@ -190,7 +193,8 @@ public class SellerPaymentStatisticsService {
     }
 
     /**
-     * 판매자 환불율 통계를 조회합니다. 일별 적재 데이터에서 결제금액과 환불금액을 합산한 뒤 버킷별 환불율을 다시 계산해 응답합니다.
+     * 판매자 환불율 통계를 조회합니다.
+     * 일별 적재 데이터에서 결제금액과 환불금액을 합산한 뒤 버킷별 환불율을 다시 계산해 응답합니다.
      */
     @Transactional(readOnly = true)
     public DailyRefundRateResponse getDailyRefundRate(
@@ -222,15 +226,11 @@ public class SellerPaymentStatisticsService {
             ));
 
         List<DailyRefundRateItem> items = buildRefundRateItems(range, resolvedPeriod, statisticsByDate);
-        BigDecimal averageRefundRate = resolvedPeriod == StatisticsPeriod.DAY
-            ? null
-            : calculateAverageRefundRate(items);
 
         return new DailyRefundRateResponse(
             range.startDate(),
             range.endDate(),
             resolvedPeriod,
-            averageRefundRate,
             items
         );
     }
@@ -334,14 +334,15 @@ public class SellerPaymentStatisticsService {
     }
 
     /**
-     * 기간 버킷별 결제금액/환불금액 합계와 환불율을 계산합니다. 환불율은 적재된 일별 환불율이 아니라 합산 금액 기준으로 다시 계산합니다.
+     * 기간 버킷별 결제금액/환불금액 합계와 환불율을 계산합니다.
+     * 환불율은 적재된 일별 환불율이 아니라 합산 금액 기준으로 다시 계산합니다.
      */
     private List<DailyRefundRateItem> buildRefundRateItems(
         DateRange range,
         StatisticsPeriod period,
         Map<LocalDate, SellerStatisticsDaily> statisticsByDate
     ) {
-        // refund_rate 컬럼은 참고용으로 두고, 응답용 비율은 합산 금액 기준으로 다시 계산합니다.
+        // refund_rate 컬럼은 참고용으로만 두고, 응답의 비율은 합산 금액 기준으로 다시 계산합니다.
         List<DailyRefundRateItem> items = new ArrayList<>();
         LocalDate cursor = range.startDate();
 
@@ -376,25 +377,10 @@ public class SellerPaymentStatisticsService {
     }
 
     /**
-     * 버킷별 환불율의 산술 평균을 계산합니다.
-     */
-    private BigDecimal calculateAverageRefundRate(List<DailyRefundRateItem> items) {
-        // 주/월 조회의 평균 환불율은 각 버킷 환불율의 평균으로 제공합니다.
-        if (items.isEmpty()) {
-            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
-        }
-
-        return items.stream()
-            .map(DailyRefundRateItem::refundRate)
-            .reduce(BigDecimal.ZERO, BigDecimal::add)
-            .divide(BigDecimal.valueOf(items.size()), 2, RoundingMode.HALF_UP);
-    }
-
-    /**
      * 결제금액 대비 환불금액 비율을 계산합니다.
      */
     private BigDecimal calculateRefundRate(long paymentAmount, long refundAmount) {
-        // 분모가 0이면 환불율은 0으로 간주합니다.
+        // 분모가 0이면 환불율을 0으로 간주합니다.
         if (paymentAmount <= 0L || refundAmount <= 0L) {
             return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
         }

--- a/src/test/java/com/bbangle/bbangle/statistics/seller/controller/SellerPaymentStatisticsControllerSliceTest.java
+++ b/src/test/java/com/bbangle/bbangle/statistics/seller/controller/SellerPaymentStatisticsControllerSliceTest.java
@@ -173,7 +173,6 @@ class SellerPaymentStatisticsControllerSliceTest {
             LocalDate.of(2026, 3, 1),
             LocalDate.of(2026, 3, 7),
             StatisticsPeriod.DAY,
-            null,
             List.of(
                 new DailyRefundRateItem(LocalDate.of(2026, 3, 1), 12000L, 3000L, new BigDecimal("25.00")),
                 new DailyRefundRateItem(LocalDate.of(2026, 3, 2), 0L, 0L, new BigDecimal("0.00")),

--- a/src/test/java/com/bbangle/bbangle/statistics/seller/controller/SellerPaymentStatisticsControllerSliceTest.java
+++ b/src/test/java/com/bbangle/bbangle/statistics/seller/controller/SellerPaymentStatisticsControllerSliceTest.java
@@ -14,9 +14,12 @@ import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse.DailyPaymentAmountItem;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse.DailyPaymentCountItem;
+import com.bbangle.bbangle.statistics.seller.dto.DailyRefundRateResponse;
+import com.bbangle.bbangle.statistics.seller.dto.DailyRefundRateResponse.DailyRefundRateItem;
 import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse.WeekdayPaymentAmountItem;
 import com.bbangle.bbangle.statistics.seller.service.SellerPaymentStatisticsService;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -161,5 +164,44 @@ class SellerPaymentStatisticsControllerSliceTest {
             .andExpect(jsonPath("$.result.weekdayAmounts[6].weekday").value(7))
             .andExpect(jsonPath("$.result.weekdayAmounts[6].amount").value(7000))
             .andExpect(jsonPath("$.result.weekdayAmounts[6].averageAmount").value(7000));
+    }
+
+    @Test
+    @DisplayName("환불율 통계를 반환한다")
+    void getDailyRefundRate_success() throws Exception {
+        DailyRefundRateResponse response = new DailyRefundRateResponse(
+            LocalDate.of(2026, 3, 1),
+            LocalDate.of(2026, 3, 7),
+            StatisticsPeriod.DAY,
+            null,
+            List.of(
+                new DailyRefundRateItem(LocalDate.of(2026, 3, 1), 12000L, 3000L, new BigDecimal("25.00")),
+                new DailyRefundRateItem(LocalDate.of(2026, 3, 2), 0L, 0L, new BigDecimal("0.00")),
+                new DailyRefundRateItem(LocalDate.of(2026, 3, 3), 10000L, 2000L, new BigDecimal("20.00")),
+                new DailyRefundRateItem(LocalDate.of(2026, 3, 4), 0L, 0L, new BigDecimal("0.00")),
+                new DailyRefundRateItem(LocalDate.of(2026, 3, 5), 0L, 0L, new BigDecimal("0.00")),
+                new DailyRefundRateItem(LocalDate.of(2026, 3, 6), 0L, 0L, new BigDecimal("0.00")),
+                new DailyRefundRateItem(LocalDate.of(2026, 3, 7), 0L, 0L, new BigDecimal("0.00"))
+            )
+        );
+
+        given(sellerPaymentStatisticsService.getDailyRefundRate(any(), any(), any()))
+            .willReturn(response);
+
+        mvc.perform(get("/api/v1/seller/payments/statistics/daily-refund-rate")
+                .param("date", "2026-03-07")
+                .param("period", "DAY"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()))
+            .andExpect(jsonPath("$.result.startDate").value("2026-03-01"))
+            .andExpect(jsonPath("$.result.endDate").value("2026-03-07"))
+            .andExpect(jsonPath("$.result.period").value("DAY"))
+            .andExpect(jsonPath("$.result.dailyRefundRates.length()").value(7))
+            .andExpect(jsonPath("$.result.dailyRefundRates[0].paymentAmount").value(12000))
+            .andExpect(jsonPath("$.result.dailyRefundRates[0].refundAmount").value(3000))
+            .andExpect(jsonPath("$.result.dailyRefundRates[0].refundRate").value(25.00))
+            .andExpect(jsonPath("$.result.dailyRefundRates[2].refundRate").value(20.00));
     }
 }

--- a/src/test/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsServiceUnitTest.java
@@ -377,7 +377,6 @@ class SellerPaymentStatisticsServiceUnitTest {
         assertThat(result.dailyRefundRates().get(6).paymentAmount()).isEqualTo(18000L);
         assertThat(result.dailyRefundRates().get(6).refundAmount()).isEqualTo(5000L);
         assertThat(result.dailyRefundRates().get(6).refundRate()).isEqualByComparingTo("27.78");
-        assertThat(result.averageRefundRate()).isEqualByComparingTo("6.83");
     }
 
     @Test

--- a/src/test/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/statistics/seller/service/SellerPaymentStatisticsServiceUnitTest.java
@@ -15,6 +15,7 @@ import com.bbangle.bbangle.statistics.domain.model.StatisticsPeriod;
 import com.bbangle.bbangle.statistics.repository.SellerStatisticsRepository;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentAmountResponse;
 import com.bbangle.bbangle.statistics.seller.dto.DailyPaymentCountResponse;
+import com.bbangle.bbangle.statistics.seller.dto.DailyRefundRateResponse;
 import com.bbangle.bbangle.statistics.seller.dto.WeekdayPaymentAmountResponse;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -42,7 +43,7 @@ class SellerPaymentStatisticsServiceUnitTest {
     private SellerStatisticsRepository sellerStatisticsRepository;
 
     @Test
-    @DisplayName("결제 금액 조회 시 비어 있는 일자 구간은 0으로 채운다")
+    @DisplayName("결제 금액 조회 시 비어 있는 날짜 구간은 0으로 채운다")
     void getDailyPaymentAmount_fillMissingDatesWithZero() {
         Long sellerId = 1L;
         LocalDate targetDate = LocalDate.of(2026, 3, 7);
@@ -291,7 +292,7 @@ class SellerPaymentStatisticsServiceUnitTest {
     }
 
     @Test
-    @DisplayName("결제 건수 조회 시 비어 있는 일자 구간은 0으로 채운다")
+    @DisplayName("결제 건수 조회 시 비어 있는 날짜 구간은 0으로 채운다")
     void getDailyPaymentCount_fillMissingDatesWithZero() {
         Long sellerId = 1L;
         LocalDate targetDate = LocalDate.of(2026, 3, 7);
@@ -330,6 +331,56 @@ class SellerPaymentStatisticsServiceUnitTest {
     }
 
     @Test
+    @DisplayName("환불율 통계는 statistics 적재 데이터 기준으로 버킷 집계한다")
+    void getDailyRefundRate_success() {
+        Long sellerId = 1L;
+        LocalDate targetDate = LocalDate.of(2026, 3, 16);
+
+        givenExistingSeller(sellerId);
+
+        SellerStatisticsDaily week1Day1 = mockStatisticsDaily(
+            LocalDateTime.of(2026, 2, 2, 10, 0),
+            10000L,
+            0,
+            0,
+            2000L
+        );
+        SellerStatisticsDaily week1Day2 = mockStatisticsDaily(
+            LocalDateTime.of(2026, 2, 5, 10, 0),
+            5000L,
+            0,
+            0,
+            1000L
+        );
+        SellerStatisticsDaily week7Day = mockStatisticsDaily(
+            LocalDateTime.of(2026, 3, 20, 10, 0),
+            18000L,
+            0,
+            0,
+            5000L
+        );
+
+        given(sellerStatisticsRepository.findBySellerIdAndStatDateBetweenOrderByStatDateAsc(
+            eq(sellerId), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(List.of(week1Day1, week1Day2, week7Day));
+
+        DailyRefundRateResponse result = sut.getDailyRefundRate(
+            sellerId, Optional.of(targetDate), Optional.of(StatisticsPeriod.WEEK));
+
+        assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 2, 2));
+        assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, 3, 22));
+        assertThat(result.period()).isEqualTo(StatisticsPeriod.WEEK);
+        assertThat(result.dailyRefundRates()).hasSize(7);
+        assertThat(result.dailyRefundRates().get(0).paymentAmount()).isEqualTo(15000L);
+        assertThat(result.dailyRefundRates().get(0).refundAmount()).isEqualTo(3000L);
+        assertThat(result.dailyRefundRates().get(0).refundRate()).isEqualByComparingTo("20.00");
+        assertThat(result.dailyRefundRates().get(6).paymentAmount()).isEqualTo(18000L);
+        assertThat(result.dailyRefundRates().get(6).refundAmount()).isEqualTo(5000L);
+        assertThat(result.dailyRefundRates().get(6).refundRate()).isEqualByComparingTo("27.78");
+        assertThat(result.averageRefundRate()).isEqualByComparingTo("6.83");
+    }
+
+    @Test
     @DisplayName("판매자가 없으면 SELLER_NOT_FOUND 예외를 던진다")
     void getDailyPaymentAmount_sellerNotFound() {
         Long sellerId = 999L;
@@ -354,14 +405,24 @@ class SellerPaymentStatisticsServiceUnitTest {
         int totalOrders,
         int totalBuyers
     ) {
+        return mockStatisticsDaily(statDate, amount, totalOrders, totalBuyers, 0L);
+    }
+
+    private SellerStatisticsDaily mockStatisticsDaily(
+        LocalDateTime statDate,
+        long amount,
+        int totalOrders,
+        int totalBuyers,
+        long refundAmount
+    ) {
         return SellerStatisticsDaily.create(
             statDate,
             statDate.getDayOfWeek().getValue(),
             BigDecimal.valueOf(amount),
             totalOrders,
             totalBuyers,
-            BigDecimal.ZERO,
-            0,
+            BigDecimal.valueOf(refundAmount),
+            refundAmount > 0 ? 1 : 0,
             BigDecimal.ZERO,
             null
         );


### PR DESCRIPTION
리뷰어 : @mono0801  @kimbro97 

## Major Changes & Explanations

  - 판매자 결제 통계 API에 환불율 조회 기능을 추가했습니다.
    - 경로: `/api/v1/seller/payments/statistics/daily-refund-rate`
    - `SellerApiPath.PREFIX` 기반 경로로 통일했습니다.

  - 환불율 조회는  `seller_statistics_daily` 적재 데이터를 기준으로 동작하도록 구성했습니다.
    - `total_amount`, `refund_amount`를 버킷별로 합산합니다.
    - 응답용 `refundRate`는 적재된 `refund_rate`를 그대로 사용하지 않고, `refundAmount / paymentAmount * 100`으로 다시 계산합니다.

  - 환불율 응답 DTO와 통계 서비스에 설명 주석을 보강했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
- 일일 환불율 통계 조회 기능 추가
  - 지정된 날짜 범위에서 환불율 데이터를 일/주/월 단위로 집계하여 조회 가능
  - 환불액과 결제액의 비율을 자동으로 계산하여 제공

**문서화**
- API 응답 구조에 대한 상세 스키마 설명 추가

**테스트**
- 새로운 기능에 대한 통합 테스트 및 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->