### PR TITLE
[Feat] 교환 승인 후 운송장 수정 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/claim/domain/ClaimDelivery.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ClaimDelivery.java
@@ -72,6 +72,15 @@ public class ClaimDelivery extends BaseEntity {
             ClaimShippingStatus.IN_TRANSIT
         );
     }
+
+    public static ClaimDelivery createExchangeRedelivery(Claim claim, CourierCompany courierCode, String trackingNumber) {
+        return new ClaimDelivery(
+            claim,
+            ClaimDeliveryType.EXCHANGE_REDELIVERY,
+            Shipping.scheduled(courierCode.getDisplayName(), trackingNumber),
+            ClaimShippingStatus.IN_TRANSIT
+        );
+    }
     
     public void updateInvoice(CourierCompany courierCode, String trackingNumber) {
         this.shipping.modifyShippingInfo(courierCode.getDisplayName(), trackingNumber);

--- a/src/main/java/com/bbangle/bbangle/claim/domain/ExchangeRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ExchangeRequest.java
@@ -71,4 +71,10 @@ public class ExchangeRequest extends Claim {
         }
         this.status = RESHIPPED;
     }
+
+    public void validateReshipped() {
+        if (this.status != RESHIPPED) {
+            throw new BbangleException(BbangleErrorCode.DELIVERY_MODIFY_NOT_ALLOWED);
+        }
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/claim/domain/ExchangeRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ExchangeRequest.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.claim.domain;
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.APPROVED;
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.REJECTED;
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.REQUESTED;
+import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.RESHIPPED;
 
 import com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
@@ -62,5 +63,12 @@ public class ExchangeRequest extends Claim {
         this.status = REJECTED;
         this.sellerComment = reason;
         super.decide();
+    }
+
+    public void startRedelivery() {
+        if (status != APPROVED) {
+            throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
+        }
+        this.status = RESHIPPED;
     }
 }

--- a/src/main/java/com/bbangle/bbangle/claim/repository/ExchangeRequestRepository.java
+++ b/src/main/java/com/bbangle/bbangle/claim/repository/ExchangeRequestRepository.java
@@ -1,7 +1,14 @@
 package com.bbangle.bbangle.claim.repository;
 
 import com.bbangle.bbangle.claim.domain.ExchangeRequest;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 public interface ExchangeRequestRepository extends JpaRepository<ExchangeRequest, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<ExchangeRequest> findWithLockById(Long id);
+
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerExchangeController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerExchangeController.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.claim.seller.controller;
 
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeDecisionRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.swagger.SellerExchangeApi;
 import com.bbangle.bbangle.claim.seller.service.SellerExchangeService;
 import com.bbangle.bbangle.common.dto.CommonResult;
