### PR TITLE
[Feat] (관리자) 등록된 스토어 목록 조회 및 스토어 다중 삭제 API

### DIFF
--- a/src/main/java/com/bbangle/bbangle/seller/repository/SellerRepository.java
+++ b/src/main/java/com/bbangle/bbangle/seller/repository/SellerRepository.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.seller.repository;
 
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
 import com.bbangle.bbangle.seller.domain.Seller;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,7 @@ public interface SellerRepository extends JpaRepository<Seller, Long> {
     Optional<Seller> findByProviderAndProviderId(OauthServerType provider, String providerId);
 
     boolean existsByStore_Id(Long storeId);
+
+    @Query("SELECT se FROM Seller se WHERE se.store.id IN :storeIds")
+    List<Seller> findByStoreIdIn(@Param("storeIds") List<Long> storeIds);
 }

--- a/src/main/java/com/bbangle/bbangle/seller/repository/SellerRepository.java
+++ b/src/main/java/com/bbangle/bbangle/seller/repository/SellerRepository.java
@@ -5,6 +5,7 @@ import com.bbangle.bbangle.seller.domain.Seller;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -22,4 +23,8 @@ public interface SellerRepository extends JpaRepository<Seller, Long> {
 
     @Query("SELECT se FROM Seller se WHERE se.store.id IN :storeIds")
     List<Seller> findByStoreIdIn(@Param("storeIds") List<Long> storeIds);
+
+    @Modifying
+    @Query("UPDATE Seller s SET s.store = null WHERE s.store.id IN :storeIds")
+    void clearStoreByStoreIdIn(@Param("storeIds") List<Long> storeIds);
 }

--- a/src/main/java/com/bbangle/bbangle/seller/repository/SellerRepository.java
+++ b/src/main/java/com/bbangle/bbangle/seller/repository/SellerRepository.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.seller.repository;
 
 import com.bbangle.bbangle.auth.oauth.OauthServerType;
 import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,6 +26,6 @@ public interface SellerRepository extends JpaRepository<Seller, Long> {
     List<Seller> findByStoreIdIn(@Param("storeIds") List<Long> storeIds);
 
     @Modifying
-    @Query("UPDATE Seller s SET s.store = null WHERE s.store.id IN :storeIds")
-    void clearStoreByStoreIdIn(@Param("storeIds") List<Long> storeIds);
+    @Query("UPDATE Seller s SET s.store = null, s.certificationStatus = :status WHERE s.store.id IN :storeIds")
+    void clearStoreAndResetStatusByStoreIdIn(@Param("storeIds") List<Long> storeIds, @Param("status") CertificationStatus status);
 }

--- a/src/main/java/com/bbangle/bbangle/store/admin/controller/AdminStoreController.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/controller/AdminStoreController.java
@@ -1,6 +1,8 @@
 package com.bbangle.bbangle.store.admin.controller;
 
+import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.AdminApiPath;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreRequest.UpdateStoreNameRejectRequest;
@@ -10,10 +12,17 @@ import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.UpdateS
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.UpdateStoreNameRequest;
 import com.bbangle.bbangle.store.admin.controller.swagger.AdminStoreApi;
 import com.bbangle.bbangle.store.admin.service.AdminStoreService;
+import com.bbangle.bbangle.store.admin.service.model.RegisteredStoreInfo;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -40,6 +49,25 @@ public class AdminStoreController implements AdminStoreApi {
         return responseService.getSingleResult(
             adminStoreService.searchStoresByName(storeName, page)
         );
+    }
+
+    @Override
+    @GetMapping("/registered")
+    public SingleResult<BbanglePageResponse<RegisteredStoreInfo>> getRegisteredStores(
+        @ParameterObject
+        @PageableDefault(size = 20, page = 0, sort = "createdAt", direction = Sort.Direction.DESC)
+        Pageable pageable
+    ) {
+        return responseService.getSingleResult(
+            BbanglePageResponse.of(adminStoreService.getRegisteredStores(pageable))
+        );
+    }
+
+    @Override
+    @DeleteMapping
+    public CommonResult deleteStores(@RequestParam List<Long> storeIds) {
+        adminStoreService.deleteStores(storeIds);
+        return responseService.getSuccessResult();
     }
 
     @Override

--- a/src/main/java/com/bbangle/bbangle/store/admin/controller/swagger/AdminStoreApi.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/controller/swagger/AdminStoreApi.java
@@ -1,14 +1,20 @@
 package com.bbangle.bbangle.store.admin.controller.swagger;
 
