### PR TITLE
[Fix] 셀러 서류 업로드 시 PDF 파일 형식 오류 수정

### DIFF
--- a/src/main/java/com/bbangle/bbangle/image/customer/service/S3Service.java
+++ b/src/main/java/com/bbangle/bbangle/image/customer/service/S3Service.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.image.customer.service;
 import static com.bbangle.bbangle.image.customer.validation.ImageValidator.validateImage;
 
 import com.amazonaws.services.s3.AmazonS3;
+import io.jsonwebtoken.lang.Assert;
 import com.amazonaws.services.s3.model.AccessControlList;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
@@ -54,6 +55,38 @@ public class S3Service {
         log.debug("Show image path: {}", imagePath);
         imagePath = removeBucketDomainInFolder(imagePath);
         return addCdnDomain(imagePath);
+    }
+
+    public String saveDocumentAndReturnWithCdn(String folderName, MultipartFile file) {
+        String filePath = saveDocument(file, folderName);
+        log.debug("Show document path: {}", filePath);
+        filePath = removeBucketDomainInFolder(filePath);
+        return addCdnDomain(filePath);
+    }
+
+    public String saveDocument(MultipartFile file, String folder) {
+        Assert.notNull(file, "비어있는 파일은 업로드 할 수 없습니다.");
+        Assert.isTrue(!file.isEmpty(), "비어있는 파일은 업로드 할 수 없습니다.");
+        Assert.isTrue(file.getSize() < 10_000_000, "파일이 허용된 최대 크기를 초과했습니다.");
+
+        final String originName = file.getOriginalFilename();
+        Assert.notNull(originName, "파일명이 없습니다.");
+        final String ext = originName.substring(originName.lastIndexOf("."));
+        final String changedFileName = folder + "/" + UUID.randomUUID() + ext;
+
+        final ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
+
+        try {
+            amazonS3.putObject(new PutObjectRequest(
+                bucket, changedFileName, file.getInputStream(), metadata)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (final IOException e) {
+            throw new BbangleException("저장하기 유효하지 않은 파일입니다.", e);
+        }
+
+        return amazonS3.getUrl(bucket, changedFileName).toString();
     }
 
     public List<String> saveMultipleAndReturnWithCdn(String folderName, List<MultipartFile> images) {

--- a/src/main/java/com/bbangle/bbangle/seller/seller/facade/SellerFacade.java
+++ b/src/main/java/com/bbangle/bbangle/seller/seller/facade/SellerFacade.java
@@ -45,7 +45,7 @@ public class SellerFacade {
         List<UploadedDocument> uploadedDocuments = new ArrayList<>();
         try {
             for (DocumentUploadInfo doc : documents) {
-                String filePath = s3Service.saveAndReturnWithCdn(SELLER_DOCUMENT_FOLDER, doc.file());
+                String filePath = s3Service.saveDocumentAndReturnWithCdn(SELLER_DOCUMENT_FOLDER, doc.file());
                 String fileName = doc.file().getOriginalFilename();
                 uploadedDocuments.add(new UploadedDocument(doc.type(), filePath, fileName));
             }

--- a/src/test/java/com/bbangle/bbangle/image/customer/service/S3ServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/image/customer/service/S3ServiceUnitTest.java
@@ -117,6 +117,43 @@ class S3ServiceUnitTest {
     }
 
     @Test
+    @DisplayName("PDF 문서를 S3에 업로드하고 CDN 도메인이 포함된 URL을 반환한다")
+    void saveDocumentAndReturnWithCdn_uploadsPdfAndReturnsCdnUrl() throws IOException {
+        // given
+        String folderName = "seller-documents";
+        byte[] content = "test pdf content".getBytes();
+        MultipartFile mockMultipartFile = new MockMultipartFile(
+            "document",
+            "business-license.pdf",
+            "application/pdf",
+            new ByteArrayInputStream(content)
+        );
+
+        when(amazonS3.putObject(any(PutObjectRequest.class))).thenReturn(mock(PutObjectResult.class));
+        when(amazonS3.getUrl(any(String.class), any(String.class)))
+            .thenAnswer(invocation -> {
+                String key = invocation.getArgument(1);
+                return new URL(BUCKET_DOMAIN + key);
+            });
+
+        // when
+        String resultUrl = s3Service.saveDocumentAndReturnWithCdn(folderName, mockMultipartFile);
+
+        // then
+        ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(amazonS3).putObject(captor.capture());
+        PutObjectRequest capturedRequest = captor.getValue();
+
+        assertThat(capturedRequest.getBucketName()).isEqualTo(BUCKET_NAME);
+        assertThat(capturedRequest.getKey()).startsWith(folderName + "/");
+        assertThat(capturedRequest.getKey()).endsWith(".pdf");
+        assertThat(capturedRequest.getMetadata().getContentType()).isEqualTo("application/pdf");
+        assertThat(resultUrl).startsWith(CDN_DOMAIN + folderName + "/");
+        assertThat(resultUrl).endsWith(".pdf");
+        assertThat(resultUrl).doesNotContain(BUCKET_DOMAIN);
+    }
+
+    @Test
     @DisplayName("유효하지 않은 이미지 파일인 경우 예외를 발생시킨다")
     void saveAndReturnWithCdn_throwsExceptionForInvalidImage() throws IOException {
         // given


### PR DESCRIPTION
 ## History                                                                                                                                                                
                                                                                                                                                                            
  없음                                                                                                                                                                      
                                                            
  ## 🚀 Major Changes & Explanations                                                                                                                                        
   
  셀러 서류 등록(`POST /api/v1/seller/sellers/documents`) 시 PDF 파일 업로드가 불가능한 버그 수정                                                                           
                                                            
  **원인**                                                                                                                                                                  
  `S3Service.saveAndReturnWithCdn()`이 내부적으로 `ImageValidator.validateImage()`를 호출하여
  `contentType.startsWith("image")` 조건만 허용 → PDF(`application/pdf`)는 무조건 튕김                                                                                      
                                                                                                                                                                            
  **변경 내용**                                                                                                                                                             
  - `S3Service`: 문서 전용 업로드 메서드 `saveDocument()` / `saveDocumentAndReturnWithCdn()` 추가                                                                           
    - PDF ContentType 그대로 유지하여 S3 업로드                                                                                                                             
  - `SellerFacade`: 서류 업로드 시 `saveDocumentAndReturnWithCdn()` 사용하도록 교체                                                                                         
  - `S3ServiceUnitTest`: PDF 업로드 성공 케이스 테스트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 문서 업로드 기능이 추가되었습니다. 파일을 클라우드 스토리지에 저장하고 접근 가능한 URL을 반환합니다.

* **테스트**
  * 문서 업로드 기능에 대한 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->