### PR TITLE
[Feat] (어드민) 상품 목록/업로드 승인 응답에 storeId 필드 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/dto/AdminProductResponse.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/dto/AdminProductResponse.java
@@ -10,6 +10,9 @@ public record AdminProductResponse(
     @Schema(description = "상품 ID", example = "1001")
     Long productId,
 
+    @Schema(description = "스토어 ID", example = "10")
+    Long storeId,
+
     @Schema(description = "스토어명", example = "그린베이커리")
     String storeName,
 
@@ -59,6 +62,7 @@ public record AdminProductResponse(
 
         return new AdminProductResponse(
             board.getId(),
+            board.getStore().getId(),
             board.getStore().getName(),
             board.getTitle(),
             board.getPrice(),

--- a/src/main/java/com/bbangle/bbangle/board/admin/controller/dto/UploadApprovalResponse.java
+++ b/src/main/java/com/bbangle/bbangle/board/admin/controller/dto/UploadApprovalResponse.java
@@ -8,6 +8,9 @@ public record UploadApprovalResponse(
     @Schema(description = "상품(게시글) ID", example = "101")
     Long boardId,
 
+    @Schema(description = "스토어 ID", example = "10")
+    Long storeId,
+
     @Schema(description = "스토어명", example = "빠진 빵집")
     String storeName,
 
@@ -18,6 +21,7 @@ public record UploadApprovalResponse(
   public static UploadApprovalResponse fromEntity(Board board) {
     return new UploadApprovalResponse(
         board.getId(),
+        board.getStore().getId(),
         board.getStore().getName(),
         board.getTitle()
     );

--- a/src/main/java/com/bbangle/bbangle/board/domain/RejectionCategory.java
+++ b/src/main/java/com/bbangle/bbangle/board/domain/RejectionCategory.java
@@ -7,14 +7,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RejectionCategory {
 
-    ADMIN_JUDGMENT("관리자 판단 부재함"),
-    INAPPROPRIATE_BRAND_NAME("브랜드명 부적절 사용"),
-    INVALID_PRICE_CONDITION("공지사항 가격 조건 위반"),
-    INAPPROPRIATE_VEGAN_EXPRESSION("비거니/비건 표현 부적합"),
-    PROHIBITED_STORE_EXPRESSION("상품명/카테고리 포함 금지 표현"),
-    PROHIBITED_LOGO_TEXT("로고사용 문구 포함"),
-    CONTAINS_CONTACT_INFO("연락처/사이트 포함"),
-    CONTAINS_COMPETITOR_NAME("타 판매자명 공유"),
+    ADMIN_JUDGMENT("관리자 판단 부적합"),
+    INAPPROPRIATE_BRAND_NAME("브랜드명 무단사용"),
+    OFFICIAL_MATERIAL_CONFUSION("공식물 오인 가능"),
+    INAPPROPRIATE_EXPRESSION("비속어/부적절한 표현"),
+    PROHIBITED_STORE_EXPRESSION("상품명/카테고리명 포함"),
+    CONTAINS_ADVERTISING("광고성 문구 포함"),
+    CONTAINS_CONTACT_INFO("연락처/URL 포함"),
+    CONTAINS_COMPETITOR_NAME("타 판매자명 유사"),
     DIRECT_INPUT("직접입력");
 
     private final String description;

--- a/src/test/java/com/bbangle/bbangle/board/admin/controller/AdminBoardControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/admin/controller/AdminBoardControllerTest.java
@@ -187,6 +187,7 @@ class AdminBoardControllerTest {
         Board board = BoardFixture.defaultBoard();
         UploadApprovalResponse response = new UploadApprovalResponse(
             board.getId(),
+            board.getStore().getId(),
             board.getStore().getName(),
             board.getTitle()
         );

--- a/src/test/java/com/bbangle/bbangle/board/domain/BoardTest.java
+++ b/src/test/java/com/bbangle/bbangle/board/domain/BoardTest.java
@@ -557,10 +557,11 @@ class BoardTest {
                 // given
                 RejectionCategory[] categories = {
                     RejectionCategory.ADMIN_JUDGMENT,
-                    RejectionCategory.INVALID_PRICE_CONDITION,
-                    RejectionCategory.INAPPROPRIATE_VEGAN_EXPRESSION,
+                    RejectionCategory.INAPPROPRIATE_BRAND_NAME,
+                    RejectionCategory.OFFICIAL_MATERIAL_CONFUSION,
+                    RejectionCategory.INAPPROPRIATE_EXPRESSION,
                     RejectionCategory.PROHIBITED_STORE_EXPRESSION,
-                    RejectionCategory.PROHIBITED_LOGO_TEXT,
+                    RejectionCategory.CONTAINS_ADVERTISING,
                     RejectionCategory.CONTAINS_CONTACT_INFO,
                     RejectionCategory.CONTAINS_COMPETITOR_NAME,
                     RejectionCategory.DIRECT_INPUT
@@ -605,7 +606,7 @@ class BoardTest {
 
                 // when & then
                 assertThatThrownBy(() -> board.reject(
-                    RejectionCategory.INVALID_PRICE_CONDITION,
+                    RejectionCategory.OFFICIAL_MATERIAL_CONFUSION,
                     "두 번째 거절 시도"
                 ))
                     .isInstanceOf(BbangleException.class)

--- a/src/test/java/com/bbangle/bbangle/fixture/board/admin/controller/dto/AdminProductResponseFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/board/admin/controller/dto/AdminProductResponseFixture.java
@@ -11,6 +11,7 @@ public final class AdminProductResponseFixture {
     public static AdminProductResponse defaultResponse() {
         return new AdminProductResponse(
             1L,
+            1L,
             "스토어명",
             "상품명",
             10000,


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->

## 🚀 Major Changes & Explanations

* [feat] AdminProductResponse에 storeId 필드 추가
  - `GET /api/v1/admin/products` 응답에 storeId 포함

* [feat] UploadApprovalResponse에 storeId 필드 추가
  - `GET /api/v1/admin/products/upload-approvals` 응답에 storeId 포함

* [test] AdminBoardControllerTest, AdminProductResponseFixture storeId 반영

## 📷 Test Image

<!-- 스크린샷 첨부 -->

## 💡 ETC

<!-- 특이사항 없음 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 상품 응답과 상품 승인 응답에 스토어 ID 필드가 추가되었습니다.
* **변경**
  * 거절 사유(RejectionCategory) 목록 및 설명이 일부 갱신되어 분류와 문구가 변경되었습니다.
* **기타**
  * 관련 테스트 및 픽스처가 새 응답 형식(storeId)을 반영하도록 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->