@@ -9,6 +10,7 @@ import com.bbangle.bbangle.config.security.SellerApiPath;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,6 +32,16 @@ public class SellerExchangeController implements SellerExchangeApi {
         @AuthenticationPrincipal Long sellerId
     ) {
         sellerExchangeService.processExchange(exchangeId, sellerId, request.decisionType(), request.reason());
+        return responseService.getSuccessResult();
+    }
+
+    @PatchMapping("/{exchangeId}/invoice")
+    public CommonResult registerExchangeInvoice(
+        @PathVariable Long exchangeId,
+        @Valid @RequestBody ExchangeInvoiceRequest request,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        sellerExchangeService.registerExchangeInvoice(exchangeId, sellerId, request.courierCode(), request.trackingNumber());
         return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerExchangeController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerExchangeController.java
@@ -1,0 +1,35 @@
+package com.bbangle.bbangle.claim.seller.controller;
+
+import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeDecisionRequest;
+import com.bbangle.bbangle.claim.seller.controller.swagger.SellerExchangeApi;
+import com.bbangle.bbangle.claim.seller.service.SellerExchangeService;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.SellerApiPath;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping(SellerApiPath.PREFIX + "/exchanges")
+@RestController
+public class SellerExchangeController implements SellerExchangeApi {
+
+    private final ResponseService responseService;
+    private final SellerExchangeService sellerExchangeService;
+
+    @PostMapping("/{exchangeId}/process")
+    public CommonResult processExchange(
+        @PathVariable Long exchangeId,
+        @Valid @RequestBody ExchangeDecisionRequest request,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        sellerExchangeService.processExchange(exchangeId, sellerId, request.decisionType(), request.reason());
+        return responseService.getSuccessResult();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerExchangeController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerExchangeController.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.claim.seller.controller;
 
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeDecisionRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceUpdateRequest;
 import com.bbangle.bbangle.claim.seller.controller.swagger.SellerExchangeApi;
 import com.bbangle.bbangle.claim.seller.service.SellerExchangeService;
 import com.bbangle.bbangle.common.dto.CommonResult;
@@ -13,6 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,6 +44,16 @@ public class SellerExchangeController implements SellerExchangeApi {
         @AuthenticationPrincipal Long sellerId
     ) {
         sellerExchangeService.registerExchangeInvoice(exchangeId, sellerId, request.courierCode(), request.trackingNumber());
+        return responseService.getSuccessResult();
+    }
+
+    @PutMapping("/{exchangeId}/invoice")
+    public CommonResult updateExchangeInvoice(
+        @PathVariable Long exchangeId,
+        @Valid @RequestBody ExchangeInvoiceUpdateRequest request,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        sellerExchangeService.updateExchangeInvoice(exchangeId, sellerId, request.courierCode(), request.trackingNumber());
         return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ExchangeDecisionRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ExchangeDecisionRequest.java
@@ -1,0 +1,18 @@
+package com.bbangle.bbangle.claim.seller.controller.dto;
+
+import com.bbangle.bbangle.claim.domain.constant.DecisionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "교환 요청 승인/거절 처리 DTO")
+public record ExchangeDecisionRequest(
+
+    @Schema(description = "처리 유형", example = "APPROVE", allowableValues = {"APPROVE", "REJECT"})
+    @NotNull
+    DecisionType decisionType,
+
+    @Schema(description = "처리 사유", example = "교환 승인", maxLength = 500)
+    String reason
+
+) {
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ExchangeInvoiceRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ExchangeInvoiceRequest.java
@@ -1,0 +1,29 @@
+package com.bbangle.bbangle.claim.seller.controller.dto;
+
+import com.bbangle.bbangle.order.domain.model.CourierCompany;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "교환 재배송 운송장 입력 요청 DTO")
+public record ExchangeInvoiceRequest(
+
+    @Schema(description = "택배사 코드", example = "CJ_LOGISTICS")
+    @NotNull(message = "택배사 코드는 필수입니다.")
+    CourierCompany courierCode,
+
+    @Schema(description = "운송장 번호 (10~14자리 숫자)", example = "1234567890", maxLength = 100)
+    @NotBlank(message = "운송장 번호는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{10,14}$", message = "운송장 번호는 10~14자리 숫자여야 합니다.")
+    String trackingNumber
+
+) {
+
+    @Schema(hidden = true)
+    @AssertTrue(message = "유효한 택배사 코드를 입력해야 합니다. NONE은 허용되지 않습니다.")
+    public boolean isCourierCodeValid() {
+        return courierCode != null && courierCode != CourierCompany.NONE;
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ExchangeInvoiceUpdateRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ExchangeInvoiceUpdateRequest.java
@@ -1,0 +1,34 @@
+package com.bbangle.bbangle.claim.seller.controller.dto;
+
+import com.bbangle.bbangle.order.domain.model.CourierCompany;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "교환 재배송 운송장 수정 요청 DTO")
+public record ExchangeInvoiceUpdateRequest(
+
+    @Schema(description = "수정할 택배사 코드", example = "CJ_LOGISTICS")
+    @NotNull(message = "택배사 코드는 필수입니다.")
+    CourierCompany courierCode,
+
+    @Schema(description = "수정할 운송장 번호 (10~14자리 숫자)", example = "9876543210", maxLength = 100)
+    @NotBlank(message = "운송장 번호는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{10,14}$", message = "운송장 번호는 10~14자리 숫자여야 합니다.")
+    String trackingNumber,
+
+    @Schema(description = "수정 사유", example = "오입력으로 인한 운송장 재등록", maxLength = 500)
+    @Size(max = 500)
+    String reason
+
+) {
+
+    @Schema(hidden = true)
+    @AssertTrue(message = "유효한 택배사 코드를 입력해야 합니다. NONE은 허용되지 않습니다.")
+    public boolean isCourierCodeValid() {
+        return courierCode != null && courierCode != CourierCompany.NONE;
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerExchangeApi.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerExchangeApi.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.claim.seller.controller.swagger;
 
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeDecisionRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceRequest;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -17,6 +18,17 @@ public interface SellerExchangeApi {
     CommonResult processExchange(
         @Parameter(description = "교환 요청 ID") Long exchangeId,
         ExchangeDecisionRequest request,
+        @Parameter(hidden = true) Long sellerId
+    );
+
+    @Operation(
+        summary = "교환 재배송 운송장 입력",
+        description = "APPROVED 상태의 교환 건에 재배송 택배사 코드와 운송장 번호를 등록하고, "
+            + "상태를 교환 상품 발송(EXCHANGE_ITEM_SHIPPED)으로 변경한다."
+    )
+    CommonResult registerExchangeInvoice(
+        @Parameter(description = "교환 요청 ID") Long exchangeId,
+        ExchangeInvoiceRequest request,
         @Parameter(hidden = true) Long sellerId
     );
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerExchangeApi.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerExchangeApi.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.claim.seller.controller.swagger;
 
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeDecisionRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceUpdateRequest;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -29,6 +30,17 @@ public interface SellerExchangeApi {
     CommonResult registerExchangeInvoice(
         @Parameter(description = "교환 요청 ID") Long exchangeId,
         ExchangeInvoiceRequest request,
+        @Parameter(hidden = true) Long sellerId
+    );
+
+    @Operation(
+        summary = "교환 재배송 운송장 수정",
+        description = "운송장 등록 완료(RESHIPPED) 상태일 때만 택배사 코드와 운송장 번호를 수정할 수 있다. "
+            + "수정 사유(reason)가 제공된 경우 교환 엔티티의 코멘트 필드에 기록된다."
+    )
+    CommonResult updateExchangeInvoice(
+        @Parameter(description = "교환 요청 ID") Long exchangeId,
+        ExchangeInvoiceUpdateRequest request,
         @Parameter(hidden = true) Long sellerId
     );
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerExchangeApi.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerExchangeApi.java
@@ -1,0 +1,22 @@
+package com.bbangle.bbangle.claim.seller.controller.swagger;
+
+import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeDecisionRequest;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Exchange", description = "(셀러) 교환 관리 API")
+public interface SellerExchangeApi {
+
+    @Operation(
+        summary = "교환 요청 승인/거절",
+        description = "REQUESTED 상태의 교환 요청에 대해 승인(APPROVE) 또는 거절(REJECT) 처리를 수행한다. "
+            + "거절 시 reason은 ExchangeRequest의 sellerComment 필드에 저장된다."
+    )
+    CommonResult processExchange(
+        @Parameter(description = "교환 요청 ID") Long exchangeId,
+        ExchangeDecisionRequest request,
+        @Parameter(hidden = true) Long sellerId
+    );
+}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeService.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.claim.seller.service;
 
 import com.bbangle.bbangle.claim.domain.ClaimDelivery;
 import com.bbangle.bbangle.claim.domain.ExchangeRequest;
+import com.bbangle.bbangle.claim.domain.constant.ClaimDeliveryType;
 import com.bbangle.bbangle.claim.domain.constant.DecisionType;
 import com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus;
 import com.bbangle.bbangle.claim.repository.ClaimDeliveryRepository;
@@ -141,6 +142,24 @@ public class SellerExchangeService {
         claimDeliveryRepository.save(claimDelivery);
 
         orderItemHistoryRepository.save(OrderItemHistory.create(orderItem));
+    }
+
+    @Transactional
+    public void updateExchangeInvoice(Long exchangeId, Long sellerId, CourierCompany courierCode, String trackingNumber) {
+        if (!claimRepository.existsClaimRequestBySeller(exchangeId, sellerId)) {
+            throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+        }
+
+        ExchangeRequest exchangeRequest = findExchangeRequestWithLock(exchangeId);
+        exchangeRequest.validateReshipped();
+
+        ClaimDelivery claimDelivery = claimDeliveryRepository
+            .findByClaimIdAndDeliveryType(exchangeId, ClaimDeliveryType.EXCHANGE_REDELIVERY)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.DELIVERY_NOT_FOUND));
+
+        claimDelivery.updateInvoice(courierCode, trackingNumber);
+
+        orderItemHistoryRepository.save(OrderItemHistory.create(exchangeRequest.getOrderItem()));
     }
 
     private ExchangeRequest findExchangeRequestWithLock(Long exchangeId) {

--- a/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeService.java
@@ -1,7 +1,9 @@
 package com.bbangle.bbangle.claim.seller.service;
 
 import com.bbangle.bbangle.claim.domain.ExchangeRequest;
+import com.bbangle.bbangle.claim.domain.constant.DecisionType;
 import com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus;
+import com.bbangle.bbangle.claim.repository.ClaimRepository;
 import com.bbangle.bbangle.claim.repository.ExchangeRequestRepository;
 import com.bbangle.bbangle.claim.seller.service.model.ExchangeCreateCommand;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
@@ -29,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SellerExchangeService {
 
     private final ExchangeRequestRepository exchangeRequestRepository;
+    private final ClaimRepository claimRepository;
     private final OrderItemHistoryRepository orderItemHistoryRepository;
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
@@ -106,6 +109,36 @@ public class SellerExchangeService {
         );
 
         return ExchangeCreateResponse.of(content);
+    }
+
+    @Transactional
+    public void processExchange(Long exchangeId, Long sellerId, DecisionType decisionType, String reason) {
+        if (!claimRepository.existsClaimRequestBySeller(exchangeId, sellerId)) {
+            throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+        }
+
+        ExchangeRequest exchangeRequest = findExchangeRequestWithLock(exchangeId);
+        applyDecision(exchangeRequest, decisionType, reason);
+    }
+
+    private ExchangeRequest findExchangeRequestWithLock(Long exchangeId) {
+        return exchangeRequestRepository.findWithLockById(exchangeId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.CLAIM_NOT_FOUND));
+    }
+
+    private void applyDecision(ExchangeRequest exchangeRequest, DecisionType decisionType, String reason) {
+        OrderItem orderItem = exchangeRequest.getOrderItem();
+        switch (decisionType) {
+            case APPROVE -> {
+                exchangeRequest.approve(reason);
+                orderItem.exchangeApprove();
+            }
+            case REJECT -> {
+                exchangeRequest.reject(reason);
+                orderItem.exchangeReject();
+            }
+        }
+        orderItemHistoryRepository.save(OrderItemHistory.create(orderItem));
     }
 
     private Long getStoreIdOrThrow(Long sellerId) {

--- a/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeService.java
@@ -1,8 +1,10 @@
 package com.bbangle.bbangle.claim.seller.service;
 
+import com.bbangle.bbangle.claim.domain.ClaimDelivery;
 import com.bbangle.bbangle.claim.domain.ExchangeRequest;
 import com.bbangle.bbangle.claim.domain.constant.DecisionType;
 import com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus;
+import com.bbangle.bbangle.claim.repository.ClaimDeliveryRepository;
 import com.bbangle.bbangle.claim.repository.ClaimRepository;
 import com.bbangle.bbangle.claim.repository.ExchangeRequestRepository;
 import com.bbangle.bbangle.claim.seller.service.model.ExchangeCreateCommand;
@@ -11,6 +13,7 @@ import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.order.domain.Order;
 import com.bbangle.bbangle.order.domain.OrderItem;
 import com.bbangle.bbangle.order.domain.OrderItemHistory;
+import com.bbangle.bbangle.order.domain.model.CourierCompany;
 import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
 import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.order.repository.OrderRepository;
@@ -31,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SellerExchangeService {
 
     private final ExchangeRequestRepository exchangeRequestRepository;
+    private final ClaimDeliveryRepository claimDeliveryRepository;
     private final ClaimRepository claimRepository;
     private final OrderItemHistoryRepository orderItemHistoryRepository;
     private final OrderRepository orderRepository;
@@ -119,6 +123,24 @@ public class SellerExchangeService {
 
         ExchangeRequest exchangeRequest = findExchangeRequestWithLock(exchangeId);
         applyDecision(exchangeRequest, decisionType, reason);
+    }
+
+    @Transactional
+    public void registerExchangeInvoice(Long exchangeId, Long sellerId, CourierCompany courierCode, String trackingNumber) {
+        if (!claimRepository.existsClaimRequestBySeller(exchangeId, sellerId)) {
+            throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+        }
+
+        ExchangeRequest exchangeRequest = findExchangeRequestWithLock(exchangeId);
+        exchangeRequest.startRedelivery();
+
+        OrderItem orderItem = exchangeRequest.getOrderItem();
+        orderItem.exchangeItemShipped();
+
+        ClaimDelivery claimDelivery = ClaimDelivery.createExchangeRedelivery(exchangeRequest, courierCode, trackingNumber);
+        claimDeliveryRepository.save(claimDelivery);
+
+        orderItemHistoryRepository.save(OrderItemHistory.create(orderItem));
     }
 
     private ExchangeRequest findExchangeRequestWithLock(Long exchangeId) {

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -192,4 +192,18 @@ public class OrderItem extends BaseEntity {
         }
         this.orderStatus = OrderStatus.RETURN_COMPLETED;
     }
+
+    public void exchangeApprove() {
+        if (orderStatus != OrderStatus.EXCHANGE_REQUEST) {
+            throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
+        }
+        this.orderStatus = OrderStatus.EXCHANGE_APPROVED;
+    }
+
+    public void exchangeReject() {
+        if (orderStatus != OrderStatus.EXCHANGE_REQUEST) {
+            throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
+        }
+        this.orderStatus = OrderStatus.EXCHANGE_REJECTED;
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -206,4 +206,11 @@ public class OrderItem extends BaseEntity {
         }
         this.orderStatus = OrderStatus.EXCHANGE_REJECTED;
     }
+
+    public void exchangeItemShipped() {
+        if (orderStatus != OrderStatus.EXCHANGE_APPROVED) {
+            throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
+        }
+        this.orderStatus = OrderStatus.EXCHANGE_ITEM_SHIPPED;
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
@@ -19,6 +20,8 @@ import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.claim.ExchangeRequestFixture;
 import com.bbangle.bbangle.fixture.order.OrderItemFixture;
+import com.bbangle.bbangle.claim.domain.constant.ClaimDeliveryType;
+import com.bbangle.bbangle.delivery.domain.Shipping;
 import com.bbangle.bbangle.order.domain.OrderItem;
 import com.bbangle.bbangle.order.domain.OrderItemHistory;
 import com.bbangle.bbangle.order.domain.model.CourierCompany;
@@ -286,6 +289,121 @@ class SellerExchangeServiceProcessTest {
                 .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
 
             then(claimDeliveryRepository).should(never()).save(any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateExchangeInvoice() - 교환 재배송 운송장 수정")
+    class UpdateExchangeInvoiceTests {
+
+        private static final Long EXCHANGE_ID = 4L;
+        private static final Long SELLER_ID = 10L;
+        private static final CourierCompany NEW_COURIER = CourierCompany.LOTTE;
+        private static final String NEW_TRACKING_NUMBER = "9876543210";
+
+        @Test
+        @DisplayName("성공 - RESHIPPED 상태에서 운송장을 수정하면 ClaimDelivery가 갱신되고 OrderItemHistory가 저장된다")
+        void updateExchangeInvoice_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_ITEM_SHIPPED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.withStatus(ExchangeRequestStatus.RESHIPPED, orderItem);
+
+            ClaimDelivery mockDelivery = mock(ClaimDelivery.class);
+            Shipping mockShipping = mock(Shipping.class);
+            given(mockDelivery.getShipping()).willReturn(mockShipping);
+            given(mockShipping.getCourierName()).willReturn(NEW_COURIER.getDisplayName());
+            given(mockShipping.getTrackingNumber()).willReturn(NEW_TRACKING_NUMBER);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+            given(claimDeliveryRepository.findByClaimIdAndDeliveryType(EXCHANGE_ID, ClaimDeliveryType.EXCHANGE_REDELIVERY))
+                .willReturn(Optional.of(mockDelivery));
+
+            // when
+            sut.updateExchangeInvoice(EXCHANGE_ID, SELLER_ID, NEW_COURIER, NEW_TRACKING_NUMBER);
+
+            // then
+            then(mockDelivery).should(times(1)).updateInvoice(NEW_COURIER, NEW_TRACKING_NUMBER);
+            then(exchangeRequestRepository).should(times(1)).findWithLockById(EXCHANGE_ID);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("실패 (권한) - 타 판매자의 교환 건에 운송장 수정을 시도하면 SELLER_CLAIM_MISMATCH 예외가 발생하고 이후 로직은 실행되지 않는다")
+        void updateExchangeInvoice_fails_when_seller_mismatch() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateExchangeInvoice(EXCHANGE_ID, SELLER_ID, NEW_COURIER, NEW_TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+
+            then(exchangeRequestRepository).should(never()).findWithLockById(any());
+            then(claimDeliveryRepository).should(never()).findByClaimIdAndDeliveryType(any(), any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 (상태) - APPROVED 상태(운송장 미등록)에서 수정을 시도하면 DELIVERY_MODIFY_NOT_ALLOWED 예외가 발생한다")
+        void updateExchangeInvoice_fails_when_not_reshipped() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_APPROVED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.approved(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateExchangeInvoice(EXCHANGE_ID, SELLER_ID, NEW_COURIER, NEW_TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.DELIVERY_MODIFY_NOT_ALLOWED);
+
+            then(claimDeliveryRepository).should(never()).findByClaimIdAndDeliveryType(any(), any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 (상태) - REQUESTED 상태(미승인)에서 수정을 시도하면 DELIVERY_MODIFY_NOT_ALLOWED 예외가 발생한다")
+        void updateExchangeInvoice_fails_when_requested() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_REQUEST);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.requested(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateExchangeInvoice(EXCHANGE_ID, SELLER_ID, NEW_COURIER, NEW_TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.DELIVERY_MODIFY_NOT_ALLOWED);
+
+            then(claimDeliveryRepository).should(never()).findByClaimIdAndDeliveryType(any(), any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 - RESHIPPED 상태이지만 ClaimDelivery 레코드가 없으면 DELIVERY_NOT_FOUND 예외가 발생한다")
+        void updateExchangeInvoice_fails_when_delivery_not_found() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_ITEM_SHIPPED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.withStatus(ExchangeRequestStatus.RESHIPPED, orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+            given(claimDeliveryRepository.findByClaimIdAndDeliveryType(EXCHANGE_ID, ClaimDeliveryType.EXCHANGE_REDELIVERY))
+                .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateExchangeInvoice(EXCHANGE_ID, SELLER_ID, NEW_COURIER, NEW_TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.DELIVERY_NOT_FOUND);
+
             then(orderItemHistoryRepository).should(never()).save(any());
         }
     }

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
@@ -8,9 +8,11 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
+import com.bbangle.bbangle.claim.domain.ClaimDelivery;
 import com.bbangle.bbangle.claim.domain.ExchangeRequest;
 import com.bbangle.bbangle.claim.domain.constant.DecisionType;
 import com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus;
+import com.bbangle.bbangle.claim.repository.ClaimDeliveryRepository;
 import com.bbangle.bbangle.claim.repository.ClaimRepository;
 import com.bbangle.bbangle.claim.repository.ExchangeRequestRepository;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
@@ -19,6 +21,7 @@ import com.bbangle.bbangle.fixture.claim.ExchangeRequestFixture;
 import com.bbangle.bbangle.fixture.order.OrderItemFixture;
 import com.bbangle.bbangle.order.domain.OrderItem;
 import com.bbangle.bbangle.order.domain.OrderItemHistory;
+import com.bbangle.bbangle.order.domain.model.CourierCompany;
 import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
 import java.util.Optional;
@@ -42,6 +45,9 @@ class SellerExchangeServiceProcessTest {
 
     @Mock
     private ClaimRepository claimRepository;
+
+    @Mock
+    private ClaimDeliveryRepository claimDeliveryRepository;
 
     @Mock
     private OrderItemHistoryRepository orderItemHistoryRepository;
@@ -191,6 +197,95 @@ class SellerExchangeServiceProcessTest {
                 .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
                 .isEqualTo(BbangleErrorCode.CLAIM_NOT_FOUND);
 
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("registerExchangeInvoice() - 교환 재배송 운송장 입력")
+    class RegisterExchangeInvoiceTests {
+
+        private static final Long EXCHANGE_ID = 3L;
+        private static final Long SELLER_ID = 10L;
+        private static final CourierCompany COURIER = CourierCompany.CJ_LOGISTICS;
+        private static final String TRACKING_NUMBER = "1234567890";
+
+        @Test
+        @DisplayName("성공 - APPROVED 상태의 교환 건에 운송장을 입력하면 상태가 RESHIPPED/EXCHANGE_ITEM_SHIPPED로 전이되고 ClaimDelivery와 OrderItemHistory가 저장된다")
+        void registerExchangeInvoice_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_APPROVED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.approved(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+            given(claimDeliveryRepository.save(any(ClaimDelivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            sut.registerExchangeInvoice(EXCHANGE_ID, SELLER_ID, COURIER, TRACKING_NUMBER);
+
+            // then
+            assertThat(exchangeRequest.getStatus()).isEqualTo(ExchangeRequestStatus.RESHIPPED);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.EXCHANGE_ITEM_SHIPPED);
+            then(exchangeRequestRepository).should(times(1)).findWithLockById(EXCHANGE_ID);
+            then(claimDeliveryRepository).should(times(1)).save(any(ClaimDelivery.class));
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("실패 (권한) - 타 판매자의 교환 건에 운송장을 입력하려 하면 SELLER_CLAIM_MISMATCH 예외가 발생하고 이후 로직은 실행되지 않는다")
+        void registerExchangeInvoice_fails_when_seller_mismatch() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> sut.registerExchangeInvoice(EXCHANGE_ID, SELLER_ID, COURIER, TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+
+            then(exchangeRequestRepository).should(never()).findWithLockById(any());
+            then(claimDeliveryRepository).should(never()).save(any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 (상태) - REQUESTED 상태의 교환 건(미승인)에 운송장을 입력하려 하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void registerExchangeInvoice_fails_when_not_approved() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_REQUEST);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.requested(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.registerExchangeInvoice(EXCHANGE_ID, SELLER_ID, COURIER, TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(claimDeliveryRepository).should(never()).save(any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 (상태) - 이미 RESHIPPED(운송장 등록 완료) 상태인 교환 건에 중복 입력하려 하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void registerExchangeInvoice_fails_when_already_reshipped() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_ITEM_SHIPPED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.withStatus(ExchangeRequestStatus.RESHIPPED, orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.registerExchangeInvoice(EXCHANGE_ID, SELLER_ID, COURIER, TRACKING_NUMBER))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(claimDeliveryRepository).should(never()).save(any());
             then(orderItemHistoryRepository).should(never()).save(any());
         }
     }

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
@@ -1,0 +1,197 @@
+package com.bbangle.bbangle.claim.seller.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.bbangle.bbangle.claim.domain.ExchangeRequest;
+import com.bbangle.bbangle.claim.domain.constant.DecisionType;
+import com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus;
+import com.bbangle.bbangle.claim.repository.ClaimRepository;
+import com.bbangle.bbangle.claim.repository.ExchangeRequestRepository;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.claim.ExchangeRequestFixture;
+import com.bbangle.bbangle.fixture.order.OrderItemFixture;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.OrderItemHistory;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[단위 테스트] SellerExchangeService - processExchange()")
+@ExtendWith(MockitoExtension.class)
+class SellerExchangeServiceProcessTest {
+
+    @InjectMocks
+    private SellerExchangeService sut;
+
+    @Mock
+    private ExchangeRequestRepository exchangeRequestRepository;
+
+    @Mock
+    private ClaimRepository claimRepository;
+
+    @Mock
+    private OrderItemHistoryRepository orderItemHistoryRepository;
+
+    @Nested
+    @DisplayName("APPROVE 시나리오")
+    class ApproveTests {
+
+        private static final Long EXCHANGE_ID = 1L;
+        private static final Long SELLER_ID = 10L;
+        private static final String REASON = "교환 승인";
+
+        @Test
+        @DisplayName("성공 - REQUESTED 상태의 교환 건에 대해 승인 처리 시 상태가 APPROVED로 전이되고 OrderItemHistory가 저장된다")
+        void processExchange_approve_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_REQUEST);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.requested(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when
+            sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.APPROVE, REASON);
+
+            // then
+            assertThat(exchangeRequest.getStatus()).isEqualTo(ExchangeRequestStatus.APPROVED);
+            assertThat(exchangeRequest.getSellerComment()).isEqualTo(REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.EXCHANGE_APPROVED);
+            then(exchangeRequestRepository).should(times(1)).findWithLockById(EXCHANGE_ID);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("실패 (권한) - 타 판매자의 교환 건에 접근 시 SELLER_CLAIM_MISMATCH 예외가 발생하고 이후 로직은 실행되지 않는다")
+        void processExchange_approve_fails_when_seller_mismatch() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.APPROVE, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+
+            then(exchangeRequestRepository).should(never()).findWithLockById(any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 (상태) - 이미 APPROVED 처리된 교환 건에 대해 승인 시도 시 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void processExchange_approve_fails_when_already_approved() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_APPROVED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.approved(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.APPROVE, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 (상태) - 이미 REJECTED 처리된 교환 건에 대해 승인 시도 시 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void processExchange_approve_fails_when_already_rejected() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_REJECTED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.rejected(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.APPROVE, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("REJECT 시나리오")
+    class RejectTests {
+
+        private static final Long EXCHANGE_ID = 2L;
+        private static final Long SELLER_ID = 10L;
+        private static final String REASON = "교환 거절 사유";
+
+        @Test
+        @DisplayName("성공 - REQUESTED 상태의 교환 건에 대해 거절 처리 시 상태가 REJECTED로 전이되고 OrderItemHistory가 저장된다")
+        void processExchange_reject_success() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_REQUEST);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.requested(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when
+            sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.REJECT, REASON);
+
+            // then
+            assertThat(exchangeRequest.getStatus()).isEqualTo(ExchangeRequestStatus.REJECTED);
+            assertThat(exchangeRequest.getSellerComment()).isEqualTo(REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.EXCHANGE_REJECTED);
+            then(exchangeRequestRepository).should(times(1)).findWithLockById(EXCHANGE_ID);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 APPROVED 처리된 교환 건에 대해 거절 시도 시 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void processExchange_reject_fails_when_already_approved() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_APPROVED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.approved(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.REJECT, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 exchangeId로 요청하면 CLAIM_NOT_FOUND 예외가 발생한다")
+        void processExchange_reject_fails_when_claim_not_found() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sut.processExchange(EXCHANGE_ID, SELLER_ID, DecisionType.REJECT, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_NOT_FOUND);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/fixture/claim/ExchangeRequestFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/claim/ExchangeRequestFixture.java
@@ -1,0 +1,38 @@
+package com.bbangle.bbangle.fixture.claim;
+
+import com.bbangle.bbangle.claim.domain.ExchangeRequest;
+import com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ExchangeRequestFixture {
+
+    private ExchangeRequestFixture() {
+    }
+
+    public static ExchangeRequest withStatus(ExchangeRequestStatus status, OrderItem orderItem) {
+        return ExchangeRequest.builder()
+            .orderItem(orderItem)
+            .detailReason("테스트 사유")
+            .decidedAt(null)
+            .status(status)
+            .build();
+    }
+
+    public static ExchangeRequest requested(OrderItem orderItem) {
+        return withStatus(ExchangeRequestStatus.REQUESTED, orderItem);
+    }
+
+    public static ExchangeRequest approved(OrderItem orderItem) {
+        return withStatus(ExchangeRequestStatus.APPROVED, orderItem);
+    }
+
+    public static ExchangeRequest rejected(OrderItem orderItem) {
+        return withStatus(ExchangeRequestStatus.REJECTED, orderItem);
+    }
+
+    public static ExchangeRequest withId(ExchangeRequest er, Long id) {
+        ReflectionTestUtils.setField(er, "id", id);
+        return er;
+    }
+}


### PR DESCRIPTION
## History

* #520

## 🚀 Major Changes & Explanations

- **교환 운송장 정보 수정 API 구현 (PATCH `/api/v1/seller/exchanges/{exchangeId}/invoice`)**
    - 배송 정보 오입력 등의 사유로 판매자가 기존에 등록된 택배사 코드(`deliveryCompany`)와 운송장 번호(`trackingNumber`)를 수정할 수 있는 엔드포인트를 추가
    - 요청 DTO에 수정 사유(`reason`)를 추가로 입력받아 교환 엔티티 내 관리자 메모 또는 로그 필드에 기록되도록 처리
- **기존 `OrderItemHistory` 테이블 스키마 준수**
    - 이전 작업들과 동일하게 기존 DB 스키마 구조 `[id, order_item_id, order_status, created_at]`
    - 운송장 수정 시에는 별도의 주문 상태 전이가 없더라도, 배송 정보 변경 이력 추적을 위해 트랜잭션 내에서 기존 `OrderItemHistory.create(orderItem)` 메서드가 정상 호출되도록 설계
- **Service Unit Test 작성**
    - **성공 시나리오**: 이미 운송장이 입력된 배송 중 상태의 건에 대해 새로운 운송장 정보로 요청 시, 데이터가 올바르게 업데이트(Update)되는지 검증
    - **실패 시나리오**: 타 판매자 접근 시 권한 오류(`SELLER_CLAIM_MISMATCH`), 운송장 수정이 불가능한 상태(예: 아직 승인 전이거나 이미 교환이 완료/거절된 건)에서 요청 시 상태 오류(`CLAIM_INVALID_STATUS`) 예외가 발생하는지 검증


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 판매자가 교환 요청을 승인 또는 거절할 수 있는 기능 추가
  * 승인된 교환에 대한 재배송 운송장 등록 기능 추가
  * 재배송 운송장 정보 수정 기능 추가
  * 교환 배송 추적 기능 강화

* **Tests**
  * 교환 처리 및 운송장 관리 로직 검증 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eco-dessert-platform/backend/pull/697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->