### PR TITLE
[Feat] 외부 유입 링크 추적 기능 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -190,7 +190,10 @@ public enum BbangleErrorCode {
 
     // Statistics Error(811~820)
     INVALID_STATISTICS_PERIOD(-811, "유효하지 않은 통계 기간입니다.", BAD_REQUEST),
-    INVALID_DATE_RANGE(-812, "유효하지 않은 날짜 범위입니다.", BAD_REQUEST);
+    INVALID_DATE_RANGE(-812, "유효하지 않은 날짜 범위입니다.", BAD_REQUEST),
+
+    // LinkTracking Error(831 ~ 840)
+    TRACKING_LINK_NOT_FOUND(-831, "존재하지 않는 추적 링크입니다.", NOT_FOUND);
 
     private final int code;
     private final String message;

--- a/src/main/java/com/bbangle/bbangle/linktracking/customer/controller/LinkTrackingController.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/customer/controller/LinkTrackingController.java
@@ -1,12 +1,10 @@
 package com.bbangle.bbangle.linktracking.customer.controller;
 
-import com.bbangle.bbangle.linktracking.customer.service.command.LinkTrackingCommand;
-import com.bbangle.bbangle.linktracking.customer.facade.LinkTrackingFacade;
 import com.bbangle.bbangle.linktracking.customer.controller.mapper.LinkTrackingCommandMapper;
+import com.bbangle.bbangle.linktracking.customer.controller.swagger.LinkTrackingApi;
+import com.bbangle.bbangle.linktracking.customer.facade.LinkTrackingFacade;
+import com.bbangle.bbangle.linktracking.customer.service.command.LinkTrackingCommand;
 import com.bbangle.bbangle.linktracking.domain.LinkChannel;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -17,19 +15,16 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "LinkTracking", description = "외부 유입 링크 추적")
 @RestController
 @RequestMapping("/api/v1/link")
 @RequiredArgsConstructor
