### PR TITLE
[Feat] 셀러 주문 응답 PaymentInfo에 결제일 필드 추가

### DIFF
--- a/src/main/java/com/bbangle/bbangle/order/seller/controller/model/PaymentInfo.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/controller/model/PaymentInfo.java
@@ -1,15 +1,23 @@
 package com.bbangle.bbangle.order.seller.controller.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "결제 정보")
 public record PaymentInfo(
 
+    @Schema(description = "결제상태", example = "결제완료")
     String paymentStatus,
-    String paymentMethod
+
+    @Schema(description = "결제수단", example = "신용/체크카드")
+    String paymentMethod,
+
+    @Schema(description = "결제일", example = "2025-03-01")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    LocalDateTime paidAt
 ) {
-    public static PaymentInfo of(String paymentStatus, String paymentMethod) {
-        return new PaymentInfo(paymentStatus, paymentMethod);
-
-
+    public static PaymentInfo of(String paymentStatus, String paymentMethod, LocalDateTime paidAt) {
+        return new PaymentInfo(paymentStatus, paymentMethod, paidAt);
     }
-
-
 }

--- a/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/seller/service/SellerOrderService.java
@@ -448,8 +448,10 @@ public class SellerOrderService {
             Payment payment = order.getPayment();
             PaymentInfo paymentInfo = null;
             if (payment != null) {
-                paymentInfo = PaymentInfo.of(payment.getPaymentStatus().getDescription(),
-                    payment.getPaymentMethod().getDescription());
+                paymentInfo = PaymentInfo.of(
+                    payment.getPaymentStatus().getDescription(),
+                    payment.getPaymentMethod().getDescription(),
+                    payment.getPaidAt());
             } else {
                 log.debug("결제 정보 없음 (결제 대기 상태): orderId={}, orderNumber={}",
                     order.getId(), order.getOrderNumber());

--- a/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceIntegrationTest.java
@@ -174,5 +174,6 @@ public class SellerOrderServiceIntegrationTest {
 
         // 결제 정보 검증
         assertThat(response.paymentInfo()).isNotNull();
+        assertThat(response.paymentInfo().paidAt()).isEqualTo(payment.getPaidAt());
     }
 }

--- a/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceUnitTest.java
@@ -572,6 +572,7 @@ class SellerOrderServiceUnitTest {
 
             // 결제 정보 검증
             assertThat(response.paymentInfo()).isNotNull();
+            assertThat(response.paymentInfo().paidAt()).isEqualTo(payment.getPaidAt());
         }
 
         @DisplayName("OrderItem이 없는 주문은 orderItems가 빈 목록으로 포함되어 조회된다")
@@ -677,6 +678,7 @@ class SellerOrderServiceUnitTest {
             assertThat(result.orders().content()).asList().hasSize(2);
             assertThat(result.orders().content().get(0).orderNumber()).isEqualTo(validOrder.getOrderNumber());
             assertThat(result.orders().content().get(0).paymentInfo()).isNotNull();
+            assertThat(result.orders().content().get(0).paymentInfo().paidAt()).isEqualTo(validPayment.getPaidAt());
             assertThat(result.orders().content().get(1).orderNumber()).isEqualTo(invalidOrder.getOrderNumber());
             assertThat(result.orders().content().get(1).paymentInfo()).isNull();
         }


### PR DESCRIPTION
## Summary
- `PaymentInfo` record에 `paidAt(LocalDateTime)` 필드 추가
- `@JsonFormat(pattern = "yyyy-MM-dd")`으로 날짜 직렬화 형식 지정
- `@Schema` 어노테이션으로 Swagger 문서에 결제일 설명 추가
- `SellerOrderService`에서 `payment.getPaidAt()` 매핑 반영
- 단위/통합 테스트에 `paidAt` 검증 어서션 추가

## Test plan
- [x] 셀러 주문 단건 조회 API 응답에 `paidAt` 필드가 포함되는지 확인
- [x] 결제 정보가 없는 주문은 `paymentInfo`가 `null`인지 확인
- [x] `SellerOrderServiceUnitTest` 통과 확인
- [x] `SellerOrderServiceIntegrationTest` 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 결제 완료 시간 추적 기능 추가: 주문 조회 시 각 결제의 정확한 완료 시간이 포함되어 이제 제공됩니다.

* **Tests**
  * 결제 완료 시간 관련 테스트 케이스 추가로 기능 안정성 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->