+import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreRequest.UpdateStoreNameRejectRequest;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.StoreSearchResult;
+import com.bbangle.bbangle.store.admin.service.model.RegisteredStoreInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import java.util.List;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,6 +33,23 @@ public interface AdminStoreApi {
         @RequestParam(defaultValue = "1")
         @Min(1)
         int page
+    );
+
+    @Operation(
+        summary = "(관리자) 등록된 스토어 목록 조회",
+        description = "등록된 전체 스토어 목록을 페이지네이션으로 조회합니다."
+    )
+    SingleResult<BbanglePageResponse<RegisteredStoreInfo>> getRegisteredStores(
+        @ParameterObject Pageable pageable
+    );
+
+    @Operation(
+        summary = "(관리자) 스토어 다중 삭제",
+        description = "등록된 스토어를 hard delete 방식으로 삭제합니다."
+    )
+    CommonResult deleteStores(
+        @Parameter(description = "삭제할 스토어 ID 목록", example = "1")
+        @RequestParam List<Long> storeIds
     );
 
     @Operation(

--- a/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.store.admin.service;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerRequest.StoreApplicationApprove;
+import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreRequest.UpdateStoreNameRejectRequest;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse;
@@ -12,6 +13,7 @@ import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.UpdateS
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.UpdateStoreNameReject;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.UpdateStoreNameRequest;
 import com.bbangle.bbangle.store.admin.service.model.RegisterApproveResult;
+import com.bbangle.bbangle.store.admin.service.model.RegisteredStoreInfo;
 import com.bbangle.bbangle.store.admin.service.model.UpdateStoreNamesInfo.UpdateStoreNames;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.domain.StoreApplication;
@@ -20,6 +22,9 @@ import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
 import com.bbangle.bbangle.store.repository.StoreApplicationRepository;
 import com.bbangle.bbangle.store.repository.StoreNameRequestRepository;
 import com.bbangle.bbangle.store.repository.StoreRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -65,7 +70,34 @@ public class AdminStoreService {
     }
 
     @Transactional(readOnly = true)
-    public AdminStoreResponse.UpdateStoreNameRequest getPendingRequests(int page) {
+    public Page<RegisteredStoreInfo> getRegisteredStores(Pageable pageable) {
+        Page<Store> storePage = storeRepository.findByIsDeletedFalse(pageable);
+
+        List<Long> storeIds = storePage.getContent().stream()
+            .map(Store::getId)
+            .toList();
+
+        Map<Long, Seller> sellerByStoreId = sellerRepository.findByStoreIdIn(storeIds)
+            .stream()
+            .collect(Collectors.toMap(
+                seller -> seller.getStore().getId(),
+                seller -> seller
+            ));
+
+        return storePage.map(store -> RegisteredStoreInfo.from(store, sellerByStoreId.get(store.getId())));
+    }
+
+    @Transactional
+    public void deleteStores(List<Long> storeIds) {
+        long count = storeRepository.countByIdInAndIsDeletedFalse(storeIds);
+        if (count != storeIds.size()) {
+            throw new BbangleException(BbangleErrorCode.STORE_NOT_FOUND);
+        }
+        storeRepository.softDeleteByIds(storeIds);
+    }
+
+    @Transactional(readOnly = true)
+    public UpdateStoreNameRequest getPendingRequests(int page) {
         page = Math.max(page, 1);
         Pageable pageable = PageRequest.of(
             page - 1,

--- a/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
@@ -3,7 +3,6 @@ package com.bbangle.bbangle.store.admin.service;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerRequest.StoreApplicationApprove;
-import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreRequest.UpdateStoreNameRejectRequest;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse;
@@ -23,8 +22,6 @@ import com.bbangle.bbangle.store.repository.StoreApplicationRepository;
 import com.bbangle.bbangle.store.repository.StoreNameRequestRepository;
 import com.bbangle.bbangle.store.repository.StoreRepository;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -71,20 +68,8 @@ public class AdminStoreService {
 
     @Transactional(readOnly = true)
     public Page<RegisteredStoreInfo> getRegisteredStores(Pageable pageable) {
-        Page<Store> storePage = storeRepository.findByIsDeletedFalse(pageable);
-
-        List<Long> storeIds = storePage.getContent().stream()
-            .map(Store::getId)
-            .toList();
-
-        Map<Long, Seller> sellerByStoreId = sellerRepository.findByStoreIdIn(storeIds)
-            .stream()
-            .collect(Collectors.toMap(
-                seller -> seller.getStore().getId(),
-                seller -> seller
-            ));
-
-        return storePage.map(store -> RegisteredStoreInfo.from(store, sellerByStoreId.get(store.getId())));
+        return storeRepository.findByIsDeletedFalse(pageable)
+            .map(RegisteredStoreInfo::from);
     }
 
     @Transactional

--- a/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
@@ -68,17 +68,18 @@ public class AdminStoreService {
 
     @Transactional(readOnly = true)
     public Page<RegisteredStoreInfo> getRegisteredStores(Pageable pageable) {
-        return storeRepository.findByIsDeletedFalse(pageable)
+        return storeRepository.findAll(pageable)
             .map(RegisteredStoreInfo::from);
     }
 
     @Transactional
     public void deleteStores(List<Long> storeIds) {
-        long count = storeRepository.countByIdInAndIsDeletedFalse(storeIds);
+        long count = storeRepository.countByIdIn(storeIds);
         if (count != storeIds.size()) {
             throw new BbangleException(BbangleErrorCode.STORE_NOT_FOUND);
         }
-        storeRepository.softDeleteByIds(storeIds);
+        sellerRepository.clearStoreByStoreIdIn(storeIds);
+        storeRepository.deleteAllByIdInBatch(storeIds);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.store.admin.service;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerRequest.StoreApplicationApprove;
+import com.bbangle.bbangle.seller.domain.model.CertificationStatus;
 import com.bbangle.bbangle.seller.repository.SellerRepository;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreRequest.UpdateStoreNameRejectRequest;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse;
@@ -78,7 +79,7 @@ public class AdminStoreService {
         if (count != storeIds.size()) {
             throw new BbangleException(BbangleErrorCode.STORE_NOT_FOUND);
         }
-        sellerRepository.clearStoreByStoreIdIn(storeIds);
+        sellerRepository.clearStoreAndResetStatusByStoreIdIn(storeIds, CertificationStatus.NEW);
         storeRepository.deleteAllByIdInBatch(storeIds);
     }
 

--- a/src/main/java/com/bbangle/bbangle/store/admin/service/model/RegisteredStoreInfo.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/service/model/RegisteredStoreInfo.java
@@ -1,0 +1,34 @@
+package com.bbangle.bbangle.store.admin.service.model;
+
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.store.domain.Store;
+
+public record RegisteredStoreInfo(
+    long storeId,
+    String storeName,
+    String businessNumber,
+    String sellerName,
+    String phoneNumber,
+    String subPhoneNumber,
+    String email,
+    String address
+) {
+
+    public static RegisteredStoreInfo from(Store store, Seller seller) {
+        String detail = store.getOriginAddressDetail();
+        String address = (detail != null && !detail.isBlank())
+            ? store.getOriginAddressLine() + " " + detail
+            : store.getOriginAddressLine();
+
+        return new RegisteredStoreInfo(
+            store.getId(),
+            store.getName(),
+            store.getIdentifier(),
+            seller != null ? seller.getName() : null,
+            store.getPhoneNumberVO().getPhoneNumber(),
+            store.getPhoneNumberVO().getSubPhoneNumber(),
+            store.getEmailVO().getEmail(),
+            address
+        );
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/store/admin/service/model/RegisteredStoreInfo.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/service/model/RegisteredStoreInfo.java
@@ -2,6 +2,8 @@ package com.bbangle.bbangle.store.admin.service.model;
 
 import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.domain.model.EmailVO;
+import com.bbangle.bbangle.store.domain.model.PhoneNumberVO;
 
 public record RegisteredStoreInfo(
     long storeId,
@@ -20,14 +22,16 @@ public record RegisteredStoreInfo(
             ? store.getOriginAddressLine() + " " + detail
             : store.getOriginAddressLine();
 
+        PhoneNumberVO phoneNumberVO = store.getPhoneNumberVO();
+        EmailVO emailVO = store.getEmailVO();
         return new RegisteredStoreInfo(
             store.getId(),
             store.getName(),
             store.getIdentifier(),
             seller != null ? seller.getName() : null,
-            store.getPhoneNumberVO().getPhoneNumber(),
-            store.getPhoneNumberVO().getSubPhoneNumber(),
-            store.getEmailVO().getEmail(),
+            phoneNumberVO != null ? phoneNumberVO.getPhoneNumber() : null,
+            phoneNumberVO != null ? phoneNumberVO.getSubPhoneNumber() : null,
+            emailVO != null ? emailVO.getEmail() : null,
             address
         );
     }

--- a/src/main/java/com/bbangle/bbangle/store/admin/service/model/RegisteredStoreInfo.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/service/model/RegisteredStoreInfo.java
@@ -1,6 +1,5 @@
 package com.bbangle.bbangle.store.admin.service.model;
 
-import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.domain.model.EmailVO;
 import com.bbangle.bbangle.store.domain.model.PhoneNumberVO;
@@ -9,30 +8,27 @@ public record RegisteredStoreInfo(
     long storeId,
     String storeName,
     String businessNumber,
-    String sellerName,
+    String introduce,
     String phoneNumber,
     String subPhoneNumber,
     String email,
-    String address
+    String originAddressLine,
+    String originAddressDetail
 ) {
 
-    public static RegisteredStoreInfo from(Store store, Seller seller) {
-        String detail = store.getOriginAddressDetail();
-        String address = (detail != null && !detail.isBlank())
-            ? store.getOriginAddressLine() + " " + detail
-            : store.getOriginAddressLine();
-
+    public static RegisteredStoreInfo from(Store store) {
         PhoneNumberVO phoneNumberVO = store.getPhoneNumberVO();
         EmailVO emailVO = store.getEmailVO();
         return new RegisteredStoreInfo(
             store.getId(),
             store.getName(),
             store.getIdentifier(),
-            seller != null ? seller.getName() : null,
+            store.getIntroduce(),
             phoneNumberVO != null ? phoneNumberVO.getPhoneNumber() : null,
             phoneNumberVO != null ? phoneNumberVO.getSubPhoneNumber() : null,
             emailVO != null ? emailVO.getEmail() : null,
-            address
+            store.getOriginAddressLine(),
+            store.getOriginAddressDetail()
         );
     }
 }

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreRepository.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreRepository.java
@@ -1,9 +1,27 @@
 package com.bbangle.bbangle.store.repository;
 
 import com.bbangle.bbangle.store.domain.Store;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StoreRepository extends JpaRepository<Store, Long>, StoreQueryDSLRepository {
 
     boolean existsByName(String name);
+
+    Page<Store> findByIsDeletedFalse(Pageable pageable);
+
+    long countByIdInAndIsDeletedFalse(List<Long> ids);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        UPDATE Store s
+        SET s.isDeleted = true
+        WHERE s.id IN :storeIds
+        """)
+    void softDeleteByIds(@Param("storeIds") List<Long> storeIds);
 }

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreRepository.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreRepository.java
@@ -2,26 +2,11 @@ package com.bbangle.bbangle.store.repository;
 
 import com.bbangle.bbangle.store.domain.Store;
 import java.util.List;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface StoreRepository extends JpaRepository<Store, Long>, StoreQueryDSLRepository {
 
     boolean existsByName(String name);
 
-    Page<Store> findByIsDeletedFalse(Pageable pageable);
-
-    long countByIdInAndIsDeletedFalse(List<Long> ids);
-
-    @Modifying(clearAutomatically = true)
-    @Query("""
-        UPDATE Store s
-        SET s.isDeleted = true
-        WHERE s.id IN :storeIds
-        """)
-    void softDeleteByIds(@Param("storeIds") List<Long> storeIds);
+    long countByIdIn(List<Long> ids);
 }

--- a/src/test/java/com/bbangle/bbangle/store/admin/controller/AdminStoreControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/admin/controller/AdminStoreControllerTest.java
@@ -7,6 +7,10 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -21,6 +25,7 @@ import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
 import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreRequest.UpdateStoreNameRejectRequest;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.StoreSearchResult;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.StoreSearchResult.StoreSummary;
@@ -28,7 +33,9 @@ import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.UpdateS
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.UpdateStoreNameReject;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.UpdateStoreNameRequest;
 import com.bbangle.bbangle.store.admin.service.AdminStoreService;
+import com.bbangle.bbangle.store.admin.service.model.RegisteredStoreInfo;
 import com.bbangle.bbangle.store.admin.service.model.UpdateStoreNamesInfo.UpdateStoreNames;
+import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
 import com.bbangle.bbangle.store.domain.model.StoreNameRejectCategory;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,6 +46,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
@@ -143,6 +154,128 @@ class AdminStoreControllerTest {
                     .param("page", "0")
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("getRegisteredStores() 테스트")
+    class GetRegisteredStoresTest {
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("등록된 스토어 목록을 페이징 형태로 조회한다")
+        void success_getRegisteredStores() throws Exception {
+            // given
+            int page = 0;
+            int size = 20;
+            Store store = StoreFixture.withId(StoreFixture.defaultStore(), 1L);
+            RegisteredStoreInfo info = RegisteredStoreInfo.from(store);
+            Page<RegisteredStoreInfo> pageResult = new PageImpl<>(List.of(info), PageRequest.of(page, size), 1);
+
+            given(adminStoreService.getRegisteredStores(any(Pageable.class))).willReturn(pageResult);
+
+            // when & then
+            mockMvc.perform(get(AdminApiPath.PREFIX + "/stores/registered")
+                    .param("page", String.valueOf(page))
+                    .param("size", String.valueOf(size)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.result.content.length()").value(1))
+                .andExpect(jsonPath("$.result.content[0].storeId").value(1L))
+                .andExpect(jsonPath("$.result.content[0].storeName").value(StoreFixture.DEFAULT_STORE_NAME))
+                .andExpect(jsonPath("$.result.content[0].businessNumber").value(StoreFixture.DEFAULT_IDENTIFIER))
+                .andExpect(jsonPath("$.result.page").value(page))
+                .andExpect(jsonPath("$.result.size").value(size))
+                .andExpect(jsonPath("$.result.totalPages").value(1))
+                .andExpect(jsonPath("$.result.totalElements").value(1));
+
+            then(adminStoreService).should().getRegisteredStores(any(Pageable.class));
+        }
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("등록된 스토어가 없으면 빈 목록을 반환한다")
+        void emptyResult_getRegisteredStores() throws Exception {
+            // given
+            int page = 0;
+            int size = 20;
+            Page<RegisteredStoreInfo> emptyPage = new PageImpl<>(List.of(), PageRequest.of(page, size), 0);
+
+            given(adminStoreService.getRegisteredStores(any(Pageable.class))).willReturn(emptyPage);
+
+            // when & then
+            mockMvc.perform(get(AdminApiPath.PREFIX + "/stores/registered")
+                    .param("page", String.valueOf(page))
+                    .param("size", String.valueOf(size)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.result.content.length()").value(0))
+                .andExpect(jsonPath("$.result.totalElements").value(0));
+
+            then(adminStoreService).should().getRegisteredStores(any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("ADMIN 권한이 없으면 접근에 실패한다")
+        void fail_getRegisteredStores_noAdminRole() throws Exception {
+            // when & then
+            mockMvc.perform(get(AdminApiPath.PREFIX + "/stores/registered"))
+                .andExpect(status().isUnauthorized());
+
+            then(adminStoreService).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteStores() 테스트")
+    class DeleteStoresTest {
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("지정한 스토어를 삭제한다")
+        void success_deleteStores() throws Exception {
+            // given
+            List<Long> storeIds = List.of(1L, 2L, 3L);
+            willDoNothing().given(adminStoreService).deleteStores(storeIds);
+
+            // when & then
+            mockMvc.perform(delete(AdminApiPath.PREFIX + "/stores")
+                    .param("storeIds", "1", "2", "3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.message").value("SUCCESS"));
+
+            then(adminStoreService).should().deleteStores(storeIds);
+        }
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("존재하지 않는 storeId가 포함되면 예외 응답을 반환한다")
+        void fail_deleteStores_notFound() throws Exception {
+            // given
+            List<Long> storeIds = List.of(1L, 999L);
+            willThrow(new BbangleException(BbangleErrorCode.STORE_NOT_FOUND))
+                .given(adminStoreService).deleteStores(storeIds);
+
+            // when & then
+            mockMvc.perform(delete(AdminApiPath.PREFIX + "/stores")
+                    .param("storeIds", "1", "999"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(BbangleErrorCode.STORE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(BbangleErrorCode.STORE_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("ADMIN 권한이 없으면 접근에 실패한다")
+        void fail_deleteStores_noAdminRole() throws Exception {
+            // when & then
+            mockMvc.perform(delete(AdminApiPath.PREFIX + "/stores")
+                    .param("storeIds", "1", "2"))
+                .andExpect(status().isUnauthorized());
+
+            then(adminStoreService).shouldHaveNoInteractions();
         }
     }
 

--- a/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceUnitTest.java
@@ -687,7 +687,7 @@ class AdminStoreServiceUnitTest {
             Store store = StoreFixture.withId(StoreFixture.defaultStore(), 1L);
             Page<Store> storePage = new PageImpl<>(List.of(store), pageable, 1);
 
-            given(storeRepository.findByIsDeletedFalse(pageable)).willReturn(storePage);
+            given(storeRepository.findAll(pageable)).willReturn(storePage);
 
             // when
             Page<RegisteredStoreInfo> result = adminStoreService.getRegisteredStores(pageable);
@@ -699,7 +699,7 @@ class AdminStoreServiceUnitTest {
             assertThat(info.storeName()).isEqualTo(DEFAULT_STORE_NAME);
             assertThat(info.businessNumber()).isEqualTo(DEFAULT_IDENTIFIER);
             assertThat(result.getTotalElements()).isEqualTo(1);
-            then(storeRepository).should().findByIsDeletedFalse(pageable);
+            then(storeRepository).should().findAll(pageable);
         }
 
         @Test
@@ -709,7 +709,7 @@ class AdminStoreServiceUnitTest {
             Pageable pageable = PageRequest.of(0, 20);
             Page<Store> emptyPage = new PageImpl<>(List.of(), pageable, 0);
 
-            given(storeRepository.findByIsDeletedFalse(pageable)).willReturn(emptyPage);
+            given(storeRepository.findAll(pageable)).willReturn(emptyPage);
 
             // when
             Page<RegisteredStoreInfo> result = adminStoreService.getRegisteredStores(pageable);
@@ -717,7 +717,7 @@ class AdminStoreServiceUnitTest {
             // then
             assertThat(result.getContent()).isEmpty();
             assertThat(result.getTotalElements()).isZero();
-            then(storeRepository).should().findByIsDeletedFalse(pageable);
+            then(storeRepository).should().findAll(pageable);
         }
     }
 
@@ -726,18 +726,19 @@ class AdminStoreServiceUnitTest {
     class DeleteStoresTest {
 
         @Test
-        @DisplayName("모든 storeId가 유효하면 소프트 딜리트한다")
+        @DisplayName("모든 storeId가 유효하면 seller 관계를 끊고 hard delete한다")
         void success_deleteStores() {
             // given
             List<Long> storeIds = List.of(1L, 2L, 3L);
-            given(storeRepository.countByIdInAndIsDeletedFalse(storeIds)).willReturn(3L);
+            given(storeRepository.countByIdIn(storeIds)).willReturn(3L);
 
             // when
             adminStoreService.deleteStores(storeIds);
 
             // then
-            then(storeRepository).should().countByIdInAndIsDeletedFalse(storeIds);
-            then(storeRepository).should().softDeleteByIds(storeIds);
+            then(storeRepository).should().countByIdIn(storeIds);
+            then(sellerRepository).should().clearStoreByStoreIdIn(storeIds);
+            then(storeRepository).should().deleteAllByIdInBatch(storeIds);
         }
 
         @Test
@@ -745,7 +746,7 @@ class AdminStoreServiceUnitTest {
         void fail_deleteStores_notFound() {
             // given
             List<Long> storeIds = List.of(1L, 2L, 999L);
-            given(storeRepository.countByIdInAndIsDeletedFalse(storeIds)).willReturn(2L);
+            given(storeRepository.countByIdIn(storeIds)).willReturn(2L);
 
             // when & then
             assertThatThrownBy(() -> adminStoreService.deleteStores(storeIds))
@@ -755,8 +756,9 @@ class AdminStoreServiceUnitTest {
                     assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.STORE_NOT_FOUND);
                 });
 
-            then(storeRepository).should().countByIdInAndIsDeletedFalse(storeIds);
-            then(storeRepository).should(never()).softDeleteByIds(any());
+            then(storeRepository).should().countByIdIn(storeIds);
+            then(sellerRepository).should(never()).clearStoreByStoreIdIn(any());
+            then(storeRepository).should(never()).deleteAllByIdInBatch(any());
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceUnitTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.StoreSe
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.UpdateStoreNameApprove;
 import com.bbangle.bbangle.store.admin.controller.dto.AdminStoreResponse.UpdateStoreNameReject;
 import com.bbangle.bbangle.store.admin.service.model.RegisterApproveResult;
+import com.bbangle.bbangle.store.admin.service.model.RegisteredStoreInfo;
 import com.bbangle.bbangle.store.admin.service.model.UpdateStoreNamesInfo.UpdateStoreNames;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.domain.StoreApplication;
@@ -650,7 +652,7 @@ class AdminStoreServiceUnitTest {
         }
 
         @Test
-        @DisplayName("application이 없으면 예외 발생")
+        @DisplayName("등록 신청 정보가 없으면 예외 발생")
         void fail_registerApprove_notFound() {
 
             // given
@@ -670,6 +672,96 @@ class AdminStoreServiceUnitTest {
                     BbangleException ex = (BbangleException) e;
                     assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.NOT_FOUND_REQUEST);
                 });
+        }
+    }
+
+    @Nested
+    @DisplayName("getRegisteredStores() 테스트")
+    class GetRegisteredStoresTest {
+
+        @Test
+        @DisplayName("등록된 스토어 목록을 페이징 형태로 반환한다")
+        void success_getRegisteredStores() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            Store store = StoreFixture.withId(StoreFixture.defaultStore(), 1L);
+            Seller seller = SellerFixture.defaultSeller("홍길동", store);
+            Page<Store> storePage = new PageImpl<>(List.of(store), pageable, 1);
+
+            given(storeRepository.findByIsDeletedFalse(pageable)).willReturn(storePage);
+            given(sellerRepository.findByStoreIdIn(List.of(1L))).willReturn(List.of(seller));
+
+            // when
+            Page<RegisteredStoreInfo> result = adminStoreService.getRegisteredStores(pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            RegisteredStoreInfo info = result.getContent().get(0);
+            assertThat(info.storeId()).isEqualTo(1L);
+            assertThat(info.storeName()).isEqualTo(DEFAULT_STORE_NAME);
+            assertThat(info.businessNumber()).isEqualTo(DEFAULT_IDENTIFIER);
+            assertThat(info.sellerName()).isEqualTo("홍길동");
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            then(storeRepository).should().findByIsDeletedFalse(pageable);
+            then(sellerRepository).should().findByStoreIdIn(List.of(1L));
+        }
+
+        @Test
+        @DisplayName("등록된 스토어가 없으면 빈 Page를 반환한다")
+        void emptyResult_getRegisteredStores() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            Page<Store> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+            given(storeRepository.findByIsDeletedFalse(pageable)).willReturn(emptyPage);
+            given(sellerRepository.findByStoreIdIn(List.of())).willReturn(List.of());
+
+            // when
+            Page<RegisteredStoreInfo> result = adminStoreService.getRegisteredStores(pageable);
+
+            // then
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.getTotalElements()).isZero();
+            then(storeRepository).should().findByIsDeletedFalse(pageable);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteStores() 테스트")
+    class DeleteStoresTest {
+
+        @Test
+        @DisplayName("모든 storeId가 유효하면 소프트 딜리트한다")
+        void success_deleteStores() {
+            // given
+            List<Long> storeIds = List.of(1L, 2L, 3L);
+            given(storeRepository.countByIdInAndIsDeletedFalse(storeIds)).willReturn(3L);
+
+            // when
+            adminStoreService.deleteStores(storeIds);
+
+            // then
+            then(storeRepository).should().countByIdInAndIsDeletedFalse(storeIds);
+            then(storeRepository).should().softDeleteByIds(storeIds);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 storeId가 포함되면 STORE_NOT_FOUND 예외가 발생한다")
+        void fail_deleteStores_notFound() {
+            // given
+            List<Long> storeIds = List.of(1L, 2L, 999L);
+            given(storeRepository.countByIdInAndIsDeletedFalse(storeIds)).willReturn(2L);
+
+            // when & then
+            assertThatThrownBy(() -> adminStoreService.deleteStores(storeIds))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.STORE_NOT_FOUND);
+                });
+
+            then(storeRepository).should().countByIdInAndIsDeletedFalse(storeIds);
+            then(storeRepository).should(never()).softDeleteByIds(any());
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceUnitTest.java
@@ -726,7 +726,7 @@ class AdminStoreServiceUnitTest {
     class DeleteStoresTest {
 
         @Test
-        @DisplayName("모든 storeId가 유효하면 seller 관계를 끊고 hard delete한다")
+        @DisplayName("모든 storeId가 유효하면 seller 관계를 끊고 상태를 NEW로 변경한 뒤 hard delete한다")
         void success_deleteStores() {
             // given
             List<Long> storeIds = List.of(1L, 2L, 3L);
@@ -737,7 +737,7 @@ class AdminStoreServiceUnitTest {
 
             // then
             then(storeRepository).should().countByIdIn(storeIds);
-            then(sellerRepository).should().clearStoreByStoreIdIn(storeIds);
+            then(sellerRepository).should().clearStoreAndResetStatusByStoreIdIn(storeIds, CertificationStatus.NEW);
             then(storeRepository).should().deleteAllByIdInBatch(storeIds);
         }
 
@@ -757,7 +757,7 @@ class AdminStoreServiceUnitTest {
                 });
 
             then(storeRepository).should().countByIdIn(storeIds);
-            then(sellerRepository).should(never()).clearStoreByStoreIdIn(any());
+            then(sellerRepository).should(never()).clearStoreAndResetStatusByStoreIdIn(any(), any());
             then(storeRepository).should(never()).deleteAllByIdInBatch(any());
         }
     }

--- a/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceUnitTest.java
@@ -685,11 +685,9 @@ class AdminStoreServiceUnitTest {
             // given
             Pageable pageable = PageRequest.of(0, 20);
             Store store = StoreFixture.withId(StoreFixture.defaultStore(), 1L);
-            Seller seller = SellerFixture.defaultSeller("홍길동", store);
             Page<Store> storePage = new PageImpl<>(List.of(store), pageable, 1);
 
             given(storeRepository.findByIsDeletedFalse(pageable)).willReturn(storePage);
-            given(sellerRepository.findByStoreIdIn(List.of(1L))).willReturn(List.of(seller));
 
             // when
             Page<RegisteredStoreInfo> result = adminStoreService.getRegisteredStores(pageable);
@@ -700,10 +698,8 @@ class AdminStoreServiceUnitTest {
             assertThat(info.storeId()).isEqualTo(1L);
             assertThat(info.storeName()).isEqualTo(DEFAULT_STORE_NAME);
             assertThat(info.businessNumber()).isEqualTo(DEFAULT_IDENTIFIER);
-            assertThat(info.sellerName()).isEqualTo("홍길동");
             assertThat(result.getTotalElements()).isEqualTo(1);
             then(storeRepository).should().findByIsDeletedFalse(pageable);
-            then(sellerRepository).should().findByStoreIdIn(List.of(1L));
         }
 
         @Test
@@ -714,7 +710,6 @@ class AdminStoreServiceUnitTest {
             Page<Store> emptyPage = new PageImpl<>(List.of(), pageable, 0);
 
             given(storeRepository.findByIsDeletedFalse(pageable)).willReturn(emptyPage);
-            given(sellerRepository.findByStoreIdIn(List.of())).willReturn(List.of());
 
             // when
             Page<RegisteredStoreInfo> result = adminStoreService.getRegisteredStores(pageable);


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->

## 🚀 Major Changes & Explanations

* [feat] GET /api/v1/admin/stores/registered — 등록된 스토어 목록 조회
  - `StoreRepository.findByIsDeletedFalse(Pageable)` 추가
  - `SellerRepository.findByStoreIdIn(List<Long>)` 배치 조회 추가 (N+1 방지)
  - `RegisteredStoreInfo` 서비스 모델 추가 (Seller 객체 기반 매핑)
  - `BbanglePageResponse` 패턴 적용

* [feat] DELETE /api/v1/admin/stores — 스토어 다중 소프트 딜리트
  - `StoreRepository.countByIdInAndIsDeletedFalse`, `softDeleteByIds` 추가
  - 존재하지 않는 storeId 포함 시 `STORE_NOT_FOUND` 예외 처리

* [test] AdminStoreServiceUnitTest — getRegisteredStores / deleteStores
  - 목록 정상 조회, 빈 결과, seller 배치 로드 검증
  - 전체 storeId 유효 시 소프트 딜리트 / 존재하지 않는 ID 포함 시 예외

* [test] AdminStoreControllerTest — getRegisteredStores / deleteStores
  - 페이징 응답 JSON 검증, 빈 목록, 삭제 성공, 에러 응답, 권한 없음 401 검증

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 등록된 매장 목록 조회(페이지네이션) 추가 — 매장 상세(사업자번호, 소개, 연락처, 이메일, 주소 등) 확인 가능.
  * 관리자용 다중 매장 삭제(일괄 삭제) 추가 — 삭제 시 연관 판매자 연결 해제 및 인증 상태 초기화 적용; 존재하지 않는 매장 ID 입력 시 오류 반환.

* **테스트**
  * 신규 API의 성공·실패·권한 관련 동작을 검증하는 단위 및 컨트롤러 테스트 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eco-dessert-platform/backend/pull/692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->