### PR TITLE
[Feature] 반품 반려 거절 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/claim/domain/ReturnRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ReturnRequest.java
@@ -65,6 +65,15 @@ public class ReturnRequest extends Claim {
         super.decide();
     }
 
+    public void refuse(String refusalReason) {
+        if (status != REQUESTED && status != PICKUP_SCHEDULED) {
+            throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
+        }
+        this.status = REJECTED;
+        this.sellerComment = refusalReason;
+        super.decide();
+    }
+
     public void startReturnPickup() {
         this.status.validateTransition(ReturnRequestRequestStatus.PICKUP_SCHEDULED);
         this.status = ReturnRequestRequestStatus.PICKUP_SCHEDULED;

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerReturnController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerReturnController.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.claim.seller.controller;
 
 import com.bbangle.bbangle.claim.seller.controller.dto.RegisterReturnInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ReturnDecisionRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.ReturnRefuseRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.UpdateReturnInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.UpdateReturnInvoiceResponse;
 import com.bbangle.bbangle.claim.seller.controller.swagger.SellerReturnApi;
@@ -36,6 +37,16 @@ public class SellerReturnController implements SellerReturnApi {
     ) {
         sellerReturnService.decision(returnDecisionRequest.returnIds(), sellerId,
             returnDecisionRequest.decisionType(), returnDecisionRequest.reason());
+        return responseService.getSuccessResult();
+    }
+
+    @PostMapping("/{returnId}/refuse")
+    public CommonResult refuseReturn(
+        @PathVariable Long returnId,
+        @Valid @RequestBody ReturnRefuseRequest request,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        sellerReturnService.refuseReturn(returnId, sellerId, request.refusalReason());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ReturnRefuseRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ReturnRefuseRequest.java
@@ -1,0 +1,16 @@
+package com.bbangle.bbangle.claim.seller.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "반품 거절(반려) 요청 DTO")
+public record ReturnRefuseRequest(
+
+    @Schema(description = "거절 사유", example = "반품 불가 상품입니다.", maxLength = 500)
+    @NotBlank
+    @Size(max = 500)
+    String refusalReason
+
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerReturnApi.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerReturnApi.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.claim.seller.controller.swagger;
 
 import com.bbangle.bbangle.claim.seller.controller.dto.RegisterReturnInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ReturnDecisionRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.ReturnRefuseRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.UpdateReturnInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.UpdateReturnInvoiceResponse;
 import com.bbangle.bbangle.common.dto.CommonResult;
@@ -12,6 +13,17 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Return", description = "(셀러) 반품 관리 API")
 public interface SellerReturnApi {
+
+    @Operation(
+        summary = "반품 거절(반려)",
+        description = "REQUESTED(대기) 또는 PICKUP_SCHEDULED(수거 예약) 상태의 반품 요청을 거절한다. "
+            + "거절 사유(refusalReason)는 필수이며, ReturnRequest의 sellerComment 필드에 저장된다."
+    )
+    CommonResult refuseReturn(
+        @Parameter(description = "반품 요청 ID") Long returnId,
+        ReturnRefuseRequest request,
+        @Parameter(hidden = true) Long sellerId
+    );
 
     @Operation(
         summary = "반품 요청 승인/거절",

--- a/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerReturnService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerReturnService.java
@@ -171,6 +171,29 @@ public class SellerReturnService {
         return UpdateReturnInvoiceResponse.of(returnId, claimDelivery);
     }
 
+    @Transactional
+    public void refuseReturn(Long returnId, Long sellerId, String refusalReason) {
+        if (!claimRepository.existsClaimRequestBySeller(returnId, sellerId)) {
+            throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+        }
+
+        ReturnRequest returnRequest = findReturnRequestWithLock(returnId);
+        applyRefusal(returnRequest, refusalReason);
+    }
+
+    // 락 전략 전환이 필요할 경우 이 메서드만 교체하면 된다 (현재: 비관적 락).
+    private ReturnRequest findReturnRequestWithLock(Long returnId) {
+        return returnRequestRepository.findWithLockById(returnId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.CLAIM_NOT_FOUND));
+    }
+
+    private void applyRefusal(ReturnRequest returnRequest, String refusalReason) {
+        returnRequest.refuse(refusalReason);
+        OrderItem orderItem = returnRequest.getOrderItem();
+        orderItem.returnRefuse();
+        orderItemHistoryRepository.save(OrderItemHistory.create(orderItem));
+    }
+
     private Long getStoreIdOrThrow(Long sellerId) {
         Long storeId = sellerRepository.findStoreIdBySellerId(sellerId);
         if (storeId == null) {

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -158,6 +158,13 @@ public class OrderItem extends BaseEntity {
         this.orderStatus = OrderStatus.RETURN_REJECTED;
     }
 
+    public void returnRefuse() {
+        if (orderStatus != RETURN_REQUESTED && orderStatus != OrderStatus.RETURN_APPROVED) {
+            throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
+        }
+        this.orderStatus = OrderStatus.RETURN_REJECTED;
+    }
+
     public void cancelApprove() {
         if (orderStatus != CANCEL_REQUESTED) {
             throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerReturnServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerReturnServiceIntegrationTest.java
@@ -16,6 +16,7 @@ import com.bbangle.bbangle.fixture.order.OrderItemFixture;
 import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
 import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
 import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.seller.domain.Seller;
@@ -274,6 +275,237 @@ class SellerReturnServiceIntegrationTest {
             // when & then
             assertThatThrownBy(
                 () -> sut.decision(nonExistentIds, seller.getId(), DecisionType.APPROVE, "사유")
+            ).isInstanceOf(BbangleException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("refuseReturn() - 성공 시나리오")
+    class RefuseReturnSuccessTests {
+
+        @Test
+        @DisplayName("REQUESTED 상태의 반품을 거절하면 REJECTED로 변경되고 거절 사유와 히스토리가 저장된다")
+        void refuseReturn_fromRequested_success() {
+            // given
+            long historyCountBefore = orderItemHistoryRepository.count();
+
+            OrderItem orderItem = orderItemRepository.save(
+                OrderItemFixture.returnRequestedWithProduct(product)
+            );
+            ReturnRequest returnRequest = returnRequestRepository.save(
+                ReturnRequestFixture.requested(orderItem)
+            );
+
+            Long returnId = returnRequest.getId();
+            Long orderItemId = orderItem.getId();
+            String refusalReason = "사용 흔적이 있는 상품입니다.";
+
+            em.flush();
+            em.clear();
+
+            // when
+            sut.refuseReturn(returnId, seller.getId(), refusalReason);
+
+            // then
+            em.flush();
+            em.clear();
+
+            ReturnRequest refused = returnRequestRepository.findById(returnId).orElseThrow();
+            assertThat(refused.getStatus()).isEqualTo(ReturnRequestRequestStatus.REJECTED);
+            assertThat(refused.getSellerComment()).isEqualTo(refusalReason);
+
+            OrderItem refusedItem = orderItemRepository.findById(orderItemId).orElseThrow();
+            assertThat(refusedItem.getOrderStatus()).isEqualTo(OrderStatus.RETURN_REJECTED);
+
+            assertThat(orderItemHistoryRepository.count()).isEqualTo(historyCountBefore + 1);
+        }
+
+        @Test
+        @DisplayName("PICKUP_SCHEDULED 상태의 반품을 거절하면 REJECTED로 변경되고 히스토리가 저장된다")
+        void refuseReturn_fromPickupScheduled_success() {
+            // given
+            long historyCountBefore = orderItemHistoryRepository.count();
+
+            OrderItem orderItem = orderItemRepository.save(
+                OrderItemFixture.returnApprovedWithProduct(product)
+            );
+            ReturnRequest returnRequest = returnRequestRepository.save(
+                ReturnRequestFixture.pickupScheduled(orderItem)
+            );
+
+            Long returnId = returnRequest.getId();
+            Long orderItemId = orderItem.getId();
+            String refusalReason = "수거 중 파손이 확인되어 반품 불가합니다.";
+
+            em.flush();
+            em.clear();
+
+            // when
+            sut.refuseReturn(returnId, seller.getId(), refusalReason);
+
+            // then
+            em.flush();
+            em.clear();
+
+            ReturnRequest refused = returnRequestRepository.findById(returnId).orElseThrow();
+            assertThat(refused.getStatus()).isEqualTo(ReturnRequestRequestStatus.REJECTED);
+            assertThat(refused.getSellerComment()).isEqualTo(refusalReason);
+
+            OrderItem refusedItem = orderItemRepository.findById(orderItemId).orElseThrow();
+            assertThat(refusedItem.getOrderStatus()).isEqualTo(OrderStatus.RETURN_REJECTED);
+
+            assertThat(orderItemHistoryRepository.count()).isEqualTo(historyCountBefore + 1);
+        }
+    }
+
+    @Nested
+    @DisplayName("refuseReturn() - 실패 시나리오")
+    class RefuseReturnFailureTests {
+
+        @Test
+        @DisplayName("다른 판매자의 반품은 거절할 수 없다")
+        void refuseReturn_fails_when_seller_mismatch() {
+            // given
+            Store otherStore = storeRepository.save(StoreFixture.defaultStore());
+            Seller otherSeller = sellerRepository.save(SellerFixture.defaultSeller(otherStore));
+
+            OrderItem orderItem = orderItemRepository.save(
+                OrderItemFixture.returnRequestedWithProduct(product)
+            );
+            ReturnRequest returnRequest = returnRequestRepository.save(
+                ReturnRequestFixture.requested(orderItem)
+            );
+
+            Long returnId = returnRequest.getId();
+
+            em.flush();
+            em.clear();
+
+            // when & then
+            assertThatThrownBy(
+                () -> sut.refuseReturn(returnId, otherSeller.getId(), "거절 사유")
+            ).isInstanceOf(BbangleException.class);
+
+            // 상태가 변경되지 않았는지 확인
+            ReturnRequest unchanged = returnRequestRepository.findById(returnId).orElseThrow();
+            assertThat(unchanged.getStatus()).isEqualTo(ReturnRequestRequestStatus.REQUESTED);
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태의 반품을 거절하려 하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void refuseReturn_fails_when_already_completed() {
+            // given
+            OrderItem orderItem = orderItemRepository.save(
+                OrderItemFixture.returnApprovedWithProduct(product)
+            );
+            ReturnRequest returnRequest = returnRequestRepository.save(
+                ReturnRequestFixture.completed(orderItem)
+            );
+
+            Long returnId = returnRequest.getId();
+
+            em.flush();
+            em.clear();
+
+            // when & then
+            assertThatThrownBy(
+                () -> sut.refuseReturn(returnId, seller.getId(), "거절 사유")
+            ).isInstanceOf(BbangleException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("processReturn() - 성공 시나리오")
+    class ProcessReturnSuccessTests {
+
+        @Test
+        @DisplayName("INSPECTION_APPROVED 상태의 반품을 처리하면 COMPLETED로 변경되고 히스토리가 저장된다")
+        void processReturn_success() {
+            // given
+            long historyCountBefore = orderItemHistoryRepository.count();
+
+            OrderItem orderItem = orderItemRepository.save(
+                OrderItemFixture.returnApprovedWithProduct(product)
+            );
+            ReturnRequest returnRequest = returnRequestRepository.save(
+                ReturnRequestFixture.inspectionApproved(orderItem)
+            );
+
+            Long returnId = returnRequest.getId();
+            Long orderItemId = orderItem.getId();
+
+            em.flush();
+            em.clear();
+
+            // when
+            sut.processReturn(returnId, seller.getId());
+
+            // then
+            em.flush();
+            em.clear();
+
+            ReturnRequest completed = returnRequestRepository.findById(returnId).orElseThrow();
+            assertThat(completed.getStatus()).isEqualTo(ReturnRequestRequestStatus.COMPLETED);
+
+            OrderItem completedItem = orderItemRepository.findById(orderItemId).orElseThrow();
+            assertThat(completedItem.getOrderStatus()).isEqualTo(OrderStatus.RETURN_COMPLETED);
+
+            assertThat(orderItemHistoryRepository.count()).isEqualTo(historyCountBefore + 1);
+        }
+    }
+
+    @Nested
+    @DisplayName("processReturn() - 실패 시나리오")
+    class ProcessReturnFailureTests {
+
+        @Test
+        @DisplayName("다른 판매자의 반품은 처리할 수 없다")
+        void processReturn_fails_when_seller_mismatch() {
+            // given
+            Store otherStore = storeRepository.save(StoreFixture.defaultStore());
+            Seller otherSeller = sellerRepository.save(SellerFixture.defaultSeller(otherStore));
+
+            OrderItem orderItem = orderItemRepository.save(
+                OrderItemFixture.returnApprovedWithProduct(product)
+            );
+            ReturnRequest returnRequest = returnRequestRepository.save(
+                ReturnRequestFixture.inspectionApproved(orderItem)
+            );
+
+            Long returnId = returnRequest.getId();
+
+            em.flush();
+            em.clear();
+
+            // when & then
+            assertThatThrownBy(
+                () -> sut.processReturn(returnId, otherSeller.getId())
+            ).isInstanceOf(BbangleException.class);
+
+            // 상태가 변경되지 않았는지 확인
+            ReturnRequest unchanged = returnRequestRepository.findById(returnId).orElseThrow();
+            assertThat(unchanged.getStatus()).isEqualTo(ReturnRequestRequestStatus.INSPECTION_APPROVED);
+        }
+
+        @Test
+        @DisplayName("REQUESTED 상태의 반품을 최종 처리하려 하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void processReturn_fails_when_invalid_status() {
+            // given
+            OrderItem orderItem = orderItemRepository.save(
+                OrderItemFixture.returnRequestedWithProduct(product)
+            );
+            ReturnRequest returnRequest = returnRequestRepository.save(
+                ReturnRequestFixture.requested(orderItem)
+            );
+
+            Long returnId = returnRequest.getId();
+
+            em.flush();
+            em.clear();
+
+            // when & then
+            assertThatThrownBy(
+                () -> sut.processReturn(returnId, seller.getId())
             ).isInstanceOf(BbangleException.class);
         }
     }

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerReturnServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerReturnServiceUnitTest.java
@@ -21,6 +21,7 @@ import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.claim.ReturnRequestFixture;
 import com.bbangle.bbangle.fixture.order.OrderItemFixture;
 import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.OrderItemHistory;
 import com.bbangle.bbangle.order.domain.model.CourierCompany;
 import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
@@ -259,6 +260,210 @@ class SellerReturnServiceUnitTest {
             assertThatThrownBy(
                 () -> sut.decision(returnIds, sellerId, DecisionType.APPROVE, reason)
             ).isInstanceOf(BbangleException.class);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("refuseReturn()")
+    class RefuseReturnTests {
+
+        private static final Long RETURN_ID = 1L;
+        private static final Long SELLER_ID = 10L;
+        private static final String REFUSAL_REASON = "반품 불가 상품입니다.";
+
+        @Test
+        @DisplayName("REQUESTED 상태의 반품을 거절하면 상태가 REJECTED로 변경되고 거절 사유와 히스토리가 저장된다")
+        void refuseReturn_fromRequested_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderReturnRequested();
+            ReturnRequest returnRequest = ReturnRequestFixture.requested(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when
+            sut.refuseReturn(RETURN_ID, SELLER_ID, REFUSAL_REASON);
+
+            // then
+            assertThat(returnRequest.getStatus()).isEqualTo(ReturnRequestRequestStatus.REJECTED);
+            assertThat(returnRequest.getSellerComment()).isEqualTo(REFUSAL_REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.RETURN_REJECTED);
+            then(returnRequestRepository).should(times(1)).findWithLockById(RETURN_ID);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("PICKUP_SCHEDULED 상태의 반품을 거절하면 상태가 REJECTED로 변경되고 히스토리가 저장된다")
+        void refuseReturn_fromPickupScheduled_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_APPROVED);
+            ReturnRequest returnRequest = ReturnRequestFixture.pickupScheduled(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when
+            sut.refuseReturn(RETURN_ID, SELLER_ID, REFUSAL_REASON);
+
+            // then
+            assertThat(returnRequest.getStatus()).isEqualTo(ReturnRequestRequestStatus.REJECTED);
+            assertThat(returnRequest.getSellerComment()).isEqualTo(REFUSAL_REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.RETURN_REJECTED);
+            then(returnRequestRepository).should(times(1)).findWithLockById(RETURN_ID);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("셀러 소유권 검증 실패 시 SELLER_CLAIM_MISMATCH 예외가 발생하고 이후 로직은 실행되지 않는다")
+        void refuseReturn_fails_when_seller_mismatch() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> sut.refuseReturn(RETURN_ID, SELLER_ID, REFUSAL_REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+
+            then(returnRequestRepository).should(never()).findWithLockById(any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 returnId로 요청하면 CLAIM_NOT_FOUND 예외가 발생한다")
+        void refuseReturn_fails_when_claim_not_found() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sut.refuseReturn(RETURN_ID, SELLER_ID, REFUSAL_REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_NOT_FOUND);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태의 반품을 거절하려 하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void refuseReturn_fails_when_already_completed() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_COMPLETED);
+            ReturnRequest returnRequest = ReturnRequestFixture.withStatus(
+                ReturnRequestRequestStatus.COMPLETED, orderItem
+            );
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.refuseReturn(RETURN_ID, SELLER_ID, REFUSAL_REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("이미 REJECTED 상태인 반품을 다시 거절하려 하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void refuseReturn_fails_when_already_rejected() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_REJECTED);
+            ReturnRequest returnRequest = ReturnRequestFixture.rejected(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.refuseReturn(RETURN_ID, SELLER_ID, REFUSAL_REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("processReturn()")
+    class ProcessReturnTests {
+
+        private static final Long RETURN_ID = 1L;
+        private static final Long SELLER_ID = 10L;
+
+        @Test
+        @DisplayName("INSPECTION_APPROVED 상태의 반품을 처리하면 COMPLETED로 변경되고 OrderItem이 RETURN_COMPLETED가 된다")
+        void processReturn_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_APPROVED);
+            ReturnRequest returnRequest = ReturnRequestFixture.withStatus(
+                ReturnRequestRequestStatus.INSPECTION_APPROVED, orderItem
+            );
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when
+            sut.processReturn(RETURN_ID, SELLER_ID);
+
+            // then
+            assertThat(returnRequest.getStatus()).isEqualTo(ReturnRequestRequestStatus.COMPLETED);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.RETURN_COMPLETED);
+            then(returnRequestRepository).should(times(1)).findWithLockById(RETURN_ID);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("셀러 소유권 검증 실패 시 SELLER_CLAIM_MISMATCH 예외가 발생하고 이후 로직은 실행되지 않는다")
+        void processReturn_fails_when_seller_mismatch() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> sut.processReturn(RETURN_ID, SELLER_ID))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+
+            then(returnRequestRepository).should(never()).findWithLockById(any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 returnId로 요청하면 CLAIM_NOT_FOUND 예외가 발생한다")
+        void processReturn_fails_when_claim_not_found() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sut.processReturn(RETURN_ID, SELLER_ID))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_NOT_FOUND);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("REQUESTED 상태의 반품을 최종 처리하려 하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void processReturn_fails_when_invalid_status() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderReturnRequested();
+            ReturnRequest returnRequest = ReturnRequestFixture.requested(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.processReturn(RETURN_ID, SELLER_ID))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
 
             then(orderItemHistoryRepository).should(never()).save(any());
         }

--- a/src/test/java/com/bbangle/bbangle/fixture/claim/ReturnRequestFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/claim/ReturnRequestFixture.java
@@ -36,6 +36,14 @@ public class ReturnRequestFixture {
         return withStatus(ReturnRequestRequestStatus.PICKUP_SCHEDULED, orderItem);
     }
 
+    public static ReturnRequest inspectionApproved(OrderItem orderItem) {
+        return withStatus(ReturnRequestRequestStatus.INSPECTION_APPROVED, orderItem);
+    }
+
+    public static ReturnRequest completed(OrderItem orderItem) {
+        return withStatus(ReturnRequestRequestStatus.COMPLETED, orderItem);
+    }
+
     public static ReturnRequest withId(ReturnRequest rr, Long id) {
         ReflectionTestUtils.setField(rr, "id", id); // Claim의 id 필드
         return rr;

--- a/src/test/java/com/bbangle/bbangle/fixture/order/OrderItemFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/order/OrderItemFixture.java
@@ -42,6 +42,17 @@ public class OrderItemFixture {
             .build();
     }
 
+    public static OrderItem returnApprovedWithProduct(Product product) {
+        return OrderItem.builder()
+            .product(product)
+            .quantity(1)
+            .productPrice(10000)
+            .unitPrice(10000)
+            .totalPrice(10000)
+            .orderStatus(OrderStatus.RETURN_APPROVED)
+            .build();
+    }
+
     public static OrderItem paymentCompleted() {
         return orderItemWithStatus(OrderStatus.PAYMENT_COMPLETED);
     }


### PR DESCRIPTION
## History
- 리뷰어 : 경민님, 종수님
- 연관된 이슈 : #515 

## 🚀 Major Changes & Explanations
- 반품 거절 (POST /api/v1/seller/returns/{returnId}/refuse)
- 판매자 사유를 입력받아 반품 요청을 REFUSED 상태로 변경
- 상태 전이가 일어날 때마다 OrderItemHistory 테이블에 기록
- 이를 통해 CS 발생 시 관리자가 데이터 변경 이력을 명확히 추적할 수 있도록 설계
- 비관적 락(Pessimistic Lock) 적용: 환불 및 재고와 직결된 로직의 원자성을 보장하기 위해 findWithLockById를 사용하여 상태 경합을 방지
- 권한 검증: 요청 판매자와 클레임 소유자 일치 여부를 검증하는 로직을 추가
- Service Unit Test: 성공 시나리오(상태 전이 확인) 및 실패 시나리오(권한 미일치, 잘못된 상태에서의 요청)를 모두 검증
- History 연동 검증: 상태 변경 시 이력 저장 Repository가 의도한 파라미터로 호출되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 판매자 반품 거절 기능 추가 - 요청 또는 픽업 예정 상태의 반품을 거절할 수 있으며, 거절 사유 기록 가능

* **테스트**
  * 반품 거절 워크플로우 단위 및 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->