### PR TITLE
[Feat] 외부 유입 링크 추적 기능 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -190,7 +190,10 @@ public enum BbangleErrorCode {
 
     // Statistics Error(811~820)
     INVALID_STATISTICS_PERIOD(-811, "유효하지 않은 통계 기간입니다.", BAD_REQUEST),
-    INVALID_DATE_RANGE(-812, "유효하지 않은 날짜 범위입니다.", BAD_REQUEST);
+    INVALID_DATE_RANGE(-812, "유효하지 않은 날짜 범위입니다.", BAD_REQUEST),
+
+    // LinkTracking Error(831 ~ 840)
+    TRACKING_LINK_NOT_FOUND(-831, "존재하지 않는 추적 링크입니다.", NOT_FOUND);
 
     private final int code;
     private final String message;

--- a/src/main/java/com/bbangle/bbangle/linktracking/customer/controller/LinkTrackingController.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/customer/controller/LinkTrackingController.java
@@ -1,0 +1,44 @@
+package com.bbangle.bbangle.linktracking.customer.controller;
+
+import com.bbangle.bbangle.linktracking.customer.service.command.LinkTrackingCommand;
+import com.bbangle.bbangle.linktracking.customer.facade.LinkTrackingFacade;
+import com.bbangle.bbangle.linktracking.customer.controller.mapper.LinkTrackingCommandMapper;
+import com.bbangle.bbangle.linktracking.domain.LinkChannel;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "LinkTracking", description = "외부 유입 링크 추적")
+@RestController
+@RequestMapping("/api/v1/link")
+@RequiredArgsConstructor
+public class LinkTrackingController {
+
+    private final LinkTrackingFacade linkTrackingFacade;
+    private final LinkTrackingCommandMapper linkTrackingCommandMapper;
+
+    @Operation(summary = "추적 링크 리다이렉트", description = "조회수를 기록한 뒤 실제 목적지로 302 리다이렉트")
+    @GetMapping("/{channel}")
+    public ResponseEntity<Void> redirect(
+        @Parameter(description = "유입 채널", example = "INSTAGRAM")
+        @PathVariable("channel") LinkChannel channel,
+        HttpServletRequest request
+    ) {
+        LinkTrackingCommand.Visit command = linkTrackingCommandMapper.toVisit(channel, request);
+        String destinationUrl = linkTrackingFacade.resolveAndRecordVisit(command);
+
+        return ResponseEntity
+            .status(HttpStatus.FOUND)
+            .location(URI.create(destinationUrl))
+            .build();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/customer/controller/mapper/LinkTrackingCommandMapper.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/customer/controller/mapper/LinkTrackingCommandMapper.java
@@ -1,0 +1,44 @@
+package com.bbangle.bbangle.linktracking.customer.controller.mapper;
+
+import com.bbangle.bbangle.linktracking.customer.service.command.LinkTrackingCommand;
+import com.bbangle.bbangle.linktracking.domain.LinkChannel;
+import com.bbangle.bbangle.util.VisitorFingerprintUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.ReportingPolicy;
+import org.springframework.validation.annotation.Validated;
+
+@Mapper(
+    componentModel = "spring",
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+    unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+@Validated
+public interface LinkTrackingCommandMapper {
+
+    @Valid
+    @Mapping(target = "channel", source = "channel")
+    @Mapping(target = "ipAddress", source = "request", qualifiedByName = "extractIp")
+    @Mapping(target = "userAgent", source = "request", qualifiedByName = "extractUserAgent")
+    @Mapping(target = "referer", source = "request", qualifiedByName = "extractReferer")
+    LinkTrackingCommand.Visit toVisit(LinkChannel channel, HttpServletRequest request);
+
+    @Named("extractIp")
+    default String extractIp(HttpServletRequest request) {
+        return VisitorFingerprintUtils.extractIp(request);
+    }
+
+    @Named("extractUserAgent")
+    default String extractUserAgent(HttpServletRequest request) {
+        return request.getHeader("User-Agent");
+    }
+
+    @Named("extractReferer")
+    default String extractReferer(HttpServletRequest request) {
+        return request.getHeader("Referer");
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/customer/facade/LinkTrackingFacade.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/customer/facade/LinkTrackingFacade.java
@@ -1,0 +1,17 @@
+package com.bbangle.bbangle.linktracking.customer.facade;
+
+import com.bbangle.bbangle.linktracking.customer.service.command.LinkTrackingCommand;
+import com.bbangle.bbangle.linktracking.customer.service.LinkTrackingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LinkTrackingFacade {
+
+    private final LinkTrackingService linkTrackingService;
+
+    public String resolveAndRecordVisit(LinkTrackingCommand.Visit command) {
+        return linkTrackingService.resolveAndRecordVisit(command);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/customer/service/LinkTrackingService.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/customer/service/LinkTrackingService.java
@@ -1,0 +1,51 @@
+package com.bbangle.bbangle.linktracking.customer.service;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.linktracking.customer.service.command.LinkTrackingCommand;
+import com.bbangle.bbangle.linktracking.domain.LinkVisit;
+import com.bbangle.bbangle.linktracking.domain.TrackingLink;
+import com.bbangle.bbangle.linktracking.repository.LinkVisitRepository;
+import com.bbangle.bbangle.linktracking.repository.TrackingLinkRepository;
+import com.bbangle.bbangle.util.VisitorFingerprintUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LinkTrackingService {
+
+    private final TrackingLinkRepository trackingLinkRepository;
+    private final LinkVisitRepository linkVisitRepository;
+
+    @Value("${link-tracking.destinations}")
+    private String destinationUrl;
+
+    @Transactional
+    public String resolveAndRecordVisit(LinkTrackingCommand.Visit command) {
+        TrackingLink link = trackingLinkRepository.findByChannel(command.channel())
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.TRACKING_LINK_NOT_FOUND));
+
+        String visitorHash = VisitorFingerprintUtils.hash(command.ipAddress(), command.userAgent());
+        LocalDate today = LocalDate.now();
+
+        boolean isDuplicate = linkVisitRepository.existsByTrackingLinkIdAndVisitorHashAndVisitDate(link.getId(), visitorHash, today);
+
+        LinkVisit visit = LinkVisit.create(
+            link.getId(),
+            visitorHash,
+            today,
+            isDuplicate,
+            command.referer(),
+            command.userAgent());
+
+        linkVisitRepository.save(visit);
+
+        return destinationUrl;
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/customer/service/command/LinkTrackingCommand.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/customer/service/command/LinkTrackingCommand.java
@@ -1,0 +1,24 @@
+package com.bbangle.bbangle.linktracking.customer.service.command;
+
+import com.bbangle.bbangle.linktracking.domain.LinkChannel;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class LinkTrackingCommand {
+
+    public record Visit(
+
+        @NotNull(message = "channel은 필수입니다.")
+        LinkChannel channel,
+
+        @NotBlank(message = "ipAddress는 필수입니다.")
+        String ipAddress,
+
+        String userAgent,
+
+        String referer
+    ) {}
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/domain/LinkChannel.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/domain/LinkChannel.java
@@ -1,0 +1,14 @@
+package com.bbangle.bbangle.linktracking.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LinkChannel {
+
+    INSTAGRAM("인스타그램"),
+    NAVER_BLOG("네이버 블로그");
+
+    private final String description;
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/domain/LinkVisit.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/domain/LinkVisit.java
@@ -1,0 +1,80 @@
+package com.bbangle.bbangle.linktracking.domain;
+
+import com.bbangle.bbangle.common.domain.CreatedAtBaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Table(
+    name = "link_visit",
+    indexes = {
+        @Index(name = "idx_link_visit_dedup",
+            columnList = "tracking_link_id, visitor_hash, visit_date"),
+        @Index(name = "idx_link_visit_link_date",
+            columnList = "tracking_link_id, visit_date")
+    }
+)
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LinkVisit extends CreatedAtBaseEntity {
+
+    private static final int MAX_HEADER_LENGTH = 500;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(name = "tracking_link_id", nullable = false)
+    private Long trackingLinkId;
+
+    @NotNull
+    @Column(name = "visitor_hash", length = 64, nullable = false)
+    private String visitorHash;
+
+    @NotNull
+    @Column(name = "visit_date", nullable = false)
+    private LocalDate visitDate;
+
+    @NotNull
+    @Column(name = "is_duplicate", nullable = false, columnDefinition = "tinyint default 0")
+    private boolean isDuplicate;
+
+    @Column(name = "referer", length = MAX_HEADER_LENGTH)
+    private String referer;
+
+    @Column(name = "user_agent", length = MAX_HEADER_LENGTH)
+    private String userAgent;
+
+    private LinkVisit(
+        Long trackingLinkId,
+        String visitorHash,
+        LocalDate visitDate,
+        boolean isDuplicate,
+        String referer,
+        String userAgent
+    ) {
+        this.trackingLinkId = trackingLinkId;
+        this.visitorHash = visitorHash;
+        this.visitDate = visitDate;
+        this.isDuplicate = isDuplicate;
+        this.referer = referer;
+        this.userAgent = userAgent;
+    }
+
+    public static LinkVisit create(
+        Long trackingLinkId,
+        String visitorHash,
+        LocalDate visitDate,
+        boolean isDuplicate,
+        String referer,
+        String userAgent
+    ) {
+        return new LinkVisit(trackingLinkId, visitorHash, visitDate, isDuplicate, referer, userAgent);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/domain/TrackingLink.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/domain/TrackingLink.java
@@ -1,0 +1,29 @@
+package com.bbangle.bbangle.linktracking.domain;
+
+import com.bbangle.bbangle.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "tracking_link")
+@Getter
+@Entity
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrackingLink extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel", unique = true, nullable = false)
+    private LinkChannel channel;
+
+    @Column(name = "description")
+    private String description;
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/repository/LinkVisitRepository.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/repository/LinkVisitRepository.java
@@ -1,0 +1,11 @@
+package com.bbangle.bbangle.linktracking.repository;
+
+import com.bbangle.bbangle.linktracking.domain.LinkVisit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+public interface LinkVisitRepository extends JpaRepository<LinkVisit, Long> {
+
+    boolean existsByTrackingLinkIdAndVisitorHashAndVisitDate(Long trackingLinkId, String visitorHash, LocalDate visitDate);
+}

--- a/src/main/java/com/bbangle/bbangle/linktracking/repository/TrackingLinkRepository.java
+++ b/src/main/java/com/bbangle/bbangle/linktracking/repository/TrackingLinkRepository.java
@@ -1,0 +1,11 @@
+package com.bbangle.bbangle.linktracking.repository;
+
+import com.bbangle.bbangle.linktracking.domain.LinkChannel;
+import com.bbangle.bbangle.linktracking.domain.TrackingLink;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrackingLinkRepository extends JpaRepository<TrackingLink, Long> {
+
+    Optional<TrackingLink> findByChannel(LinkChannel channel);
+}

--- a/src/main/java/com/bbangle/bbangle/util/VisitorFingerprintUtils.java
+++ b/src/main/java/com/bbangle/bbangle/util/VisitorFingerprintUtils.java
@@ -1,0 +1,52 @@
+package com.bbangle.bbangle.util;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class VisitorFingerprintUtils {
+
+    private static final String[] IP_HEADERS = {
+        "X-Forwarded-For",
+        "Proxy-Client-IP",
+        "WL-Proxy-Client-IP",
+        "HTTP_CLIENT_IP",
+        "HTTP_X_FORWARDED_FOR"
+    };
+
+    public static String hash(String ipAddress, String userAgent) {
+        return sha256(StringUtils.defaultString(ipAddress) + "|" + StringUtils.defaultString(userAgent));
+    }
+
+    public static String extractIp(HttpServletRequest request) {
+        for (String header : IP_HEADERS) {
+            String value = request.getHeader(header);
+            if (StringUtils.isNotBlank(value) && !"unknown".equalsIgnoreCase(value)) {
+                return value.split(",")[0].trim();
+            }
+        }
+        return StringUtils.defaultString(request.getRemoteAddr());
+    }
+
+    private static String sha256(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(bytes.length * 2);
+            for (byte b : bytes) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new BbangleException(BbangleErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -118,3 +118,6 @@ app:
 encryption:
   aes:
     secret-key: ${AES_SECRET_KEY}
+
+link-tracking:
+  destinations: https://develop.bbanggree.com

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -124,3 +124,6 @@ app:
 encryption:
   aes:
     secret-key: ${AES_SECRET_KEY}
+
+link-tracking:
+  destinations: http://localhost:3000

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -124,3 +124,6 @@ management:
 encryption:
   aes:
     secret-key: ${AES_SECRET_KEY}
+
+link-tracking:
+  destinations: https://www.bbanggree.com

--- a/src/main/resources/flyway/V54__app.sql
+++ b/src/main/resources/flyway/V54__app.sql
@@ -1,0 +1,11 @@
+-- 외부 유입 추적 링크 테이블 (destination URL은 환경별 yml에서 @Value로 주입)
+CREATE TABLE tracking_link
+(
+    id          BIGINT AUTO_INCREMENT,
+    channel     VARCHAR(50)  NOT NULL,
+    description VARCHAR(255) NULL,
+    created_at  DATETIME(6)  NULL,
+    modified_at DATETIME(6)  NULL,
+    CONSTRAINT tracking_link_pk PRIMARY KEY (id),
+    CONSTRAINT uk_tracking_link_channel UNIQUE (channel)
+);

--- a/src/main/resources/flyway/V55__app.sql
+++ b/src/main/resources/flyway/V55__app.sql
@@ -1,0 +1,16 @@
+-- 추적 링크 방문 기록 테이블
+CREATE TABLE link_visit
+(
+    id               BIGINT AUTO_INCREMENT,
+    tracking_link_id BIGINT       NOT NULL,
+    visitor_hash     VARCHAR(64)  NOT NULL,
+    visit_date       DATE         NOT NULL,
+    is_duplicate     TINYINT      NOT NULL DEFAULT 0,
+    referer          VARCHAR(500) NULL,
+    user_agent       VARCHAR(500) NULL,
+    created_at       DATETIME(6)  NULL,
+    CONSTRAINT link_visit_pk PRIMARY KEY (id),
+    INDEX idx_link_visit_dedup (tracking_link_id, visitor_hash, visit_date),
+    INDEX idx_link_visit_link_date (tracking_link_id, visit_date),
+    CONSTRAINT fk_tracking_link_link_visit FOREIGN KEY (tracking_link_id) REFERENCES tracking_link (id)
+);

--- a/src/main/resources/flyway/V56__app.sql
+++ b/src/main/resources/flyway/V56__app.sql
@@ -1,0 +1,3 @@
+-- 인스타그램 추적 링크 시드 데이터 (channel만 등록; 실제 destination URL은 yml의 @Value로 런타임 주입)
+INSERT INTO tracking_link (channel, description, created_at, modified_at)
+VALUES ('INSTAGRAM', '인스타 바이오 링크', NOW(6), NOW(6));

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -65,3 +65,6 @@ jwt:
 encryption:
   aes:
     secret-key: 1234567890123456
+
+link-tracking:
+  destinations: test


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->

## 🚀 Major Changes & Explanations

* [feat] 외부 유입 링크 추적 기능 구현
  - 링크 트래킹 도메인 구현 (Controller, Service, Repository)

* [fix] 링크 트래킹 테스트 설정 누락값 추가
  - `src/test/resources/application.yml`에 `link-tracking.destinations: test` 추가하여 테스트 깨짐 수정

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 링크 추적 기능 추가: Instagram과 Naver Blog 채널을 통한 링크 관리 및 모니터링 지원
  * 방문자 방문 기록 및 중복 방문 감지 기능 구현
  * 환경별 링크 리다이렉트 설정 추가

* **Chores**
  * 링크 추적 관련 데이터베이스 테이블 및 설정 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->