### PR TITLE
[Feat] 교환 반려 API, 교환 보류 API 구현 

### DIFF
--- a/src/main/java/com/bbangle/bbangle/claim/domain/ExchangeRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ExchangeRequest.java
@@ -1,6 +1,8 @@
 package com.bbangle.bbangle.claim.domain;
 
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.APPROVED;
+import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.INSPECTING;
+import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.PICKED_UP;
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.REJECTED;
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.REQUESTED;
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.RESHIPPED;
@@ -58,6 +60,15 @@ public class ExchangeRequest extends Claim {
 
     public void reject(String reason) {
         if (status != REQUESTED) {
+            throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
+        }
+        this.status = REJECTED;
+        this.sellerComment = reason;
+        super.decide();
+    }
+
+    public void rejectAfterInspection(String reason) {
+        if (status != PICKED_UP && status != INSPECTING) {
             throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
         }
         this.status = REJECTED;

--- a/src/main/java/com/bbangle/bbangle/claim/domain/ExchangeRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/ExchangeRequest.java
@@ -2,7 +2,9 @@ package com.bbangle.bbangle.claim.domain;
 
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.APPROVED;
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.INSPECTING;
+import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.ON_HOLD;
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.PICKED_UP;
+import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.PICKUP_SCHEDULED;
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.REJECTED;
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.REQUESTED;
 import static com.bbangle.bbangle.claim.domain.constant.ExchangeRequestStatus.RESHIPPED;
@@ -65,6 +67,14 @@ public class ExchangeRequest extends Claim {
         this.status = REJECTED;
         this.sellerComment = reason;
         super.decide();
+    }
+
+    public void holdExchange(String reason) {
+        if (status != REQUESTED && status != PICKUP_SCHEDULED && status != PICKED_UP && status != INSPECTING) {
+            throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
+        }
+        this.status = ON_HOLD;
+        this.sellerComment = reason;
     }
 
     public void rejectAfterInspection(String reason) {

--- a/src/main/java/com/bbangle/bbangle/claim/domain/constant/ExchangeRequestStatus.java
+++ b/src/main/java/com/bbangle/bbangle/claim/domain/constant/ExchangeRequestStatus.java
@@ -7,6 +7,7 @@ public enum ExchangeRequestStatus {
     INSPECTING,        // 교환 상품 검수 중
     APPROVED,          // 교환 승인 (새 상품 발송 가능)
     REJECTED,          // 교환 거절
+    ON_HOLD,           // 교환 보류 (추가 확인 필요)
     RESHIPPED,         // 교환 상품 재발송 완료
     COMPLETED;         // 고객 수령 및 교환 완료
 }

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerExchangeController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerExchangeController.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.claim.seller.controller;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeDecisionRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceUpdateRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeHoldRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeRejectRequest;
 import com.bbangle.bbangle.claim.seller.controller.swagger.SellerExchangeApi;
 import com.bbangle.bbangle.claim.seller.service.SellerExchangeService;
@@ -55,6 +56,16 @@ public class SellerExchangeController implements SellerExchangeApi {
         @AuthenticationPrincipal Long sellerId
     ) {
         sellerExchangeService.updateExchangeInvoice(exchangeId, sellerId, request.courierCode(), request.trackingNumber());
+        return responseService.getSuccessResult();
+    }
+
+    @PostMapping("/{exchangeId}/hold")
+    public CommonResult holdExchange(
+        @PathVariable Long exchangeId,
+        @Valid @RequestBody ExchangeHoldRequest request,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        sellerExchangeService.holdExchange(exchangeId, sellerId, request.reason());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerExchangeController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/SellerExchangeController.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.claim.seller.controller;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeDecisionRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceUpdateRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeRejectRequest;
 import com.bbangle.bbangle.claim.seller.controller.swagger.SellerExchangeApi;
 import com.bbangle.bbangle.claim.seller.service.SellerExchangeService;
 import com.bbangle.bbangle.common.dto.CommonResult;
@@ -54,6 +55,16 @@ public class SellerExchangeController implements SellerExchangeApi {
         @AuthenticationPrincipal Long sellerId
     ) {
         sellerExchangeService.updateExchangeInvoice(exchangeId, sellerId, request.courierCode(), request.trackingNumber());
+        return responseService.getSuccessResult();
+    }
+
+    @PostMapping("/{exchangeId}/reject")
+    public CommonResult rejectExchange(
+        @PathVariable Long exchangeId,
+        @Valid @RequestBody ExchangeRejectRequest request,
+        @AuthenticationPrincipal Long sellerId
+    ) {
+        sellerExchangeService.rejectExchange(exchangeId, sellerId, request.reason());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ExchangeHoldRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ExchangeHoldRequest.java
@@ -1,0 +1,10 @@
+package com.bbangle.bbangle.claim.seller.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record ExchangeHoldRequest(
+    @Schema(description = "보류 사유", example = "교환 배송비 미입금으로 인한 보류", maxLength = 500)
+    @NotBlank(message = "보류 사유는 필수입니다.")
+    String reason
+) {}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ExchangeRejectRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/dto/ExchangeRejectRequest.java
@@ -1,0 +1,10 @@
+package com.bbangle.bbangle.claim.seller.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record ExchangeRejectRequest(
+    @Schema(description = "검수 후 반려 사유", example = "고객 귀책으로 인한 상품 파손으로 교환 불가", maxLength = 500)
+    @NotBlank(message = "반려 사유는 필수입니다.")
+    String reason
+) {}

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerExchangeApi.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerExchangeApi.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.claim.seller.controller.swagger;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeDecisionRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceUpdateRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeHoldRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeRejectRequest;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,6 +43,18 @@ public interface SellerExchangeApi {
     CommonResult updateExchangeInvoice(
         @Parameter(description = "교환 요청 ID") Long exchangeId,
         ExchangeInvoiceUpdateRequest request,
+        @Parameter(hidden = true) Long sellerId
+    );
+
+    @Operation(
+        summary = "교환 보류 처리",
+        description = "REQUESTED, PICKUP_SCHEDULED, PICKED_UP, INSPECTING 상태의 교환 건에 대해 "
+            + "배송비 미입금·구성품 누락 등 추가 확인이 필요한 경우 처리를 보류한다. "
+            + "보류 사유는 ExchangeRequest의 sellerComment 필드에 저장되고, 주문 상품 상태는 EXCHANGE_ON_HOLD로 전이된다."
+    )
+    CommonResult holdExchange(
+        @Parameter(description = "교환 요청 ID") Long exchangeId,
+        ExchangeHoldRequest request,
         @Parameter(hidden = true) Long sellerId
     );
 

--- a/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerExchangeApi.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/controller/swagger/SellerExchangeApi.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.claim.seller.controller.swagger;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeDecisionRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceRequest;
 import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeInvoiceUpdateRequest;
+import com.bbangle.bbangle.claim.seller.controller.dto.ExchangeRejectRequest;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -41,6 +42,17 @@ public interface SellerExchangeApi {
     CommonResult updateExchangeInvoice(
         @Parameter(description = "교환 요청 ID") Long exchangeId,
         ExchangeInvoiceUpdateRequest request,
+        @Parameter(hidden = true) Long sellerId
+    );
+
+    @Operation(
+        summary = "교환 수거 후 반려 처리",
+        description = "PICKED_UP 또는 INSPECTING 상태의 교환 건에 대해 검수 결과 고객 귀책으로 판단하여 반려한다. "
+            + "반려 사유는 ExchangeRequest의 sellerComment 필드에 저장되고, 주문 상품 상태는 EXCHANGE_RETURNED로 전이된다."
+    )
+    CommonResult rejectExchange(
+        @Parameter(description = "교환 요청 ID") Long exchangeId,
+        ExchangeRejectRequest request,
         @Parameter(hidden = true) Long sellerId
     );
 

--- a/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeService.java
@@ -177,6 +177,21 @@ public class SellerExchangeService {
         orderItemHistoryRepository.save(OrderItemHistory.create(orderItem));
     }
 
+    @Transactional
+    public void rejectExchange(Long exchangeId, Long sellerId, String reason) {
+        if (!claimRepository.existsClaimRequestBySeller(exchangeId, sellerId)) {
+            throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+        }
+
+        ExchangeRequest exchangeRequest = findExchangeRequestWithLock(exchangeId);
+        exchangeRequest.rejectAfterInspection(reason);
+
+        OrderItem orderItem = exchangeRequest.getOrderItem();
+        orderItem.exchangeReturn();
+
+        orderItemHistoryRepository.save(OrderItemHistory.create(orderItem));
+    }
+
     // 락 전략 전환이 필요할 경우 이 메서드만 교체하면 된다 (현재: 비관적 락).
     private ExchangeRequest findExchangeRequestWithLock(Long exchangeId) {
         return exchangeRequestRepository.findWithLockById(exchangeId)

--- a/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeService.java
@@ -178,6 +178,21 @@ public class SellerExchangeService {
     }
 
     @Transactional
+    public void holdExchange(Long exchangeId, Long sellerId, String reason) {
+        if (!claimRepository.existsClaimRequestBySeller(exchangeId, sellerId)) {
+            throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+        }
+
+        ExchangeRequest exchangeRequest = findExchangeRequestWithLock(exchangeId);
+        exchangeRequest.holdExchange(reason);
+
+        OrderItem orderItem = exchangeRequest.getOrderItem();
+        orderItem.exchangeHold();
+
+        orderItemHistoryRepository.save(OrderItemHistory.create(orderItem));
+    }
+
+    @Transactional
     public void rejectExchange(Long exchangeId, Long sellerId, String reason) {
         if (!claimRepository.existsClaimRequestBySeller(exchangeId, sellerId)) {
             throw new BbangleException(BbangleErrorCode.SELLER_CLAIM_MISMATCH);

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -207,6 +207,13 @@ public class OrderItem extends BaseEntity {
         this.orderStatus = OrderStatus.EXCHANGE_REJECTED;
     }
 
+    public void exchangeReturn() {
+        if (orderStatus != OrderStatus.EXCHANGE_ITEM_COLLECTED && orderStatus != OrderStatus.EXCHANGE_ITEM_INSPECTING) {
+            throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
+        }
+        this.orderStatus = OrderStatus.EXCHANGE_RETURNED;
+    }
+
     public void exchangeItemShipped() {
         if (orderStatus != OrderStatus.EXCHANGE_APPROVED) {
             throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -207,6 +207,16 @@ public class OrderItem extends BaseEntity {
         this.orderStatus = OrderStatus.EXCHANGE_REJECTED;
     }
 
+    public void exchangeHold() {
+        if (orderStatus != OrderStatus.EXCHANGE_REQUEST
+            && orderStatus != OrderStatus.EXCHANGE_APPROVED
+            && orderStatus != OrderStatus.EXCHANGE_ITEM_COLLECTED
+            && orderStatus != OrderStatus.EXCHANGE_ITEM_INSPECTING) {
+            throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
+        }
+        this.orderStatus = OrderStatus.EXCHANGE_ON_HOLD;
+    }
+
     public void exchangeReturn() {
         if (orderStatus != OrderStatus.EXCHANGE_ITEM_COLLECTED && orderStatus != OrderStatus.EXCHANGE_ITEM_INSPECTING) {
             throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
@@ -409,6 +409,110 @@ class SellerExchangeServiceProcessTest {
     }
 
     @Nested
+    @DisplayName("rejectExchange() - 교환 수거 후 반려 처리")
+    class RejectAfterInspectionTests {
+
+        private static final Long EXCHANGE_ID = 6L;
+        private static final Long SELLER_ID = 10L;
+        private static final String REASON = "고객 귀책으로 인한 상품 파손으로 교환 불가";
+
+        @Test
+        @DisplayName("성공 - INSPECTING 상태의 교환 건에 반려 사유와 함께 요청 시 상태가 REJECTED/EXCHANGE_RETURNED로 전이되고 OrderItemHistory가 저장된다")
+        void rejectExchange_success_from_inspecting() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_ITEM_INSPECTING);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.inspecting(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when
+            sut.rejectExchange(EXCHANGE_ID, SELLER_ID, REASON);
+
+            // then
+            assertThat(exchangeRequest.getStatus()).isEqualTo(ExchangeRequestStatus.REJECTED);
+            assertThat(exchangeRequest.getSellerComment()).isEqualTo(REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.EXCHANGE_RETURNED);
+            then(exchangeRequestRepository).should(times(1)).findWithLockById(EXCHANGE_ID);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("성공 - PICKED_UP 상태의 교환 건에 반려 사유와 함께 요청 시 상태가 REJECTED/EXCHANGE_RETURNED로 전이되고 OrderItemHistory가 저장된다")
+        void rejectExchange_success_from_picked_up() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_ITEM_COLLECTED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.pickedUp(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when
+            sut.rejectExchange(EXCHANGE_ID, SELLER_ID, REASON);
+
+            // then
+            assertThat(exchangeRequest.getStatus()).isEqualTo(ExchangeRequestStatus.REJECTED);
+            assertThat(exchangeRequest.getSellerComment()).isEqualTo(REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.EXCHANGE_RETURNED);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("실패 (권한) - 타 판매자의 교환 건에 반려 처리를 시도하면 SELLER_CLAIM_MISMATCH 예외가 발생하고 이후 로직은 실행되지 않는다")
+        void rejectExchange_fails_when_seller_mismatch() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> sut.rejectExchange(EXCHANGE_ID, SELLER_ID, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+
+            then(exchangeRequestRepository).should(never()).findWithLockById(any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 (상태) - 이미 완료된(COMPLETED) 교환 건에 반려 처리를 시도하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void rejectExchange_fails_when_already_completed() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_COMPLETED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.withStatus(ExchangeRequestStatus.COMPLETED, orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.rejectExchange(EXCHANGE_ID, SELLER_ID, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 (상태) - REQUESTED 상태(수거 전)의 교환 건에 반려 처리를 시도하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void rejectExchange_fails_when_not_picked_up() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_REQUEST);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.requested(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.rejectExchange(EXCHANGE_ID, SELLER_ID, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
     @DisplayName("completeExchange() - 교환 최종 완료 처리")
     class CompleteExchangeTests {
 

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
@@ -21,7 +21,6 @@ import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.claim.ExchangeRequestFixture;
 import com.bbangle.bbangle.fixture.order.OrderItemFixture;
 import com.bbangle.bbangle.claim.domain.constant.ClaimDeliveryType;
-import com.bbangle.bbangle.delivery.domain.Shipping;
 import com.bbangle.bbangle.order.domain.OrderItem;
 import com.bbangle.bbangle.order.domain.OrderItemHistory;
 import com.bbangle.bbangle.order.domain.model.CourierCompany;
@@ -310,10 +309,6 @@ class SellerExchangeServiceProcessTest {
             ExchangeRequest exchangeRequest = ExchangeRequestFixture.withStatus(ExchangeRequestStatus.RESHIPPED, orderItem);
 
             ClaimDelivery mockDelivery = mock(ClaimDelivery.class);
-            Shipping mockShipping = mock(Shipping.class);
-            given(mockDelivery.getShipping()).willReturn(mockShipping);
-            given(mockShipping.getCourierName()).willReturn(NEW_COURIER.getDisplayName());
-            given(mockShipping.getTrackingNumber()).willReturn(NEW_TRACKING_NUMBER);
 
             given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
             given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));

--- a/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/seller/service/SellerExchangeServiceProcessTest.java
@@ -409,6 +409,110 @@ class SellerExchangeServiceProcessTest {
     }
 
     @Nested
+    @DisplayName("holdExchange() - 교환 보류 처리")
+    class HoldExchangeTests {
+
+        private static final Long EXCHANGE_ID = 7L;
+        private static final Long SELLER_ID = 10L;
+        private static final String REASON = "교환 배송비 미입금으로 인한 보류";
+
+        @Test
+        @DisplayName("성공 - INSPECTING 상태의 교환 건에 보류 사유와 함께 요청 시 상태가 ON_HOLD/EXCHANGE_ON_HOLD로 전이되고 OrderItemHistory가 저장된다")
+        void holdExchange_success_from_inspecting() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_ITEM_INSPECTING);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.inspecting(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when
+            sut.holdExchange(EXCHANGE_ID, SELLER_ID, REASON);
+
+            // then
+            assertThat(exchangeRequest.getStatus()).isEqualTo(ExchangeRequestStatus.ON_HOLD);
+            assertThat(exchangeRequest.getSellerComment()).isEqualTo(REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.EXCHANGE_ON_HOLD);
+            then(exchangeRequestRepository).should(times(1)).findWithLockById(EXCHANGE_ID);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("성공 - REQUESTED 상태의 교환 건에 보류 사유와 함께 요청 시 상태가 ON_HOLD/EXCHANGE_ON_HOLD로 전이되고 OrderItemHistory가 저장된다")
+        void holdExchange_success_from_requested() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_REQUEST);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.requested(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when
+            sut.holdExchange(EXCHANGE_ID, SELLER_ID, REASON);
+
+            // then
+            assertThat(exchangeRequest.getStatus()).isEqualTo(ExchangeRequestStatus.ON_HOLD);
+            assertThat(exchangeRequest.getSellerComment()).isEqualTo(REASON);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.EXCHANGE_ON_HOLD);
+            then(orderItemHistoryRepository).should(times(1)).save(any(OrderItemHistory.class));
+        }
+
+        @Test
+        @DisplayName("실패 (권한) - 타 판매자의 교환 건에 보류 처리를 시도하면 SELLER_CLAIM_MISMATCH 예외가 발생하고 이후 로직은 실행되지 않는다")
+        void holdExchange_fails_when_seller_mismatch() {
+            // given
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> sut.holdExchange(EXCHANGE_ID, SELLER_ID, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.SELLER_CLAIM_MISMATCH);
+
+            then(exchangeRequestRepository).should(never()).findWithLockById(any());
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 (상태) - 이미 완료된(COMPLETED) 교환 건에 보류 처리를 시도하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void holdExchange_fails_when_already_completed() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_COMPLETED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.withStatus(ExchangeRequestStatus.COMPLETED, orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.holdExchange(EXCHANGE_ID, SELLER_ID, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 (상태) - REJECTED(거절 처리 완료) 상태의 교환 건에 보류 처리를 시도하면 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void holdExchange_fails_when_already_rejected() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.EXCHANGE_REJECTED);
+            ExchangeRequest exchangeRequest = ExchangeRequestFixture.rejected(orderItem);
+
+            given(claimRepository.existsClaimRequestBySeller(EXCHANGE_ID, SELLER_ID)).willReturn(true);
+            given(exchangeRequestRepository.findWithLockById(EXCHANGE_ID)).willReturn(Optional.of(exchangeRequest));
+
+            // when & then
+            assertThatThrownBy(() -> sut.holdExchange(EXCHANGE_ID, SELLER_ID, REASON))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(orderItemHistoryRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
     @DisplayName("rejectExchange() - 교환 수거 후 반려 처리")
     class RejectAfterInspectionTests {
 

--- a/src/test/java/com/bbangle/bbangle/fixture/claim/ExchangeRequestFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/claim/ExchangeRequestFixture.java
@@ -31,6 +31,14 @@ public class ExchangeRequestFixture {
         return withStatus(ExchangeRequestStatus.REJECTED, orderItem);
     }
 
+    public static ExchangeRequest pickedUp(OrderItem orderItem) {
+        return withStatus(ExchangeRequestStatus.PICKED_UP, orderItem);
+    }
+
+    public static ExchangeRequest inspecting(OrderItem orderItem) {
+        return withStatus(ExchangeRequestStatus.INSPECTING, orderItem);
+    }
+
     public static ExchangeRequest withId(ExchangeRequest er, Long id) {
         ReflectionTestUtils.setField(er, "id", id);
         return er;

--- a/src/test/java/com/bbangle/bbangle/fixture/claim/ExchangeRequestFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/claim/ExchangeRequestFixture.java
@@ -39,6 +39,10 @@ public class ExchangeRequestFixture {
         return withStatus(ExchangeRequestStatus.INSPECTING, orderItem);
     }
 
+    public static ExchangeRequest onHold(OrderItem orderItem) {
+        return withStatus(ExchangeRequestStatus.ON_HOLD, orderItem);
+    }
+
     public static ExchangeRequest withId(ExchangeRequest er, Long id) {
         ReflectionTestUtils.setField(er, "id", id);
         return er;


### PR DESCRIPTION
## History
* #522 #523  
## 🚀 Major Changes & Explanations

- **교환 반려 및 보류 처리 API 구현**
    - **교환 반려 (POST `/api/v1/seller/exchanges/{exchangeId}/reject`)**: 수거 후 검수 단계에서 고객 귀책(상품 훼손 등)으로 교환이 불가할 경우, 반려 사유(`reason`)를 입력받아 최종 반려 상태(예: `EXCHANGE_REJECTED`)로 변경하는 엔드포인트 추가
    - **교환 보류 (POST `/api/v1/seller/exchanges/{exchangeId}/hold`)**: 배송비 미입금, 구성품 누락 등 추가 확인이 필요할 때 보류 사유(`holdReason`)를 입력받아 보류 상태(예: `EXCHANGE_HOLD`)로 잠시 멈추는 엔드포인트 추가
- **기존 `OrderItemHistory` 테이블 스키마 준수**
    - 공통 DB 구조를 해치지 않기 위해 기존 스키마 `[id, order_item_id, order_status, created_at]`를 엄격히 유지
    - 별도의 추가 필드 없이, 상태 변경 시점에 기존 `OrderItemHistory.create(orderItem)` 메서드만 호출하여 반려 및 보류 이력이 트랜잭션 내에서 누락 없이 기록되도록 보장
- **안정성 및 보안 강화**
    - 타 판매자의 무단 접근을 차단하기 위한 `sellerId` 소유권 검증 로직 적용
    - 동시성 요청 시 데이터 정합성 보장을 위해 `findWithLockById`를 통한 비관적 락(Pessimistic Lock) 적용
- **Service Unit Test 작성**
    - **성공 시나리오**: 반려/보류가 가능한 상태의 교환 건에 대해 사유와 함께 요청 시, 교환 및 주문 상품 상태가 정상 전이되고 사유가 기록되며 `OrderItemHistory`가 정상 적재되는지 검증
    - **실패 시나리오**: 권한이 없는 판매자가 접근할 경우 `SELLER_CLAIM_MISMATCH` 예외 검증, 올바르지 않은 이전 단계 상태(예: 이미 완료/취소된 건)에서 시도를 할 경우 `CLAIM_INVALID_STATUS` 예외가 정확히 발생하는지 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 판매자가 교환 요청을 일시 보류할 수 있는 기능 추가
  * 검수 후 교환을 반려할 수 있는 기능 추가
  * 교환 처리 흐름에 "보류(ON_HOLD)" 상태 추가 및 주문상품 상태 전이 지원
  * 판매자용 API 엔드포인트(보류/반려) 및 요청 모델 추가

* **테스트**
  * 보류 및 반려 처리 시나리오에 대한 단위/통합 테스트 추가 및 이력 기록 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->