### PR TITLE
[Feature] 반품 보류 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/claim/domain/ReturnRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ReturnRequest.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.claim.domain;
 
 import static com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus.APPROVED;
+import static com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus.HOLD;
 import static com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus.PICKUP_SCHEDULED;
 import static com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus.REJECTED;
 import static com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus.REQUESTED;
@@ -72,6 +73,14 @@ public class ReturnRequest extends Claim {
         this.status = REJECTED;
         this.sellerComment = refusalReason;
         super.decide();
+    }
+
+    public void hold(String holdReason) {
+        if (status != REQUESTED && status != APPROVED && status != PICKUP_SCHEDULED) {
+            throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
+        }
+        this.status = HOLD;
+        this.sellerComment = holdReason;
     }
 
     public void startReturnPickup() {

--- a/src/main/java/com/bbangle/bbangle/claim/domain/constant/ReturnRequestRequestStatus.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/constant/ReturnRequestRequestStatus.java
@@ -10,6 +10,7 @@ public enum ReturnRequestRequestStatus {
     PICKED_UP,           // 반품 수거 완료
     INSPECTING,          // 반품 상품 검수 중
     INSPECTION_APPROVED, // 검수 후 최종 승인 — 환불 진행 가능
+    HOLD,                // 추가 확인 필요로 보류됨
     REJECTED,            // 반품 거절
     COMPLETED;           // 환불까지 완료됨
 

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerReturnController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerReturnController.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.claim.seller.controller;
 
 import com.bbangle.bbangle.claim.seller.controller.dto.RegisterReturnInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ReturnDecisionRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.ReturnHoldRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ReturnRefuseRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.UpdateReturnInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.UpdateReturnInvoiceResponse;
@@ -37,6 +38,16 @@ public class SellerReturnController implements SellerReturnApi {
     ) {
         sellerReturnService.decision(returnDecisionRequest.returnIds(), sellerId,
             returnDecisionRequest.decisionType(), returnDecisionRequest.reason());
+        return responseService.getSuccessResult();
+    }
+
+    @PostMapping("/{returnId}/hold")
+    public CommonResult holdReturn(
+        @PathVariable Long returnId,
+        @Valid @RequestBody ReturnHoldRequest request,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        sellerReturnService.holdReturn(returnId, sellerId, request.holdReason());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ReturnHoldRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ReturnHoldRequest.java
@@ -1,0 +1,16 @@
+package com.bbangle.bbangle.claim.seller.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "반품 보류 요청 DTO")
+public record ReturnHoldRequest(
+
+    @Schema(description = "보류 사유", example = "배송비 미입금 확인 중입니다.", maxLength = 500)
+    @NotBlank
+    @Size(max = 500)
+    String holdReason
+
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerReturnService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerReturnService.java
@@ -172,6 +172,23 @@ public class SellerReturnService {
     }
 
     @Transactional
+    public void holdReturn(Long returnId, Long sellerId, String holdReason) {
+        if (!claimRepository.existsClaimRequestBySeller(returnId, sellerId)) {
+            throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+        }
+
+        ReturnRequest returnRequest = findReturnRequestWithLock(returnId);
+        applyHold(returnRequest, holdReason);
+    }
+
+    private void applyHold(ReturnRequest returnRequest, String holdReason) {
+        returnRequest.hold(holdReason);
+        OrderItem orderItem = returnRequest.getOrderItem();
+        orderItem.returnHold();
+        orderItemHistoryRepository.save(OrderItemHistory.create(orderItem));
+    }
+
+    @Transactional
     public void refuseReturn(Long returnId, Long sellerId, String refusalReason) {
         if (!claimRepository.existsClaimRequestBySeller(returnId, sellerId)) {
             throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -179,6 +179,13 @@ public class OrderItem extends BaseEntity {
         this.orderStatus = OrderStatus.CANCEL_REJECTED;
     }
 
+    public void returnHold() {
+        if (orderStatus != RETURN_REQUESTED && orderStatus != OrderStatus.RETURN_APPROVED) {
+            throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
+        }
+        this.orderStatus = OrderStatus.RETURN_ON_HOLD;
+    }
+
     public void returnComplete() {
         if (orderStatus != OrderStatus.RETURN_APPROVED) {
             throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerReturnServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerReturnServiceUnitTest.java
@@ -389,6 +389,148 @@ class SellerReturnServiceUnitTest {
     }
 
     @Nested
+    @DisplayName("holdReturn()")
+    class HoldReturnTests {
+
+        private static final Long RETURN_ID = 1L;
+        private static final Long SELLER_ID = 10L;
+        private static final String HOLD_REASON = "배송비 미입금 확인 중입니다.";
+
+        @Test
+        @DisplayName("REQUESTED 상태의 반품을 보류하면 상태가 HOLD로 변경되고 보류 사유와 히스토리가 저장된다")
+        void holdReturn_fromRequested_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderReturnRequested();
+            ReturnRequest returnRequest = ReturnRequestFixture.requested(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when
+            sut.holdReturn(RETURN_ID, SELLER_ID, HOLD_REASON);
+
+            // then
+            assertThat(returnRequest.getStatus()).isEqualTo(ReturnRequestRequestStatus.HOLD);
+            assertThat(returnRequest.getSellerComment()).isEqualTo(HOLD_REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.RETURN_ON_HOLD);
+            then(returnRequestRepository).should(times(1)).findWithLockById(RETURN_ID);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("APPROVED 상태의 반품을 보류하면 상태가 HOLD로 변경되고 히스토리가 저장된다")
+        void holdReturn_fromApproved_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_APPROVED);
+            ReturnRequest returnRequest = ReturnRequestFixture.approved(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when
+            sut.holdReturn(RETURN_ID, SELLER_ID, HOLD_REASON);
+
+            // then
+            assertThat(returnRequest.getStatus()).isEqualTo(ReturnRequestRequestStatus.HOLD);
+            assertThat(returnRequest.getSellerComment()).isEqualTo(HOLD_REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.RETURN_ON_HOLD);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("PICKUP_SCHEDULED 상태의 반품을 보류하면 상태가 HOLD로 변경되고 히스토리가 저장된다")
+        void holdReturn_fromPickupScheduled_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_APPROVED);
+            ReturnRequest returnRequest = ReturnRequestFixture.pickupScheduled(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when
+            sut.holdReturn(RETURN_ID, SELLER_ID, HOLD_REASON);
+
+            // then
+            assertThat(returnRequest.getStatus()).isEqualTo(ReturnRequestRequestStatus.HOLD);
+            assertThat(returnRequest.getSellerComment()).isEqualTo(HOLD_REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.RETURN_ON_HOLD);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("셀러 소유권 검증 실패 시 SELLER_CLAIM_MISMATCH 예외가 발생하고 이후 로직은 실행되지 않는다")
+        void holdReturn_fails_when_seller_mismatch() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> sut.holdReturn(RETURN_ID, SELLER_ID, HOLD_REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+
+            then(returnRequestRepository).should(never()).findWithLockById(any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 returnId로 요청하면 CLAIM_NOT_FOUND 예외가 발생한다")
+        void holdReturn_fails_when_claim_not_found() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sut.holdReturn(RETURN_ID, SELLER_ID, HOLD_REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_NOT_FOUND);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태의 반품을 보류하려 하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void holdReturn_fails_when_already_completed() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_COMPLETED);
+            ReturnRequest returnRequest = ReturnRequestFixture.withStatus(
+                ReturnRequestRequestStatus.COMPLETED, orderItem
+            );
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.holdReturn(RETURN_ID, SELLER_ID, HOLD_REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("REJECTED 상태의 반품을 보류하려 하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void holdReturn_fails_when_already_rejected() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.RETURN_REJECTED);
+            ReturnRequest returnRequest = ReturnRequestFixture.rejected(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(RETURN_ID, SELLER_ID)).willReturn(true);
+            given(returnRequestRepository.findWithLockById(RETURN_ID)).willReturn(Optional.of(returnRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.holdReturn(RETURN_ID, SELLER_ID, HOLD_REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
     @DisplayName("processReturn()")
     class ProcessReturnTests {
 

--- a/src/test/java/com/bbangle/bbangle/fixture/claim/ReturnRequestFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/claim/ReturnRequestFixture.java
@@ -36,6 +36,10 @@ public class ReturnRequestFixture {
         return withStatus(ReturnRequestRequestStatus.PICKUP_SCHEDULED, orderItem);
     }
 
+    public static ReturnRequest onHold(OrderItem orderItem) {
+        return withStatus(ReturnRequestRequestStatus.HOLD, orderItem);
+    }
+
     public static ReturnRequest inspectionApproved(OrderItem orderItem) {
         return withStatus(ReturnRequestRequestStatus.INSPECTION_APPROVED, orderItem);
     }


### PR DESCRIPTION
## History
- 리뷰어 : 경민님, 종수님
- 연관된 이슈 : #516 

## 🚀 Major Changes & Explanations
- **반품 보류 (POST /api/v1/seller/returns/{returnId}/hold)**
    - 추가 확인(배송비 미입금, 구성품 누락 등)이 필요한 경우 판매자가 반품 요청을 `HOLD` 상태로 변경
- **실시간 상태 이력 기록**
    - 상태 전이가 일어날 때마다 OrderItemHistory 테이블에 기록하여 CS 대응 시 데이터 변경 이력을 명확히 추적 가능하도록 설계
- **비관적 락(Pessimistic Lock) 적용**
    - `findWithLockById`를 사용하여 상태 경합을 방지하고, 클레임 처리 로직의 원자성을 보장
- **권한 검증 및 보안**
    - 요청한 판매자(`sellerId`)가 실제 해당 클레임의 소유자인지 확인하는 검증 로직 추가
- **Service Unit Test**
    - 성공 시나리오(HOLD 상태 전이) 및 실패 시나리오(권한 불일치, 이미 완료된 건에 대한 보류 시도 등)를 모두 검증
- **History 연동 검증**
    - 상태 변경 시 `OrderItemHistoryRepository`가 기존 테이블 스키마에 맞춰 정확하게 호출되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 반품 요청을 보류 상태로 설정할 수 있는 기능이 추가되었습니다.
  * 판매자는 보류 사유를 입력하여 기록할 수 있습니다.

* **Tests**
  * 보류 기능의 상태 전환 및 유효성 검증에 대한 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->