-public class LinkTrackingController {
+public class LinkTrackingController implements LinkTrackingApi {
 
     private final LinkTrackingFacade linkTrackingFacade;
     private final LinkTrackingCommandMapper linkTrackingCommandMapper;
 
-    @Operation(summary = "추적 링크 리다이렉트", description = "조회수를 기록한 뒤 실제 목적지로 302 리다이렉트")
     @GetMapping("/{channel}")
     public ResponseEntity<Void> redirect(
-        @Parameter(description = "유입 채널", example = "INSTAGRAM")
         @PathVariable("channel") LinkChannel channel,
         HttpServletRequest request
     ) {

--- a/src/main/java/com/bbangle/bbangle/linktracking/customer/controller/LinkTrackingController.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/customer/controller/LinkTrackingController.java
@@ -1,0 +1,44 @@
+package com.bbangle.bbangle.linktracking.customer.controller;
+
+import com.bbangle.bbangle.linktracking.customer.service.command.LinkTrackingCommand;
+import com.bbangle.bbangle.linktracking.customer.facade.LinkTrackingFacade;
+import com.bbangle.bbangle.linktracking.customer.controller.mapper.LinkTrackingCommandMapper;
+import com.bbangle.bbangle.linktracking.domain.LinkChannel;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "LinkTracking", description = "외부 유입 링크 추적")
+@RestController
+@RequestMapping("/api/v1/link")
+@RequiredArgsConstructor
+public class LinkTrackingController {
+
+    private final LinkTrackingFacade linkTrackingFacade;
+    private final LinkTrackingCommandMapper linkTrackingCommandMapper;
+
+    @Operation(summary = "추적 링크 리다이렉트", description = "조회수를 기록한 뒤 실제 목적지로 302 리다이렉트")
+    @GetMapping("/{channel}")
+    public ResponseEntity<Void> redirect(
+        @Parameter(description = "유입 채널", example = "INSTAGRAM")
+        @PathVariable("channel") LinkChannel channel,
+        HttpServletRequest request
+    ) {
+        LinkTrackingCommand.Visit command = linkTrackingCommandMapper.toVisit(channel, request);
+        String destinationUrl = linkTrackingFacade.resolveAndRecordVisit(command);
+
+        return ResponseEntity
+            .status(HttpStatus.FOUND)
+            .location(URI.create(destinationUrl))
+            .build();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/customer/controller/mapper/LinkTrackingCommandMapper.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/customer/controller/mapper/LinkTrackingCommandMapper.java
@@ -1,0 +1,44 @@
+package com.bbangle.bbangle.linktracking.customer.controller.mapper;
+
+import com.bbangle.bbangle.linktracking.customer.service.command.LinkTrackingCommand;
+import com.bbangle.bbangle.linktracking.domain.LinkChannel;
+import com.bbangle.bbangle.util.VisitorFingerprintUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.ReportingPolicy;
+import org.springframework.validation.annotation.Validated;
+
+@Mapper(
+    componentModel = "spring",
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+    unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+@Validated
+public interface LinkTrackingCommandMapper {
+
+    @Valid
+    @Mapping(target = "channel", source = "channel")
+    @Mapping(target = "ipAddress", source = "request", qualifiedByName = "extractIp")
+    @Mapping(target = "userAgent", source = "request", qualifiedByName = "extractUserAgent")
+    @Mapping(target = "referer", source = "request", qualifiedByName = "extractReferer")
+    LinkTrackingCommand.Visit toVisit(LinkChannel channel, HttpServletRequest request);
+
+    @Named("extractIp")
+    default String extractIp(HttpServletRequest request) {
+        return VisitorFingerprintUtils.extractIp(request);
+    }
+
+    @Named("extractUserAgent")
+    default String extractUserAgent(HttpServletRequest request) {
+        return request.getHeader("User-Agent");
+    }
+
+    @Named("extractReferer")
+    default String extractReferer(HttpServletRequest request) {
+        return request.getHeader("Referer");
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/customer/controller/swagger/LinkTrackingApi.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/customer/controller/swagger/LinkTrackingApi.java
@@ -1,0 +1,21 @@
+package com.bbangle.bbangle.linktracking.customer.controller.swagger;
+
+import com.bbangle.bbangle.linktracking.domain.LinkChannel;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "LinkTracking", description = "외부 유입 링크 추적")
+public interface LinkTrackingApi {
+
+    @Operation(
+        summary = "추적 링크 리다이렉트",
+        description = "조회수를 기록한 뒤 실제 목적지로 302 리다이렉트"
+    )
+    ResponseEntity<Void> redirect(
+        @Parameter(description = "유입 채널", example = "INSTAGRAM") LinkChannel channel,
+        @Parameter(hidden = true) HttpServletRequest request
+    );
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/customer/facade/LinkTrackingFacade.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/customer/facade/LinkTrackingFacade.java
@@ -1,0 +1,17 @@
+package com.bbangle.bbangle.linktracking.customer.facade;
+
+import com.bbangle.bbangle.linktracking.customer.service.command.LinkTrackingCommand;
+import com.bbangle.bbangle.linktracking.customer.service.LinkTrackingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LinkTrackingFacade {
+
+    private final LinkTrackingService linkTrackingService;
+
+    public String resolveAndRecordVisit(LinkTrackingCommand.Visit command) {
+        return linkTrackingService.resolveAndRecordVisit(command);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/customer/service/LinkTrackingService.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/customer/service/LinkTrackingService.java
@@ -1,0 +1,51 @@
+package com.bbangle.bbangle.linktracking.customer.service;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.linktracking.customer.service.command.LinkTrackingCommand;
+import com.bbangle.bbangle.linktracking.domain.LinkVisit;
+import com.bbangle.bbangle.linktracking.domain.TrackingLink;
+import com.bbangle.bbangle.linktracking.repository.LinkVisitRepository;
+import com.bbangle.bbangle.linktracking.repository.TrackingLinkRepository;
+import com.bbangle.bbangle.util.VisitorFingerprintUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LinkTrackingService {
+
+    private final TrackingLinkRepository trackingLinkRepository;
+    private final LinkVisitRepository linkVisitRepository;
+
+    @Value("${link-tracking.destinations}")
+    private String destinationUrl;
+
+    @Transactional
+    public String resolveAndRecordVisit(LinkTrackingCommand.Visit command) {
+        TrackingLink link = trackingLinkRepository.findByChannel(command.channel())
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.TRACKING_LINK_NOT_FOUND));
+
+        String visitorHash = VisitorFingerprintUtils.hash(command.ipAddress(), command.userAgent());
+        LocalDate today = LocalDate.now();
+
+        boolean isDuplicate = linkVisitRepository.existsByTrackingLinkIdAndVisitorHashAndVisitDate(link.getId(), visitorHash, today);
+
+        LinkVisit visit = LinkVisit.create(
+            link.getId(),
+            visitorHash,
+            today,
+            isDuplicate,
+            command.referer(),
+            command.userAgent());
+
+        linkVisitRepository.save(visit);
+
+        return destinationUrl;
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/customer/service/command/LinkTrackingCommand.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/customer/service/command/LinkTrackingCommand.java
@@ -1,0 +1,24 @@
+package com.bbangle.bbangle.linktracking.customer.service.command;
+
+import com.bbangle.bbangle.linktracking.domain.LinkChannel;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class LinkTrackingCommand {
+
+    public record Visit(
+
+        @NotNull(message = "channel은 필수입니다.")
+        LinkChannel channel,
+
+        @NotBlank(message = "ipAddress는 필수입니다.")
+        String ipAddress,
+
+        String userAgent,
+
+        String referer
+    ) {}
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/domain/LinkChannel.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/domain/LinkChannel.java
@@ -1,0 +1,14 @@
+package com.bbangle.bbangle.linktracking.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LinkChannel {
+
+    INSTAGRAM("인스타그램"),
+    NAVER_BLOG("네이버 블로그");
+
+    private final String description;
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/domain/LinkVisit.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/domain/LinkVisit.java
@@ -1,0 +1,80 @@
+package com.bbangle.bbangle.linktracking.domain;
+
+import com.bbangle.bbangle.common.domain.CreatedAtBaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Table(
+    name = "link_visit",
+    indexes = {
+        @Index(name = "idx_link_visit_dedup",
+            columnList = "tracking_link_id, visitor_hash, visit_date"),
+        @Index(name = "idx_link_visit_link_date",
+            columnList = "tracking_link_id, visit_date")
+    }
+)
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LinkVisit extends CreatedAtBaseEntity {
+
+    private static final int MAX_HEADER_LENGTH = 500;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(name = "tracking_link_id", nullable = false)
+    private Long trackingLinkId;
+
+    @NotNull
+    @Column(name = "visitor_hash", length = 64, nullable = false)
+    private String visitorHash;
+
+    @NotNull
+    @Column(name = "visit_date", nullable = false)
+    private LocalDate visitDate;
+
+    @NotNull
+    @Column(name = "is_duplicate", nullable = false, columnDefinition = "tinyint default 0")
+    private boolean isDuplicate;
+
+    @Column(name = "referer", length = MAX_HEADER_LENGTH)
+    private String referer;
+
+    @Column(name = "user_agent", length = MAX_HEADER_LENGTH)
+    private String userAgent;
+
+    private LinkVisit(
+        Long trackingLinkId,
+        String visitorHash,
+        LocalDate visitDate,
+        boolean isDuplicate,
+        String referer,
+        String userAgent
+    ) {
+        this.trackingLinkId = trackingLinkId;
+        this.visitorHash = visitorHash;
+        this.visitDate = visitDate;
+        this.isDuplicate = isDuplicate;
+        this.referer = referer;
+        this.userAgent = userAgent;
+    }
+
+    public static LinkVisit create(
+        Long trackingLinkId,
+        String visitorHash,
+        LocalDate visitDate,
+        boolean isDuplicate,
+        String referer,
+        String userAgent
+    ) {
+        return new LinkVisit(trackingLinkId, visitorHash, visitDate, isDuplicate, referer, userAgent);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/domain/TrackingLink.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/domain/TrackingLink.java
@@ -1,0 +1,29 @@
+package com.bbangle.bbangle.linktracking.domain;
+
+import com.bbangle.bbangle.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "tracking_link")
+@Getter
+@Entity
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrackingLink extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel", unique = true, nullable = false)
+    private LinkChannel channel;
+
+    @Column(name = "description")
+    private String description;
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/repository/LinkVisitRepository.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/repository/LinkVisitRepository.java
@@ -1,0 +1,11 @@
+package com.bbangle.bbangle.linktracking.repository;
+
+import com.bbangle.bbangle.linktracking.domain.LinkVisit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+public interface LinkVisitRepository extends JpaRepository<LinkVisit, Long> {
+
+    boolean existsByTrackingLinkIdAndVisitorHashAndVisitDate(Long trackingLinkId, String visitorHash, LocalDate visitDate);
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/repository/TrackingLinkRepository.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/repository/TrackingLinkRepository.java
@@ -1,0 +1,11 @@
+package com.bbangle.bbangle.linktracking.repository;
+
+import com.bbangle.bbangle.linktracking.domain.LinkChannel;
+import com.bbangle.bbangle.linktracking.domain.TrackingLink;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrackingLinkRepository extends JpaRepository<TrackingLink, Long> {
+
+    Optional<TrackingLink> findByChannel(LinkChannel channel);
+}

--- a/src/main/java/com/bbangle/bbangle/util/VisitorFingerprintUtils.java
+++ b/src/main/java/com/bbangle/bbangle/util/VisitorFingerprintUtils.java
@@ -1,0 +1,52 @@
+package com.bbangle.bbangle.util;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class VisitorFingerprintUtils {
+
+    private static final String[] IP_HEADERS = {
+        "X-Forwarded-For",
+        "Proxy-Client-IP",
+        "WL-Proxy-Client-IP",
+        "HTTP_CLIENT_IP",
+        "HTTP_X_FORWARDED_FOR"
+    };
+
+    public static String hash(String ipAddress, String userAgent) {
+        return sha256(StringUtils.defaultString(ipAddress) + "|" + StringUtils.defaultString(userAgent));
+    }
+
+    public static String extractIp(HttpServletRequest request) {
+        for (String header : IP_HEADERS) {
+            String value = request.getHeader(header);
+            if (StringUtils.isNotBlank(value) && !"unknown".equalsIgnoreCase(value)) {
+                return value.split(",")[0].trim();
+            }
+        }
+        return StringUtils.defaultString(request.getRemoteAddr());
+    }
+
+    private static String sha256(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(bytes.length * 2);
+            for (byte b : bytes) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new BbangleException(BbangleErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -118,3 +118,6 @@ app:
 encryption:
   aes:
     secret-key: ${AES_SECRET_KEY}
+
+link-tracking:
+  destinations: https://develop.bbanggree.com

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -124,3 +124,6 @@ app:
 encryption:
   aes:
     secret-key: ${AES_SECRET_KEY}
+
+link-tracking:
+  destinations: http://localhost:3000

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -124,3 +124,6 @@ management:
 encryption:
   aes:
     secret-key: ${AES_SECRET_KEY}
+
+link-tracking:
+  destinations: https://www.bbanggree.com

--- a/src/main/resources/flyway/V54__app.sql
+++ b/src/main/resources/flyway/V54__app.sql
@@ -1,0 +1,11 @@
+-- 외부 유입 추적 링크 테이블 (destination URL은 환경별 yml에서 @Value로 주입)
+CREATE TABLE tracking_link
+(
+    id          BIGINT AUTO_INCREMENT,
+    channel     VARCHAR(50)  NOT NULL,
+    description VARCHAR(255) NULL,
+    created_at  DATETIME(6)  NULL,
+    modified_at DATETIME(6)  NULL,
+    CONSTRAINT tracking_link_pk PRIMARY KEY (id),
+    CONSTRAINT uk_tracking_link_channel UNIQUE (channel)
+);

--- a/src/main/resources/flyway/V55__app.sql
+++ b/src/main/resources/flyway/V55__app.sql
@@ -1,0 +1,16 @@
+-- 추적 링크 방문 기록 테이블
+CREATE TABLE link_visit
+(
+    id               BIGINT AUTO_INCREMENT,
+    tracking_link_id BIGINT       NOT NULL,
+    visitor_hash     VARCHAR(64)  NOT NULL,
+    visit_date       DATE         NOT NULL,
+    is_duplicate     TINYINT      NOT NULL DEFAULT 0,
+    referer          VARCHAR(500) NULL,
+    user_agent       VARCHAR(500) NULL,
+    created_at       DATETIME(6)  NULL,
+    CONSTRAINT link_visit_pk PRIMARY KEY (id),
+    INDEX idx_link_visit_dedup (tracking_link_id, visitor_hash, visit_date),
+    INDEX idx_link_visit_link_date (tracking_link_id, visit_date),
+    CONSTRAINT fk_tracking_link_link_visit FOREIGN KEY (tracking_link_id) REFERENCES tracking_link (id)
+);

--- a/src/main/resources/flyway/V56__app.sql
+++ b/src/main/resources/flyway/V56__app.sql
@@ -1,0 +1,3 @@
+-- 인스타그램 추적 링크 시드 데이터 (channel만 등록; 실제 destination URL은 yml의 @Value로 런타임 주입)
+INSERT INTO tracking_link (channel, description, created_at, modified_at)
+VALUES ('INSTAGRAM', '인스타 바이오 링크', NOW(6), NOW(6));


### PR DESCRIPTION
# [Feat] 외부 유입 링크 추적 기능 구현

> 브랜치: `feature/link-tracking` → `dev`

## 🚀 Major Changes & Explanations

### 배경

인스타그램 등 외부 채널에 게시한 링크의 유입 트래픽을 측정하기 위해 추적 링크 기능을 도입했습니다. 채널별 클릭 수와 일별 중복 방문(unique visitor)을 분리해 집계할 수 있도록 설계했습니다. 통계 조회 화면은 별도 사이트에서 구현 예정이라 본 PR은 데이터 수집 인프라까지만 포함합니다.

### 동작 흐름

```
[인스타 바이오] https://bbangle.com/link/instagram
   ↓
프론트 라우트 핸들러 → 백엔드 호출
   ↓
GET /link/INSTAGRAM
   ↓
1) tracking_link 조회 (channel = INSTAGRAM)
2) visitor_hash = SHA-256(IP + "|" + User-Agent)
3) (link_id, visitor_hash, 오늘) 존재 여부 확인 → is_duplicate 결정
4) link_visit INSERT
5) 302 Redirect → destination_url
```

### 주요 변경 사항

#### 도메인 신규: `linktracking`

| 파일 | 역할 |
|------|------|
| `domain/LinkChannel.java` | 추적 채널 enum (INSTAGRAM, NAVER_BLOG) |
| `domain/TrackingLink.java` | 추적 링크 엔티티 (channel ↔ destination_url) |
| `domain/LinkVisit.java` | 방문 기록 엔티티 (private 생성자 + 정적 팩토리, 컬럼 길이 truncate 내장) |
| `repository/TrackingLinkRepository.java` | `findByChannelAndIsDeletedFalse` |
| `repository/LinkVisitRepository.java` | `existsBy...VisitorHashAndVisitDate` (일별 중복 판별) |
| `customer/controller/LinkTrackingController.java` | `GET /link/{channel}` → 302 |
| `customer/controller/mapper/LinkTrackingCommandMapper.java` | MapStruct, `@Validated` + `@Valid`로 반환값 자동 검증 |
| `customer/facade/LinkTrackingFacade.java` | 검증된 command만 service로 위임 |
| `customer/service/LinkTrackingService.java` | 방문 기록 + 목적지 URL 반환 |
| `customer/service/command/LinkTrackingCommand.java` | inner record `Visit` (Bean Validation) |

#### 유틸 신규

- `util/VisitorFingerprintUtils.java` — IP 추출 (X-Forwarded-For 우선) + SHA-256 fingerprint

#### 마이그레이션

- `V54__app.sql` — `tracking_link` 테이블 + UNIQUE(channel)
- `V55__app.sql` — `link_visit` 테이블 + 중복 판별/일자별 조회 인덱스 + FK

#### 에러 코드

- `BbangleErrorCode.TRACKING_LINK_NOT_FOUND` (-831, 404) 추가

### 설계 의사 결정

- **검증 위치**: 명령 객체(`LinkTrackingCommand.Visit`)는 facade 진입 전 검증이 끝나야 한다는 원칙. mapper에 `@Validated` + 반환 타입에 `@Valid`를 부착해 mapper의 AOP 경계에서 즉시 검증되도록 구성. facade·service는 검증된 command를 신뢰하고 사용.
- **Bean Validation 사용**: 수동 `if/throw` 대신 `@NotNull`, `@NotBlank` 어노테이션으로 선언적 검증. `GlobalControllerAdvice`의 `ConstraintViolationException` 핸들러가 응답 변환 처리.
- **빌더 제거**: `LinkVisit`은 `@Builder` 대신 private 생성자 + `LinkVisit.create(...)` 정적 팩토리. 컬럼 길이 제한(truncate)은 엔티티의 불변식이므로 엔티티 내부에서 처리.
- **중복 카운트 방식**: `is_duplicate` 컬럼으로 모든 클릭을 보존. "총 조회수"와 "순 방문자수"를 동일 테이블에서 집계 가능.

## 📷 Test Image

### 정상 호출

```bash
curl -v -X GET http://localhost:8080/link/INSTAGRAM \
  -H "User-Agent: TestUA/1.0" \
  -H "Referer: https://instagram.com" \
  -H "X-Forwarded-For: 211.234.123.45"

# 기대: HTTP/1.1 302
#       Location: https://bbangle.com/products/123
```

### DB 확인

```sql
-- 사전 데이터
INSERT INTO tracking_link (channel, destination_url, created_at, modified_at, is_deleted)
VALUES ('INSTAGRAM', 'https://bbangle.com/products/123', NOW(6), NOW(6), 0);

-- 호출 후
SELECT * FROM link_visit WHERE tracking_link_id = 1;
-- 기대: 1 row (is_duplicate = 0)

-- 동일 IP/UA로 재호출 후
-- 기대: 2 rows (두 번째는 is_duplicate = 1)
```

### 통계 쿼리 (참고용)

```sql
-- 채널별 총 조회수
SELECT tl.channel, COUNT(*)
FROM link_visit lv JOIN tracking_link tl ON lv.tracking_link_id = tl.id
GROUP BY tl.channel;

-- 채널별 순 방문자수 (중복 제외)
SELECT tl.channel, COUNT(*)
FROM link_visit lv JOIN tracking_link tl ON lv.tracking_link_id = tl.id
WHERE lv.is_duplicate = 0
GROUP BY tl.channel;

-- 일자별
SELECT visit_date, COUNT(*) total, SUM(is_duplicate = 0) unique_cnt
FROM link_visit
WHERE tracking_link_id = ?
GROUP BY visit_date;
```

## 💡 ETC

- **프론트와의 결합**: 프론트엔드(`dessert-front`)에 `/link/[channel]` 라우트 핸들러가 추가됩니다. 사용자 URL은 소문자(`/link/instagram`), 백엔드 호출 시 `toUpperCase()`로 변환되어 enum과 매칭. 관련 PR: `feature/link-tracking` (dessert-front)
- **신규 채널 추가 시**: `LinkChannel` enum 값 추가 → 프론트 `LINK_CHANNEL` 동기화 → DB INSERT
- **운영 데이터 등록**: 마이그레이션 적용 후 `tracking_link` 테이블에 채널별 row INSERT 필요 (URL 매핑은 운영팀 협의)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 외부 마케팅 채널(인스타그램, 네이버 블로그 등) 링크 추적 및 리디렉션 엔드포인트 추가
  * 방문자 정보(IP, User-Agent, Referer) 자동 수집 및 저장
  * 방문 중복 감지 및 기록

* **Bug Fixes**
  * 존재하지 않는 추적 링크 접근 시 적절한 404 응답 처리 추가

* **Chores**
  * 데이터베이스 스키마 마이그레이션 및 환경별 링크 추적 설정 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->