### PR TITLE
[Feat] 교환 요청 승인 / 거절 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/claim/repository/ExchangeRequestRepository.java
+++ b/src/main/java/com/bbangle/bbangle/claim/repository/ExchangeRequestRepository.java
@@ -1,7 +1,14 @@
 package com.bbangle.bbangle.claim.repository;
 
 import com.bbangle.bbangle.claim.domain.ExchangeRequest;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 public interface ExchangeRequestRepository extends JpaRepository<ExchangeRequest, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<ExchangeRequest> findWithLockById(Long id);
+
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerExchangeController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerExchangeController.java
@@ -1,0 +1,35 @@
+package com.bbangle.bbangle.claim.seller.controller;
+
+import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeDecisionRequest;
+import com.bbangle.bbangle.claim.seller.controller.swagger.SellerExchangeApi;
+import com.bbangle.bbangle.claim.seller.service.SellerExchangeService;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.SellerApiPath;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping(SellerApiPath.PREFIX + "/exchanges")
+@RestController
+public class SellerExchangeController implements SellerExchangeApi {
+
+    private final ResponseService responseService;
+    private final SellerExchangeService sellerExchangeService;
+
+    @PostMapping("/{exchangeId}/process")
+    public CommonResult processExchange(
+        @PathVariable Long exchangeId,
+        @Valid @RequestBody ExchangeDecisionRequest request,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        sellerExchangeService.processExchange(exchangeId, sellerId, request.decisionType(), request.reason());
+        return responseService.getSuccessResult();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ExchangeDecisionRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ExchangeDecisionRequest.java
@@ -1,0 +1,18 @@
+package com.bbangle.bbangle.claim.seller.controller.dto;
+
+import com.bbangle.bbangle.claim.domain.constant.DecisionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "교환 요청 승인/거절 처리 DTO")
+public record ExchangeDecisionRequest(
+
+    @Schema(description = "처리 유형", example = "APPROVE", allowableValues = {"APPROVE", "REJECT"})
+    @NotNull
+    DecisionType decisionType,
+
+    @Schema(description = "처리 사유", example = "교환 승인", maxLength = 500)
+    String reason
+
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerExchangeApi.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerExchangeApi.java
@@ -1,0 +1,22 @@
+package com.bbangle.bbangle.claim.seller.controller.swagger;
+
+import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeDecisionRequest;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Exchange", description = "(셀러) 교환 관리 API")
+public interface SellerExchangeApi {
+
+    @Operation(
+        summary = "교환 요청 승인/거절",
+        description = "REQUESTED 상태의 교환 요청에 대해 승인(APPROVE) 또는 거절(REJECT) 처리를 수행한다. "
+            + "거절 시 reason은 ExchangeRequest의 sellerComment 필드에 저장된다."
+    )
+    CommonResult processExchange(
+        @Parameter(description = "교환 요청 ID") Long exchangeId,
+        ExchangeDecisionRequest request,
+        @Parameter(hidden = true) Long sellerId
+    );
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeService.java
@@ -1,7 +1,9 @@
 package com.bbangle.bbangle.claim.seller.service;
 
 import com.bbangle.bbangle.claim.domain.ExchangeRequest;
+import com.bbangle.bbangle.claim.domain.constant.DecisionType;
 import com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus;
+import com.bbangle.bbangle.claim.repository.ClaimRepository;
 import com.bbangle.bbangle.claim.repository.ExchangeRequestRepository;
 import com.bbangle.bbangle.claim.seller.service.model.ExchangeCreateCommand;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
@@ -29,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SellerExchangeService {
 
     private final ExchangeRequestRepository exchangeRequestRepository;
+    private final ClaimRepository claimRepository;
     private final OrderItemHistoryRepository orderItemHistoryRepository;
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
@@ -106,6 +109,36 @@ public class SellerExchangeService {
         );
 
         return ExchangeCreateResponse.of(content);
+    }
+
+    @Transactional
+    public void processExchange(Long exchangeId, Long sellerId, DecisionType decisionType, String reason) {
+        if (!claimRepository.existsClaimRequestBySeller(exchangeId, sellerId)) {
+            throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+        }
+
+        ExchangeRequest exchangeRequest = findExchangeRequestWithLock(exchangeId);
+        applyDecision(exchangeRequest, decisionType, reason);
+    }
+
+    private ExchangeRequest findExchangeRequestWithLock(Long exchangeId) {
+        return exchangeRequestRepository.findWithLockById(exchangeId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.CLAIM_NOT_FOUND));
+    }
+
+    private void applyDecision(ExchangeRequest exchangeRequest, DecisionType decisionType, String reason) {
+        OrderItem orderItem = exchangeRequest.getOrderItem();
+        switch (decisionType) {
+            case APPROVE -> {
+                exchangeRequest.approve(reason);
+                orderItem.exchangeApprove();
+            }
+            case REJECT -> {
+                exchangeRequest.reject(reason);
+                orderItem.exchangeReject();
+            }
+        }
+        orderItemHistoryRepository.save(OrderItemHistory.create(orderItem));
     }
 
     private Long getStoreIdOrThrow(Long sellerId) {

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -192,4 +192,18 @@ public class OrderItem extends BaseEntity {
         }
         this.orderStatus = OrderStatus.RETURN_COMPLETED;
     }
+
+    public void exchangeApprove() {
+        if (orderStatus != OrderStatus.EXCHANGE_REQUEST) {
+            throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
+        }
+        this.orderStatus = OrderStatus.EXCHANGE_APPROVED;
+    }
+
+    public void exchangeReject() {
+        if (orderStatus != OrderStatus.EXCHANGE_REQUEST) {
+            throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
+        }
+        this.orderStatus = OrderStatus.EXCHANGE_REJECTED;
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
@@ -1,0 +1,197 @@
+package com.bbangle.bbangle.claim.seller.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.bbangle.bbangle.claim.domain.ExchangeRequest;
+import com.bbangle.bbangle.claim.domain.constant.DecisionType;
+import com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus;
+import com.bbangle.bbangle.claim.repository.ClaimRepository;
+import com.bbangle.bbangle.claim.repository.ExchangeRequestRepository;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.claim.ExchangeRequestFixture;
+import com.bbangle.bbangle.fixture.order.OrderItemFixture;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.OrderItemHistory;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[단위 테스트] SellerExchangeService - processExchange()")
+@ExtendWith(MockitoExtension.class)
+class SellerExchangeServiceProcessTest {
+
+    @InjectMocks
+    private SellerExchangeService sut;
+
+    @Mock
+    private ExchangeRequestRepository exchangeRequestRepository;
+
+    @Mock
+    private ClaimRepository claimRepository;
+
+    @Mock
+    private OrderItemHistoryRepository orderItemHistoryRepository;
+
+    @Nested
+    @DisplayName("APPROVE 시나리오")
+    class ApproveTests {
+
+        private static final Long EXCHANGE_ID = 1L;
+        private static final Long SELLER_ID = 10L;
+        private static final String REASON = "교환 승인";
+
+        @Test
+        @DisplayName("성공 - REQUESTED 상태의 교환 건에 대해 승인 처리 시 상태가 APPROVED로 전이되고 OrderItemHistory가 저장된다")
+        void processExchange_approve_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_REQUEST);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.requested(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when
+            sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.APPROVE, REASON);
+
+            // then
+            assertThat(exchangeRequest.getStatus()).isEqualTo(ExchangeRequestStatus.APPROVED);
+            assertThat(exchangeRequest.getSellerComment()).isEqualTo(REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.EXCHANGE_APPROVED);
+            then(exchangeRequestRepository).should(times(1)).findWithLockById(EXCHANGE_ID);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("실패 (권한) - 타 판매자의 교환 건에 접근 시 SELLER_CLAIM_MISMATCH 예외가 발생하고 이후 로직은 실행되지 않는다")
+        void processExchange_approve_fails_when_seller_mismatch() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.APPROVE, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+
+            then(exchangeRequestRepository).should(never()).findWithLockById(any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 (상태) - 이미 APPROVED 처리된 교환 건에 대해 승인 시도 시 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void processExchange_approve_fails_when_already_approved() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_APPROVED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.approved(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.APPROVE, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 (상태) - 이미 REJECTED 처리된 교환 건에 대해 승인 시도 시 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void processExchange_approve_fails_when_already_rejected() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_REJECTED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.rejected(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.APPROVE, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("REJECT 시나리오")
+    class RejectTests {
+
+        private static final Long EXCHANGE_ID = 2L;
+        private static final Long SELLER_ID = 10L;
+        private static final String REASON = "교환 거절 사유";
+
+        @Test
+        @DisplayName("성공 - REQUESTED 상태의 교환 건에 대해 거절 처리 시 상태가 REJECTED로 전이되고 OrderItemHistory가 저장된다")
+        void processExchange_reject_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_REQUEST);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.requested(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when
+            sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.REJECT, REASON);
+
+            // then
+            assertThat(exchangeRequest.getStatus()).isEqualTo(ExchangeRequestStatus.REJECTED);
+            assertThat(exchangeRequest.getSellerComment()).isEqualTo(REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.EXCHANGE_REJECTED);
+            then(exchangeRequestRepository).should(times(1)).findWithLockById(EXCHANGE_ID);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 APPROVED 처리된 교환 건에 대해 거절 시도 시 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void processExchange_reject_fails_when_already_approved() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_APPROVED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.approved(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.REJECT, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 exchangeId로 요청하면 CLAIM_NOT_FOUND 예외가 발생한다")
+        void processExchange_reject_fails_when_claim_not_found() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.REJECT, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_NOT_FOUND);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/fixture/claim/ExchangeRequestFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/claim/ExchangeRequestFixture.java
@@ -1,0 +1,38 @@
+package com.bbangle.bbangle.fixture.claim;
+
+import com.bbangle.bbangle.claim.domain.ExchangeRequest;
+import com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ExchangeRequestFixture {
+
+    private ExchangeRequestFixture() {
+    }
+
+    public static ExchangeRequest withStatus(ExchangeRequestStatus status, OrderItem orderItem) {
+        return ExchangeRequest.builder()
+            .orderItem(orderItem)
+            .detailReason("테스트 사유")
+            .decidedAt(null)
+            .status(status)
+            .build();
+    }
+
+    public static ExchangeRequest requested(OrderItem orderItem) {
+        return withStatus(ExchangeRequestStatus.REQUESTED, orderItem);
+    }
+
+    public static ExchangeRequest approved(OrderItem orderItem) {
+        return withStatus(ExchangeRequestStatus.APPROVED, orderItem);
+    }
+
+    public static ExchangeRequest rejected(OrderItem orderItem) {
+        return withStatus(ExchangeRequestStatus.REJECTED, orderItem);
+    }
+
+    public static ExchangeRequest withId(ExchangeRequest er, Long id) {
+        ReflectionTestUtils.setField(er, "id", id);
+        return er;
+    }
+}


### PR DESCRIPTION
## History

* Resolves #517 #518 

## 🚀 Major Changes & Explanations

- **교환 요청 처리 단일 API 구현 (POST `/api/v1/seller/exchanges/{exchangeId}/process`)**
    - 승인과 거절 엔드포인트를 따로 분리하지 않고, 팀 내 DTO 컨벤션에 맞춰 `DecisionType(APPROVE/REJECT)`에 따라 동적으로 분기 처리하도록 단일 API로 통합 구현
- **기존 `OrderItemHistory` 테이블 스키마 준수**
    - 리뷰어 피드백(추적성 강화) 내용을 검토하였으나, 공통 DB 스키마 유지 및 타 파트 영향을 고려하여 기존 구조 `[id, order_item_id, order_status, created_at]`를 그대로 유지
    - 필드 변경 없이 상태 전이 시점에 기존 `OrderItemHistory.create(orderItem)` 메서드만 호출, 실시간 이력을 트랜잭션 내에서 기록
- **Service Unit Test 작성**
    - **APPROVE 시나리오**: 정상 상태 전이 검증 / 권한 미일치 예외 검증 / 잘못된 상태 전이 시 `CLAIM_INVALID_STATUS` 예외 검증을 완료
    - **REJECT 시나리오**: 거절 사유(`reason`)를 입력받아 거절 상태로 안전하게 전이되는지 및 예외 케이스 테스트를 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* 판매자가 교환 요청을 승인 또는 거절할 수 있는 기능이 추가되었습니다. 교환 요청 처리 시 거절 사유를 입력할 수 있으며, 처리 결과에 따라 주문 상태가 자동으로 업데이트됩니다.

**Tests**
* 교환 요청 처리 로직의 성공 및 실패 시나리오를 검증하는 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eco-dessert-platform/backend/pull/695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->