### PR TITLE
[Refactor] 셀러 주문 검색 중복 집계 방지 및 검색 조건 유효성 검증 강화

### DIFF
--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepositoryImpl.java
@@ -77,8 +77,11 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
             ? command.searchCondition().getKeyword()
             : null;
 
+        // select/get에 동일 인스턴스를 사용해 Tuple 매핑이 올바르게 동작하도록 보장
+        var countExpr = orderItem.id.countDistinct();
+
         JPAQuery<Tuple> countQuery = queryFactory
-            .select(orderItem.orderStatus, orderItem.count())
+            .select(orderItem.orderStatus, countExpr)
             .from(order)
             .leftJoin(order.seller, seller)
             .leftJoin(order.orderItems, orderItem);
@@ -87,6 +90,7 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
 
         // 상태별 카운트는 orderDeliveryStatus 필터 없이 전체 집계합니다.
         // 목록 쿼리(searchOrderList)와 달리 탭별 전체 건수를 보여줘야 하므로 의도적으로 다릅니다.
+        // countDistinct: TRACKING_NUMBER 검색 시 orderDelivery join으로 같은 orderItem이 중복 집계되는 것을 방지합니다.
         List<Tuple> results = countQuery
             .where(
                 seller.id.eq(command.sellerId()),
@@ -100,7 +104,7 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
         Map<OrderStatus, Long> countMap = new EnumMap<>(OrderStatus.class);
         for (Tuple tuple : results) {
             OrderStatus status = tuple.get(orderItem.orderStatus);
-            Long count = tuple.get(orderItem.count());
+            Long count = tuple.get(countExpr);
             if (status != null && count != null) {
                 countMap.put(status, count);
             }
@@ -124,8 +128,11 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
         CompletedOrderSearchType searchType = command.searchType();
         String keyword = command.searchValue();
 
+        // select/get에 동일 인스턴스를 사용해 Tuple 매핑이 올바르게 동작하도록 보장
+        var countExpr = orderItem.id.countDistinct();
+
         JPAQuery<Tuple> countQuery = queryFactory
-            .select(orderItem.orderStatus, orderItem.count())
+            .select(orderItem.orderStatus, countExpr)
             .from(order)
             .leftJoin(order.seller, seller)
             .leftJoin(order.orderItems, orderItem);
@@ -147,7 +154,7 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
         Map<OrderStatus, Long> countMap = new EnumMap<>(OrderStatus.class);
         for (Tuple tuple : results) {
             OrderStatus status = tuple.get(orderItem.orderStatus);
-            Long count = tuple.get(orderItem.count());
+            Long count = tuple.get(countExpr);
             if (status != null && count != null) {
                 countMap.put(status, count);
             }
@@ -161,6 +168,7 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
 
         JPAQuery<Long> idQuery = queryFactory
             .select(order.id)
+            .distinct()
             .from(order)
             .leftJoin(order.seller, seller)
             .leftJoin(order.orderItems, orderItem);
@@ -227,6 +235,7 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
 
         JPAQuery<Long> idQuery = queryFactory
             .select(order.id)
+            .distinct()
             .from(order)
             .leftJoin(order.seller, seller)
             .leftJoin(order.orderItems, orderItem);
@@ -279,7 +288,9 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
         Map<Long, Order> orderMap = orders.stream()
             .collect(Collectors.toMap(Order::getId, Function.identity()));
 
+        // distinct()로 중복 제거 후 복원 — fetchOrderIds가 distinct 보장하지만 방어적으로 중복 제거
         return orderIds.stream()
+            .distinct()
             .map(orderMap::get)
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
@@ -350,6 +361,10 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
         if (keyword == null || keyword.isBlank()) {
             return null;
         }
+        // searchType이 null이면 keyword가 있어도 조건 없이 전체 조회
+        if (searchType == null) {
+            return null;
+        }
 
         // 검색 타입별로 서로 다른 컬럼에 LIKE 검색 적용 (대소문자 무관)
         return switch (searchType) {
@@ -365,15 +380,17 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
     }
 
     private LocalDateTime extractStartDate(OrderSearchCommand command) {
-        return command.searchCondition() != null
-            ? command.searchCondition().getStartDate().atStartOfDay()
-            : null;
+        if (command.searchCondition() == null || command.searchCondition().getStartDate() == null) {
+            return null;
+        }
+        return command.searchCondition().getStartDate().atStartOfDay();
     }
 
     private LocalDateTime extractEndDate(OrderSearchCommand command) {
-        return command.searchCondition() != null
-            ? command.searchCondition().getEndDate().atTime(23, 59, 59)
-            : null;
+        if (command.searchCondition() == null || command.searchCondition().getEndDate() == null) {
+            return null;
+        }
+        return command.searchCondition().getEndDate().atTime(23, 59, 59);
     }
 
     // LocalDate → 해당 날짜 00:00:00 LocalDateTime 변환 (null-safe)

--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/SellerOrderController.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/SellerOrderController.java
@@ -89,7 +89,7 @@ public class SellerOrderController implements SellerOrderApi {
     @PostMapping("/list")
     public SingleResult<OrderSearchPageResponse> searchOrders(
         @AuthenticationPrincipal Long sellerId,
-        @RequestBody OrderSearchRequest request,
+        @Valid @RequestBody OrderSearchRequest request,
         @PageableDefault(size = 100, sort = "orderDate", direction = Sort.Direction.DESC) Pageable pageable) {
 
         OrderSearchPageResponse response = sellerOrderService.orderSearch(

--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/request/OrderRequest.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/dto/request/OrderRequest.java
@@ -6,6 +6,8 @@ import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderSearchCommand;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -26,6 +28,8 @@ public class OrderRequest {
         @Schema(description = "검색 상세조건")
         private CompletedOrderSearchType searchType;
 
+        @NotNull
+        @Valid
         @JsonUnwrapped
         @Schema(hidden = true, description = "기본 검색 조건")
         private SearchFormDto.DefaultSearchCondition defaultSearchCondition;


### PR DESCRIPTION
## History
<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations

### 중복 집계 방지 (OrderDSLRepositoryImpl)
- `orderItem.count()` → `orderItem.id.countDistinct()`로 교체
  - TRACKING_NUMBER 검색 시 `orderDelivery` 조인으로 인해 동일 `orderItem`이 여러 번 카운트되는 버그 수정
  - select/get에 동일 `countExpr` 인스턴스를 사용해 Tuple 매핑 안정성 확보
- 주문 목록 ID 조회 쿼리에 `.distinct()` 추가
  - `orderDelivery` 조인 시 같은 `order.id`가 중복 조회되는 현상 방지
- `fetchOrderByIds` 내 스트림 처리에도 `.distinct()` 추가 (방어적 중복 제거)

### 검색 조건 null 안전성 강화
- `searchType`이 null이고 keyword가 있는 경우 의도치 않게 전체 조회되던 문제 수정 → null 반환 처리
- `extractStartDate` / `extractEndDate` 메서드에서 `searchCondition`뿐 아니라 날짜 필드 자체가 null인 경우도 안전하게 처리하도록 개선

### 요청 유효성 검증 강화
- `SellerOrderController.searchOrders()`에 `@Valid` 어노테이션 추가
- `OrderRequest.CompletedOrderSearchRequest.defaultSearchCondition` 필드에 `@NotNull`, `@Valid` 추가
  - 기본 검색 조건 누락 시 400 Bad Request 응답 보장

## 📷 Test Image
<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC
<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 주문 상태별 카운팅 결과의 정확성 개선
  * 주문 ID 조회 시 중복 데이터 제거
  * 날짜 필터링의 null 안정성 강화

* **기능 개선**
  * 주문 검색 요청에 대한 입력 유효성 검사 강화
  * 필수 필드 검증 및 중첩 유효성 검사 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->