### PR TITLE
[Feat] (커스터머) 영수증 조회 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/config/security/CustomerApiPath.java
+++ b/src/main/java/com/bbangle/bbangle/config/security/CustomerApiPath.java
@@ -5,7 +5,8 @@ public class CustomerApiPath {
     public static final String PREFIX = "/api/v1/customer";
 
     public static final String[] ANY_METHOD = {
-        "/api/v1/boards/folders/**"
+        "/api/v1/boards/folders/**",
+        PREFIX + "/orders/**"
     };
 
 }

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/OrderReceiptController.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/OrderReceiptController.java
@@ -1,0 +1,33 @@
+package com.bbangle.bbangle.order.customer.controller;
+
+import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.CustomerApiPath;
+import com.bbangle.bbangle.order.customer.controller.dto.response.OrderReceiptResponse;
+import com.bbangle.bbangle.order.customer.controller.swagger.CustomerOrderApi;
+import com.bbangle.bbangle.order.customer.service.OrderReceiptService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(CustomerApiPath.PREFIX + "/orders")
+public class OrderReceiptController implements CustomerOrderApi {
+
+    private final ResponseService responseService;
+    private final OrderReceiptService orderReceiptService;
+
+    @Override
+    @GetMapping("/{orderId}/receipt")
+    public SingleResult<OrderReceiptResponse> getReceipt(
+        @AuthenticationPrincipal Long memberId,
+        @PathVariable Long orderId
+    ) {
+        OrderReceiptResponse response = orderReceiptService.getReceipt(memberId, orderId);
+        return responseService.getSingleResult(response);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/dto/response/OrderReceiptResponse.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/dto/response/OrderReceiptResponse.java
@@ -16,12 +16,13 @@ public record OrderReceiptResponse(
 
     public static OrderReceiptResponse from(
         Payment payment,
+        String decryptedCardNumber,
         String orderNumber,
         List<OrderItem> activeItems,
         Store store
     ) {
         return new OrderReceiptResponse(
-            PaymentInfo.from(payment),
+            PaymentInfo.from(payment, decryptedCardNumber),
             PurchaseInfo.from(orderNumber, activeItems),
             StoreInfo.from(store)
         );
@@ -36,12 +37,12 @@ public record OrderReceiptResponse(
         LocalDateTime transactionAt
     ) {
 
-        public static PaymentInfo from(Payment payment) {
+        public static PaymentInfo from(Payment payment, String decryptedCardNumber) {
             return new PaymentInfo(
                 payment.getApprovalNumber(),
                 resolveTransactionType(payment.getPaymentMethod()),
                 resolveCardType(payment.getCardType()),
-                maskCardNumber(payment.getCardNumber()),
+                maskCardNumber(decryptedCardNumber),
                 payment.getInstallment(),
                 payment.getPaidAt()
             );

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/dto/response/OrderReceiptResponse.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/dto/response/OrderReceiptResponse.java
@@ -1,0 +1,144 @@
+package com.bbangle.bbangle.order.customer.controller.dto.response;
+
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.payment.domain.CardType;
+import com.bbangle.bbangle.payment.domain.Payment;
+import com.bbangle.bbangle.payment.domain.PaymentMethod;
+import com.bbangle.bbangle.store.domain.Store;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderReceiptResponse(
+    PaymentInfo paymentInfo,
+    PurchaseInfo purchaseInfo,
+    StoreInfo storeInfo
+) {
+
+    public static OrderReceiptResponse from(
+        Payment payment,
+        String orderNumber,
+        List<OrderItem> activeItems,
+        Store store
+    ) {
+        return new OrderReceiptResponse(
+            PaymentInfo.from(payment),
+            PurchaseInfo.from(orderNumber, activeItems),
+            StoreInfo.from(store)
+        );
+    }
+
+    public record PaymentInfo(
+        String approvalNumber,
+        String transactionType,
+        String cardType,
+        String cardNumber,
+        String installment,
+        LocalDateTime transactionAt
+    ) {
+
+        public static PaymentInfo from(Payment payment) {
+            return new PaymentInfo(
+                payment.getApprovalNumber(),
+                resolveTransactionType(payment.getPaymentMethod()),
+                resolveCardType(payment.getCardType()),
+                maskCardNumber(payment.getCardNumber()),
+                payment.getInstallment(),
+                payment.getPaidAt()
+            );
+        }
+
+        private static String resolveTransactionType(PaymentMethod method) {
+            if (method == null) {
+                return null;
+            }
+            return method.getDescription();
+        }
+
+        private static String resolveCardType(CardType cardType) {
+            if (cardType == null) {
+                return null;
+            }
+            return cardType.getDescription();
+        }
+
+        private static final int PREFIX_LENGTH = 6;
+        private static final int SUFFIX_LENGTH = 4;
+
+        private static String maskCardNumber(String cardNumber) {
+            if (cardNumber == null) {
+                return null;
+            }
+            int len = cardNumber.length();
+            if (len <= PREFIX_LENGTH + SUFFIX_LENGTH) {
+                return "*".repeat(len);
+            }
+            return cardNumber.substring(0, PREFIX_LENGTH)
+                + "*".repeat(len - PREFIX_LENGTH - SUFFIX_LENGTH)
+                + cardNumber.substring(len - SUFFIX_LENGTH);
+        }
+    }
+
+    public record PurchaseInfo(
+        String orderNumber,
+        String productName,
+        int taxableAmount,
+        int nonTaxableAmount,
+        int vat,
+        int totalAmount
+    ) {
+
+        public static PurchaseInfo from(String orderNumber, List<OrderItem> activeItems) {
+            int totalAmount = activeItems.stream()
+                .mapToInt(OrderItem::getTotalPrice)
+                .sum();
+            int taxableAmount = (int) Math.round(totalAmount / 1.1);
+            int vat = totalAmount - taxableAmount;
+
+            return new PurchaseInfo(
+                orderNumber,
+                buildProductName(activeItems),
+                taxableAmount,
+                0,
+                vat,
+                totalAmount
+            );
+        }
+
+        private static String buildProductName(List<OrderItem> items) {
+            if (items.isEmpty()) {
+                return "";
+            }
+            String firstName = items.get(0).getProduct().getTitle();
+            if (items.size() == 1) {
+                return firstName;
+            }
+            return firstName + " 외 " + (items.size() - 1) + "건";
+        }
+    }
+
+    public record StoreInfo(
+        String storeName,
+        String businessNumber,
+        String storeAddress
+    ) {
+
+        public static StoreInfo from(Store store) {
+            String address = buildAddress(store.getOriginAddressLine(), store.getOriginAddressDetail());
+            return new StoreInfo(
+                store.getName(),
+                store.getIdentifier(),
+                address
+            );
+        }
+
+        private static String buildAddress(String line, String detail) {
+            if (line == null) {
+                return detail;
+            }
+            if (detail == null) {
+                return line;
+            }
+            return line + " " + detail;
+        }
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/swagger/CustomerOrderApi.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/swagger/CustomerOrderApi.java
@@ -1,0 +1,25 @@
+package com.bbangle.bbangle.order.customer.controller.swagger;
+
+import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.order.customer.controller.dto.response.OrderReceiptResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Customer Order", description = "(커스터머) 주문 API")
+public interface CustomerOrderApi {
+
+    @Operation(
+        summary = "(커스터머) 전자 영수증 조회",
+        description = """
+            주문의 전자 영수증을 조회합니다.
+            - 취소(CANCEL_APPROVED), 반품(RETURN_COMPLETED) 상태 항목은 합계금액에서 제외됩니다.
+            - 카드 결제가 아닌 경우 cardType, cardNumber, installment는 null을 반환합니다.
+            """
+    )
+    SingleResult<OrderReceiptResponse> getReceipt(
+        @Parameter(hidden = true) Long memberId,
+        @Parameter(description = "주문 ID", required = true) @PathVariable Long orderId
+    );
+}

--- a/src/main/java/com/bbangle/bbangle/order/customer/service/OrderReceiptService.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/service/OrderReceiptService.java
@@ -1,0 +1,46 @@
+package com.bbangle.bbangle.order.customer.service;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.order.customer.controller.dto.response.OrderReceiptResponse;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderRepository;
+import com.bbangle.bbangle.payment.domain.Payment;
+import com.bbangle.bbangle.store.domain.Store;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderReceiptService {
+
+    private static final Set<OrderStatus> EXCLUDED_STATUSES =
+        EnumSet.of(OrderStatus.CANCEL_APPROVED, OrderStatus.RETURN_COMPLETED);
+
+    private final OrderRepository orderRepository;
+
+    @Transactional(readOnly = true)
+    public OrderReceiptResponse getReceipt(Long memberId, Long orderId) {
+        Order order = orderRepository.findByIdWithFullAssociations(orderId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.getMember().getId().equals(memberId)) {
+            throw new BbangleException(BbangleErrorCode.ORDER_ACCESS_DENIED);
+        }
+
+        Payment payment = order.getPayment();
+        // TODO: 카드번호 암호화 여부 결정 후 payment.getCardNumber() 복호화 로직 추가 필요
+        Store store = order.getSeller().getStore();
+        List<OrderItem> activeItems = order.getOrderItems().stream()
+            .filter(item -> !EXCLUDED_STATUSES.contains(item.getOrderStatus()))
+            .toList();
+
+        return OrderReceiptResponse.from(payment, order.getOrderNumber(), activeItems, store);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/customer/service/OrderReceiptService.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/service/OrderReceiptService.java
@@ -9,6 +9,7 @@ import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.repository.OrderRepository;
 import com.bbangle.bbangle.payment.domain.Payment;
 import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.util.AesEncryptionUtil;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -24,6 +25,7 @@ public class OrderReceiptService {
         EnumSet.of(OrderStatus.CANCEL_APPROVED, OrderStatus.RETURN_COMPLETED);
 
     private final OrderRepository orderRepository;
+    private final AesEncryptionUtil aesEncryptionUtil;
 
     @Transactional(readOnly = true)
     public OrderReceiptResponse getReceipt(Long memberId, Long orderId) {
@@ -35,12 +37,12 @@ public class OrderReceiptService {
         }
 
         Payment payment = order.getPayment();
-        // TODO: 카드번호 암호화 여부 결정 후 payment.getCardNumber() 복호화 로직 추가 필요
+        String decryptedCardNumber = aesEncryptionUtil.decrypt(payment.getCardNumber());
         Store store = order.getSeller().getStore();
         List<OrderItem> activeItems = order.getOrderItems().stream()
             .filter(item -> !EXCLUDED_STATUSES.contains(item.getOrderStatus()))
             .toList();
 
-        return OrderReceiptResponse.from(payment, order.getOrderNumber(), activeItems, store);
+        return OrderReceiptResponse.from(payment, decryptedCardNumber, order.getOrderNumber(), activeItems, store);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/order/customer/service/OrderReceiptService.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/service/OrderReceiptService.java
@@ -29,12 +29,8 @@ public class OrderReceiptService {
 
     @Transactional(readOnly = true)
     public OrderReceiptResponse getReceipt(Long memberId, Long orderId) {
-        Order order = orderRepository.findByIdWithFullAssociations(orderId)
+        Order order = orderRepository.findByIdWithFullAssociations(orderId, memberId)
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
-
-        if (!order.getMember().getId().equals(memberId)) {
-            throw new BbangleException(BbangleErrorCode.ORDER_ACCESS_DENIED);
-        }
 
         Payment payment = order.getPayment();
         String decryptedCardNumber = aesEncryptionUtil.decrypt(payment.getCardNumber());

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepository.java
@@ -6,6 +6,7 @@ import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderSearchCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.CompletedOrderSearchCommand;
 import java.util.Map;
+import java.util.Optional;
 
 public interface OrderDSLRepository {
 
@@ -16,4 +17,6 @@ public interface OrderDSLRepository {
     BbanglePageResponse<Order> searchCompletedOrderList(CompletedOrderSearchCommand command);
 
     Map<OrderStatus, Long> countByCompletedOrderStatus(CompletedOrderSearchCommand command);
+
+    Optional<Order> findByIdWithFullAssociations(Long orderId);
 }

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepository.java
@@ -18,5 +18,5 @@ public interface OrderDSLRepository {
 
     Map<OrderStatus, Long> countByCompletedOrderStatus(CompletedOrderSearchCommand command);
 
-    Optional<Order> findByIdWithFullAssociations(Long orderId);
+    Optional<Order> findByIdWithFullAssociations(Long orderId, Long memberId);
 }

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepositoryImpl.java
@@ -407,7 +407,7 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
     }
 
     @Override
-    public Optional<Order> findByIdWithFullAssociations(Long orderId) {
+    public Optional<Order> findByIdWithFullAssociations(Long orderId, Long memberId) {
         List<Order> results = queryFactory
             .selectFrom(order)
             .distinct()
@@ -416,7 +416,7 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
             .join(seller.store, store).fetchJoin()
             .join(order.orderItems, orderItem).fetchJoin()
             .join(orderItem.product, product).fetchJoin()
-            .where(order.id.eq(orderId))
+            .where(order.id.eq(orderId), order.member.id.eq(memberId))
             .fetch();
 
         return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderDSLRepositoryImpl.java
@@ -13,6 +13,7 @@ import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.OrderSearchCommand;
 import com.bbangle.bbangle.order.seller.service.model.SellerOrderCommand.CompletedOrderSearchCommand;
 import com.bbangle.bbangle.seller.domain.QSeller;
+import com.bbangle.bbangle.store.domain.QStore;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -22,6 +23,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +53,7 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
     private final QOrder order = QOrder.order;
     private final QOrderItem orderItem = QOrderItem.orderItem;
     private final QSeller seller = QSeller.seller;
+    private final QStore store = QStore.store;
     private final QProduct product = QProduct.product;
     private final QOrderDelivery orderDelivery = QOrderDelivery.orderDelivery;
 
@@ -401,6 +404,22 @@ public class OrderDSLRepositoryImpl implements OrderDSLRepository {
     // LocalDate → 해당 날짜 23:59:59 LocalDateTime 변환 (null-safe)
     private LocalDateTime toEndDateTime(LocalDate date) {
         return date != null ? date.atTime(23, 59, 59) : null;
+    }
+
+    @Override
+    public Optional<Order> findByIdWithFullAssociations(Long orderId) {
+        List<Order> results = queryFactory
+            .selectFrom(order)
+            .distinct()
+            .leftJoin(order.payment).fetchJoin()
+            .join(order.seller, seller).fetchJoin()
+            .join(seller.store, store).fetchJoin()
+            .join(order.orderItems, orderItem).fetchJoin()
+            .join(orderItem.product, product).fetchJoin()
+            .where(order.id.eq(orderId))
+            .fetch();
+
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/payment/domain/CardType.java
+++ b/src/main/java/com/bbangle/bbangle/payment/domain/CardType.java
@@ -1,0 +1,26 @@
+package com.bbangle.bbangle.payment.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CardType {
+
+    SHINHAN("신한"),
+    KB("국민"),
+    HYUNDAI("현대"),
+    SAMSUNG("삼성"),
+    LOTTE("롯데"),
+    HANA("하나"),
+    WOORI("우리"),
+    NH("농협"),
+    BC("BC"),
+    CITI("씨티"),
+    KAKAO("카카오뱅크"),
+    TOSS("토스뱅크"),
+    ETC("기타");
+
+    private final String description;
+
+}

--- a/src/main/java/com/bbangle/bbangle/payment/domain/Payment.java
+++ b/src/main/java/com/bbangle/bbangle/payment/domain/Payment.java
@@ -50,7 +50,6 @@ public class Payment extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private CardType cardType;
 
-    // TODO: 카드번호 암호화 여부 결정 후 암호화하여 저장. 마스킹은 비즈니스 로직에서 처리.
     @Column(name = "card_number", length = 255)
     private String cardNumber;
 

--- a/src/main/java/com/bbangle/bbangle/payment/domain/Payment.java
+++ b/src/main/java/com/bbangle/bbangle/payment/domain/Payment.java
@@ -43,15 +43,37 @@ public class Payment extends BaseEntity {
 
     private LocalDateTime paidAt;
 
+    @Column(name = "approval_number", length = 20)
+    private String approvalNumber;
+
+    @Column(name = "card_type", length = 20)
+    @Enumerated(EnumType.STRING)
+    private CardType cardType;
+
+    // TODO: 카드번호 암호화 여부 결정 후 암호화하여 저장. 마스킹은 비즈니스 로직에서 처리.
+    @Column(name = "card_number", length = 255)
+    private String cardNumber;
+
+    @Column(name = "installment", length = 20)
+    private String installment;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Payment(Order order,
                     PaymentStatus paymentStatus,
                     PaymentMethod paymentMethod,
-                    LocalDateTime paidAt) {
+                    LocalDateTime paidAt,
+                    String approvalNumber,
+                    CardType cardType,
+                    String cardNumber,
+                    String installment) {
         this.order = order;
         this.paymentStatus = paymentStatus;
         this.paymentMethod = paymentMethod;
         this.paidAt = paidAt;
+        this.approvalNumber = approvalNumber;
+        this.cardType = cardType;
+        this.cardNumber = cardNumber;
+        this.installment = installment;
     }
 
     public static Payment create(

--- a/src/main/resources/flyway/V59__app.sql
+++ b/src/main/resources/flyway/V59__app.sql
@@ -1,0 +1,5 @@
+ALTER TABLE payment
+    ADD COLUMN approval_number VARCHAR(20)  NULL,
+    ADD COLUMN card_type       VARCHAR(20)  NULL,
+    ADD COLUMN card_number     VARCHAR(255) NULL,
+    ADD COLUMN installment     VARCHAR(20)  NULL;

--- a/src/test/java/com/bbangle/bbangle/fixture/board/domain/ProductFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/board/domain/ProductFixture.java
@@ -15,6 +15,14 @@ public final class ProductFixture {
             .build();
     }
 
+    public static Product create(Board board, String title, int price) {
+        return Product.builder()
+            .title(title)
+            .board(board)
+            .price(price)
+            .build();
+    }
+
     public static Product defaultProductWithStore(Store store) {
         return Product.builder()
             .store(store)

--- a/src/test/java/com/bbangle/bbangle/fixture/member/domain/MemberFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/member/domain/MemberFixture.java
@@ -1,0 +1,16 @@
+package com.bbangle.bbangle.fixture.member.domain;
+
+import com.bbangle.bbangle.member.domain.Member;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public final class MemberFixture {
+
+    private MemberFixture() {
+    }
+
+    public static Member createWithId(Long id) {
+        Member member = Member.builder().build();
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/fixture/order/domain/OrderFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/order/domain/OrderFixture.java
@@ -1,9 +1,13 @@
 package com.bbangle.bbangle.fixture.order.domain;
 
+import com.bbangle.bbangle.fixture.member.domain.MemberFixture;
+import com.bbangle.bbangle.fixture.payment.domain.PaymentFixture;
 import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.payment.domain.Payment;
 import com.bbangle.bbangle.seller.domain.Seller;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public final class OrderFixture {
 
@@ -48,6 +52,17 @@ public final class OrderFixture {
         return defaultOrder()
             .seller(seller)
             .build();
+    }
+
+    public static Order createWithMemberAndSeller(Long memberId, Seller seller, int totalAmount) {
+        Order order = defaultOrder()
+            .member(MemberFixture.createWithId(memberId))
+            .seller(seller)
+            .totalAmount(totalAmount)
+            .build();
+        Payment payment = PaymentFixture.createDefaultPayment(order);
+        ReflectionTestUtils.setField(order, "payment", payment);
+        return order;
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/fixture/order/domain/OrderItemFixture.java
+++ b/src/test/java/com/bbangle/bbangle/fixture/order/domain/OrderItemFixture.java
@@ -1,10 +1,14 @@
 package com.bbangle.bbangle.fixture.order.domain;
 
+import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
+import com.bbangle.bbangle.fixture.board.domain.ProductFixture;
 import com.bbangle.bbangle.order.domain.Order;
 import com.bbangle.bbangle.order.domain.OrderItem;
 import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
 import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.store.domain.Store;
 import java.util.ArrayList;
 
 public final class OrderItemFixture {
@@ -70,6 +74,20 @@ public final class OrderItemFixture {
         return defaultOrderItem()
             .product(product)
             .build();
+    }
+
+    public static OrderItem createWithProductAndStatus(
+        Order order, Store store, String productTitle, int price, OrderStatus status
+    ) {
+        Board board = BoardFixture.defaultBoardWithStore(store, productTitle);
+        Product product = ProductFixture.create(board, productTitle, price);
+        OrderItem item = defaultOrderItem()
+            .orderStatus(status)
+            .totalPrice(price)
+            .product(product)
+            .build();
+        order.addOrderItem(item);
+        return item;
     }
 
 }

--- a/src/test/java/com/bbangle/bbangle/order/customer/controller/OrderReceiptControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/customer/controller/OrderReceiptControllerTest.java
@@ -1,0 +1,200 @@
+package com.bbangle.bbangle.order.customer.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.CustomerApiPath;
+import com.bbangle.bbangle.config.security.SecurityConfig;
+import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.order.customer.controller.dto.response.OrderReceiptResponse;
+import com.bbangle.bbangle.order.customer.service.OrderReceiptService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("[컨트롤러 테스트] OrderReceiptController")
+@Import({
+    TestSlackAdaptorConfig.class,
+    TokenProvider.class,
+    TestJwtPropertiesConfig.class,
+    ResponseService.class,
+    SecurityConfig.class
+})
+@WebMvcTest(OrderReceiptController.class)
+@ActiveProfiles("test")
+class OrderReceiptControllerTest {
+
+    private static final String RECEIPT_URL = CustomerApiPath.PREFIX + "/orders/{orderId}/receipt";
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private OrderReceiptService orderReceiptService;
+
+    @SpyBean
+    private ResponseService responseService;
+
+    @Nested
+    @DisplayName("GET /api/v1/customer/orders/{orderId}/receipt")
+    class GetReceipt {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @WithMockUser(roles = "CUSTOMER")
+            @DisplayName("정상 요청 시 영수증 정보를 반환한다")
+            void getReceipt_success() throws Exception {
+                // given
+                Long orderId = 1L;
+                OrderReceiptResponse response = new OrderReceiptResponse(
+                    new OrderReceiptResponse.PaymentInfo(
+                        "1232241511", "신용/체크카드", "신한",
+                        "484322****1234", "일시불",
+                        LocalDateTime.of(2025, 5, 29, 18, 0, 10)
+                    ),
+                    new OrderReceiptResponse.PurchaseInfo(
+                        "20100024120", "비건 쌀빵 1종 외 1건",
+                        6727, 0, 673, 7400
+                    ),
+                    new OrderReceiptResponse.StoreInfo(
+                        "빵그리의 오븐", "521-03-12345", "경기도 성남시 중원구 성남대로 1234 101호"
+                    )
+                );
+
+                given(orderReceiptService.getReceipt(any(), eq(orderId))).willReturn(response);
+
+                // when & then
+                mvc.perform(get(RECEIPT_URL, orderId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.code").value(0))
+                    .andExpect(jsonPath("$.result.paymentInfo.approvalNumber").value("1232241511"))
+                    .andExpect(jsonPath("$.result.paymentInfo.transactionType").value("신용/체크카드"))
+                    .andExpect(jsonPath("$.result.paymentInfo.cardType").value("신한"))
+                    .andExpect(jsonPath("$.result.paymentInfo.cardNumber").value("484322****1234"))
+                    .andExpect(jsonPath("$.result.paymentInfo.installment").value("일시불"))
+                    .andExpect(jsonPath("$.result.purchaseInfo.orderNumber").value("20100024120"))
+                    .andExpect(jsonPath("$.result.purchaseInfo.productName").value("비건 쌀빵 1종 외 1건"))
+                    .andExpect(jsonPath("$.result.purchaseInfo.totalAmount").value(7400))
+                    .andExpect(jsonPath("$.result.purchaseInfo.taxableAmount").value(6727))
+                    .andExpect(jsonPath("$.result.purchaseInfo.vat").value(673))
+                    .andExpect(jsonPath("$.result.purchaseInfo.nonTaxableAmount").value(0))
+                    .andExpect(jsonPath("$.result.storeInfo.storeName").value("빵그리의 오븐"))
+                    .andExpect(jsonPath("$.result.storeInfo.businessNumber").value("521-03-12345"));
+
+                then(orderReceiptService).should().getReceipt(any(), eq(orderId));
+            }
+
+            @Test
+            @WithMockUser(roles = "CUSTOMER")
+            @DisplayName("현금 결제 주문은 카드 관련 필드가 null로 반환된다")
+            void getReceipt_cashPayment_cardFieldsAreNull() throws Exception {
+                // given
+                Long orderId = 2L;
+                OrderReceiptResponse response = new OrderReceiptResponse(
+                    new OrderReceiptResponse.PaymentInfo(
+                        "9988776655", "무통장입금", null, null, null,
+                        LocalDateTime.of(2025, 5, 29, 18, 0, 10)
+                    ),
+                    new OrderReceiptResponse.PurchaseInfo(
+                        "20100024121", "비건 쌀빵 1종", 9091, 0, 909, 10000
+                    ),
+                    new OrderReceiptResponse.StoreInfo("빵그리의 오븐", "521-03-12345", "경기도 성남시")
+                );
+
+                given(orderReceiptService.getReceipt(any(), eq(orderId))).willReturn(response);
+
+                // when & then
+                mvc.perform(get(RECEIPT_URL, orderId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.paymentInfo.transactionType").value("무통장입금"))
+                    .andExpect(jsonPath("$.result.paymentInfo.cardType").isEmpty())
+                    .andExpect(jsonPath("$.result.paymentInfo.cardNumber").isEmpty())
+                    .andExpect(jsonPath("$.result.paymentInfo.installment").isEmpty());
+
+                then(orderReceiptService).should().getReceipt(any(), eq(orderId));
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("인증 없이 요청하면 401을 반환한다")
+            void getReceipt_fail_whenUnauthorized() throws Exception {
+                // when & then
+                mvc.perform(get(RECEIPT_URL, 1L))
+                    .andExpect(status().isUnauthorized());
+
+                then(orderReceiptService).shouldHaveNoInteractions();
+                then(responseService).shouldHaveNoInteractions();
+            }
+
+            @Test
+            @WithMockUser(roles = "CUSTOMER")
+            @DisplayName("존재하지 않는 주문 조회 시 404를 반환한다")
+            void getReceipt_fail_whenOrderNotFound() throws Exception {
+                // given
+                Long orderId = 999L;
+                given(orderReceiptService.getReceipt(any(), eq(orderId)))
+                    .willThrow(new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
+
+                // when & then
+                mvc.perform(get(RECEIPT_URL, orderId))
+                    .andExpect(status().isNotFound());
+
+                then(orderReceiptService).should().getReceipt(any(), eq(orderId));
+            }
+
+            @Test
+            @WithMockUser(roles = "CUSTOMER")
+            @DisplayName("다른 회원의 주문 조회 시 403을 반환한다")
+            void getReceipt_fail_whenAccessDenied() throws Exception {
+                // given
+                Long orderId = 1L;
+                given(orderReceiptService.getReceipt(any(), eq(orderId)))
+                    .willThrow(new BbangleException(BbangleErrorCode.ORDER_ACCESS_DENIED));
+
+                // when & then
+                mvc.perform(get(RECEIPT_URL, orderId))
+                    .andExpect(status().isForbidden());
+
+                then(orderReceiptService).should().getReceipt(any(), eq(orderId));
+            }
+
+            @Test
+            @WithMockUser(roles = "SELLER")
+            @DisplayName("SELLER 권한으로 요청하면 403을 반환한다")
+            void getReceipt_fail_whenSellerRole() throws Exception {
+                // when & then
+                mvc.perform(get(RECEIPT_URL, 1L))
+                    .andExpect(status().isForbidden());
+
+                then(orderReceiptService).shouldHaveNoInteractions();
+            }
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/order/customer/service/OrderReceiptServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/customer/service/OrderReceiptServiceUnitTest.java
@@ -1,0 +1,193 @@
+package com.bbangle.bbangle.order.customer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.order.domain.OrderFixture;
+import com.bbangle.bbangle.fixture.order.domain.OrderItemFixture;
+import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
+import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.order.customer.controller.dto.response.OrderReceiptResponse;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderRepository;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.store.domain.Store;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("[단위 테스트] OrderReceiptService")
+@ExtendWith(MockitoExtension.class)
+class OrderReceiptServiceUnitTest {
+
+    @InjectMocks
+    private OrderReceiptService sut;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    private Store store;
+    private Seller seller;
+
+    @BeforeEach
+    void setUp() {
+        store = StoreFixture.defaultStore();
+        seller = SellerFixture.defaultSeller(store);
+    }
+
+    @Nested
+    @DisplayName("getReceipt")
+    class GetReceipt {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("유효한 주문 조회 시 영수증을 반환한다")
+            void getReceipt_success() {
+                // given
+                Long memberId = 1L;
+                Long orderId = 10L;
+
+                Order order = OrderFixture.createWithMemberAndSeller(memberId, seller, 11100);
+                OrderItemFixture.createWithProductAndStatus(order, store, "비건 쌀빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
+                OrderItemFixture.createWithProductAndStatus(order, store, "비건 현미빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
+                OrderItemFixture.createWithProductAndStatus(order, store, "비건 귀리빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
+
+                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+
+                // when
+                OrderReceiptResponse result = sut.getReceipt(memberId, orderId);
+
+                // then
+                assertThat(result.purchaseInfo().totalAmount()).isEqualTo(11100);
+                assertThat(result.purchaseInfo().orderNumber()).isEqualTo(order.getOrderNumber());
+                assertThat(result.purchaseInfo().productName()).isEqualTo("비건 쌀빵 1종 외 2건");
+                assertThat(result.storeInfo().storeName()).isEqualTo(store.getName());
+                assertThat(result.storeInfo().businessNumber()).isEqualTo(store.getIdentifier());
+                then(orderRepository).should().findByIdWithFullAssociations(orderId);
+            }
+
+            @Test
+            @DisplayName("취소 완료(CANCEL_APPROVED) 항목은 합계금액에서 제외된다")
+            void getReceipt_excludes_cancelApprovedItems() {
+                // given
+                Long memberId = 1L;
+                Long orderId = 10L;
+
+                Order order = OrderFixture.createWithMemberAndSeller(memberId, seller, 11100);
+                OrderItemFixture.createWithProductAndStatus(order, store, "비건 쌀빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
+                OrderItemFixture.createWithProductAndStatus(order, store, "비건 현미빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
+                OrderItemFixture.createWithProductAndStatus(order, store, "비건 귀리빵 1종", 3700, OrderStatus.CANCEL_APPROVED);
+
+                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+
+                // when
+                OrderReceiptResponse result = sut.getReceipt(memberId, orderId);
+
+                // then
+                assertThat(result.purchaseInfo().totalAmount()).isEqualTo(7400);
+                assertThat(result.purchaseInfo().productName()).isEqualTo("비건 쌀빵 1종 외 1건");
+            }
+
+            @Test
+            @DisplayName("반품 완료(RETURN_COMPLETED) 항목은 합계금액에서 제외된다")
+            void getReceipt_excludes_returnCompletedItems() {
+                // given
+                Long memberId = 1L;
+                Long orderId = 10L;
+
+                Order order = OrderFixture.createWithMemberAndSeller(memberId, seller, 11100);
+                OrderItemFixture.createWithProductAndStatus(order, store, "비건 쌀빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
+                OrderItemFixture.createWithProductAndStatus(order, store, "비건 현미빵 1종", 3700, OrderStatus.RETURN_COMPLETED);
+
+                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+
+                // when
+                OrderReceiptResponse result = sut.getReceipt(memberId, orderId);
+
+                // then
+                assertThat(result.purchaseInfo().totalAmount()).isEqualTo(3700);
+                assertThat(result.purchaseInfo().productName()).isEqualTo("비건 쌀빵 1종");
+            }
+
+            @Test
+            @DisplayName("활성 항목이 1개이면 '외 N건' 없이 상품명만 반환된다")
+            void getReceipt_singleItem_productNameWithoutSuffix() {
+                // given
+                Long memberId = 1L;
+                Long orderId = 10L;
+
+                Order order = OrderFixture.createWithMemberAndSeller(memberId, seller, 3700);
+                OrderItemFixture.createWithProductAndStatus(order, store, "비건 쌀빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
+
+                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+
+                // when
+                OrderReceiptResponse result = sut.getReceipt(memberId, orderId);
+
+                // then
+                assertThat(result.purchaseInfo().productName()).isEqualTo("비건 쌀빵 1종");
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("존재하지 않는 주문 조회 시 ORDER_NOT_FOUND 예외가 발생한다")
+            void getReceipt_throwsException_whenOrderNotFound() {
+                // given
+                Long memberId = 1L;
+                Long orderId = 999L;
+
+                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.empty());
+
+                // when & then
+                BbangleException ex = catchThrowableOfType(
+                    () -> sut.getReceipt(memberId, orderId),
+                    BbangleException.class
+                );
+
+                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_NOT_FOUND);
+                then(orderRepository).should().findByIdWithFullAssociations(orderId);
+            }
+
+            @Test
+            @DisplayName("다른 회원의 주문 조회 시 ORDER_ACCESS_DENIED 예외가 발생한다")
+            void getReceipt_throwsException_whenAccessDenied() {
+                // given
+                Long requestMemberId = 2L;
+                Long actualMemberId = 1L;
+                Long orderId = 10L;
+
+                Order order = OrderFixture.createWithMemberAndSeller(actualMemberId, seller, 3700);
+                OrderItemFixture.createWithProductAndStatus(order, store, "비건 쌀빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
+
+                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+
+                // when & then
+                BbangleException ex = catchThrowableOfType(
+                    () -> sut.getReceipt(requestMemberId, orderId),
+                    BbangleException.class
+                );
+
+                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_ACCESS_DENIED);
+                then(orderRepository).should().findByIdWithFullAssociations(orderId);
+            }
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/order/customer/service/OrderReceiptServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/customer/service/OrderReceiptServiceUnitTest.java
@@ -71,7 +71,7 @@ class OrderReceiptServiceUnitTest {
                 OrderItemFixture.createWithProductAndStatus(order, store, "비건 현미빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
                 OrderItemFixture.createWithProductAndStatus(order, store, "비건 귀리빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
 
-                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+                given(orderRepository.findByIdWithFullAssociations(orderId, memberId)).willReturn(Optional.of(order));
 
                 // when
                 OrderReceiptResponse result = sut.getReceipt(memberId, orderId);
@@ -82,7 +82,7 @@ class OrderReceiptServiceUnitTest {
                 assertThat(result.purchaseInfo().productName()).isEqualTo("비건 쌀빵 1종 외 2건");
                 assertThat(result.storeInfo().storeName()).isEqualTo(store.getName());
                 assertThat(result.storeInfo().businessNumber()).isEqualTo(store.getIdentifier());
-                then(orderRepository).should().findByIdWithFullAssociations(orderId);
+                then(orderRepository).should().findByIdWithFullAssociations(orderId, memberId);
             }
 
             @Test
@@ -97,7 +97,7 @@ class OrderReceiptServiceUnitTest {
                 OrderItemFixture.createWithProductAndStatus(order, store, "비건 현미빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
                 OrderItemFixture.createWithProductAndStatus(order, store, "비건 귀리빵 1종", 3700, OrderStatus.CANCEL_APPROVED);
 
-                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+                given(orderRepository.findByIdWithFullAssociations(orderId, memberId)).willReturn(Optional.of(order));
 
                 // when
                 OrderReceiptResponse result = sut.getReceipt(memberId, orderId);
@@ -118,7 +118,7 @@ class OrderReceiptServiceUnitTest {
                 OrderItemFixture.createWithProductAndStatus(order, store, "비건 쌀빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
                 OrderItemFixture.createWithProductAndStatus(order, store, "비건 현미빵 1종", 3700, OrderStatus.RETURN_COMPLETED);
 
-                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+                given(orderRepository.findByIdWithFullAssociations(orderId, memberId)).willReturn(Optional.of(order));
 
                 // when
                 OrderReceiptResponse result = sut.getReceipt(memberId, orderId);
@@ -138,7 +138,7 @@ class OrderReceiptServiceUnitTest {
                 Order order = OrderFixture.createWithMemberAndSeller(memberId, seller, 3700);
                 OrderItemFixture.createWithProductAndStatus(order, store, "비건 쌀빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
 
-                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+                given(orderRepository.findByIdWithFullAssociations(orderId, memberId)).willReturn(Optional.of(order));
 
                 // when
                 OrderReceiptResponse result = sut.getReceipt(memberId, orderId);
@@ -161,7 +161,7 @@ class OrderReceiptServiceUnitTest {
                 String decryptedCardNumber = "1234567890123456";
                 ReflectionTestUtils.setField(order.getPayment(), "cardNumber", encryptedCardNumber);
 
-                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+                given(orderRepository.findByIdWithFullAssociations(orderId, memberId)).willReturn(Optional.of(order));
                 given(aesEncryptionUtil.decrypt(encryptedCardNumber)).willReturn(decryptedCardNumber);
 
                 // when
@@ -182,7 +182,7 @@ class OrderReceiptServiceUnitTest {
                 Order order = OrderFixture.createWithMemberAndSeller(memberId, seller, 3700);
                 OrderItemFixture.createWithProductAndStatus(order, store, "비건 쌀빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
 
-                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+                given(orderRepository.findByIdWithFullAssociations(orderId, memberId)).willReturn(Optional.of(order));
                 given(aesEncryptionUtil.decrypt(null)).willReturn(null);
 
                 // when
@@ -204,7 +204,7 @@ class OrderReceiptServiceUnitTest {
                 Long memberId = 1L;
                 Long orderId = 999L;
 
-                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.empty());
+                given(orderRepository.findByIdWithFullAssociations(orderId, memberId)).willReturn(Optional.empty());
 
                 // when & then
                 BbangleException ex = catchThrowableOfType(
@@ -213,21 +213,17 @@ class OrderReceiptServiceUnitTest {
                 );
 
                 assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_NOT_FOUND);
-                then(orderRepository).should().findByIdWithFullAssociations(orderId);
+                then(orderRepository).should().findByIdWithFullAssociations(orderId, memberId);
             }
 
             @Test
-            @DisplayName("다른 회원의 주문 조회 시 ORDER_ACCESS_DENIED 예외가 발생한다")
+            @DisplayName("다른 회원의 주문 조회 시 ORDER_NOT_FOUND 예외가 발생한다")
             void getReceipt_throwsException_whenAccessDenied() {
                 // given
                 Long requestMemberId = 2L;
-                Long actualMemberId = 1L;
                 Long orderId = 10L;
 
-                Order order = OrderFixture.createWithMemberAndSeller(actualMemberId, seller, 3700);
-                OrderItemFixture.createWithProductAndStatus(order, store, "비건 쌀빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
-
-                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+                given(orderRepository.findByIdWithFullAssociations(orderId, requestMemberId)).willReturn(Optional.empty());
 
                 // when & then
                 BbangleException ex = catchThrowableOfType(
@@ -235,8 +231,8 @@ class OrderReceiptServiceUnitTest {
                     BbangleException.class
                 );
 
-                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_ACCESS_DENIED);
-                then(orderRepository).should().findByIdWithFullAssociations(orderId);
+                assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.ORDER_NOT_FOUND);
+                then(orderRepository).should().findByIdWithFullAssociations(orderId, requestMemberId);
             }
         }
     }

--- a/src/test/java/com/bbangle/bbangle/order/customer/service/OrderReceiptServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/customer/service/OrderReceiptServiceUnitTest.java
@@ -17,6 +17,7 @@ import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.repository.OrderRepository;
 import com.bbangle.bbangle.seller.domain.Seller;
 import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.util.AesEncryptionUtil;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("[단위 테스트] OrderReceiptService")
 @ExtendWith(MockitoExtension.class)
@@ -36,6 +38,9 @@ class OrderReceiptServiceUnitTest {
 
     @Mock
     private OrderRepository orderRepository;
+
+    @Mock
+    private AesEncryptionUtil aesEncryptionUtil;
 
     private Store store;
     private Seller seller;
@@ -140,6 +145,51 @@ class OrderReceiptServiceUnitTest {
 
                 // then
                 assertThat(result.purchaseInfo().productName()).isEqualTo("비건 쌀빵 1종");
+            }
+
+            @Test
+            @DisplayName("DB에 암호화된 카드번호는 복호화 후 마스킹되어 반환된다")
+            void getReceipt_decryptsAndMasksCardNumber() {
+                // given
+                Long memberId = 1L;
+                Long orderId = 10L;
+
+                Order order = OrderFixture.createWithMemberAndSeller(memberId, seller, 3700);
+                OrderItemFixture.createWithProductAndStatus(order, store, "비건 쌀빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
+
+                String encryptedCardNumber = "encrypted-card-number";
+                String decryptedCardNumber = "1234567890123456";
+                ReflectionTestUtils.setField(order.getPayment(), "cardNumber", encryptedCardNumber);
+
+                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+                given(aesEncryptionUtil.decrypt(encryptedCardNumber)).willReturn(decryptedCardNumber);
+
+                // when
+                OrderReceiptResponse result = sut.getReceipt(memberId, orderId);
+
+                // then
+                assertThat(result.paymentInfo().cardNumber()).isEqualTo("123456******3456");
+                then(aesEncryptionUtil).should().decrypt(encryptedCardNumber);
+            }
+
+            @Test
+            @DisplayName("카드번호가 없는 주문(무통장입금 등)은 cardNumber가 null로 반환된다")
+            void getReceipt_nullCardNumber_returnsNullCardNumber() {
+                // given
+                Long memberId = 1L;
+                Long orderId = 10L;
+
+                Order order = OrderFixture.createWithMemberAndSeller(memberId, seller, 3700);
+                OrderItemFixture.createWithProductAndStatus(order, store, "비건 쌀빵 1종", 3700, OrderStatus.PURCHASE_CONFIRMED);
+
+                given(orderRepository.findByIdWithFullAssociations(orderId)).willReturn(Optional.of(order));
+                given(aesEncryptionUtil.decrypt(null)).willReturn(null);
+
+                // when
+                OrderReceiptResponse result = sut.getReceipt(memberId, orderId);
+
+                // then
+                assertThat(result.paymentInfo().cardNumber()).isNull();
             }
         }
 

--- a/src/test/java/com/bbangle/bbangle/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/repository/OrderRepositoryTest.java
@@ -1,0 +1,204 @@
+package com.bbangle.bbangle.order.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bbangle.bbangle.TestContainersConfig;
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.config.QueryDslConfig;
+import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
+import com.bbangle.bbangle.fixture.board.domain.ProductFixture;
+import com.bbangle.bbangle.fixture.order.domain.OrderFixture;
+import com.bbangle.bbangle.fixture.order.domain.OrderItemFixture;
+import com.bbangle.bbangle.fixture.payment.domain.PaymentFixture;
+import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
+import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.payment.domain.Payment;
+import com.bbangle.bbangle.search.repository.component.SearchFilter;
+import com.bbangle.bbangle.search.repository.component.SearchSort;
+import com.bbangle.bbangle.seller.domain.Seller;
+import com.bbangle.bbangle.store.domain.Store;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DisplayName("[Repository] - OrderRepository.findByIdWithFullAssociations")
+@ActiveProfiles("test")
+@Import({
+    TestContainersConfig.class,
+    QueryDslConfig.class,
+    SearchFilter.class,
+    SearchSort.class
+})
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class OrderRepositoryTest {
+
+    @Autowired
+    private OrderRepository sut;
+
+    @Autowired
+    private EntityManager em;
+
+    private Store store;
+    private Seller seller;
+    private Board board;
+    private Product product1;
+    private Product product2;
+
+    @BeforeEach
+    void setUp() {
+        store = StoreFixture.defaultStore();
+        em.persist(store);
+
+        seller = SellerFixture.defaultSeller(store);
+        em.persist(seller);
+
+        board = BoardFixture.defaultBoardWithStore(store, "비건빵 모음");
+        em.persist(board);
+
+        product1 = ProductFixture.create(board, "비건 쌀빵 1종");
+        product2 = ProductFixture.create(board, "비건 현미빵 1종");
+        em.persist(product1);
+        em.persist(product2);
+
+        em.flush();
+        em.clear();
+    }
+
+    @Nested
+    @DisplayName("findByIdWithFullAssociations")
+    class FindByIdWithFullAssociations {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("payment, seller, store, orderItems, product가 모두 fetchJoin되어 반환된다")
+            void findById_returnsOrder_withAllAssociations() {
+                // given
+                Order order = OrderFixture.defaultOrder()
+                    .seller(em.find(Seller.class, seller.getId()))
+                    .build();
+                em.persist(order);
+
+                OrderItem item1 = OrderItemFixture.defaultOrderItem()
+                    .order(order)
+                    .product(em.find(Product.class, product1.getId()))
+                    .orderStatus(OrderStatus.PURCHASE_CONFIRMED)
+                    .totalPrice(3700)
+                    .build();
+                order.addOrderItem(item1);
+                em.persist(item1);
+
+                Payment payment = PaymentFixture.createDefaultPayment(order);
+                em.persist(payment);
+
+                em.flush();
+                em.clear();
+
+                // when
+                Optional<Order> result = sut.findByIdWithFullAssociations(order.getId());
+
+                // then
+                assertThat(result).isPresent();
+
+                Order found = result.get();
+                assertThat(found.getPayment()).isNotNull();
+                assertThat(found.getSeller()).isNotNull();
+                assertThat(found.getSeller().getStore()).isNotNull();
+                assertThat(found.getSeller().getStore().getName()).isEqualTo(store.getName());
+                assertThat(found.getOrderItems()).hasSize(1);
+                assertThat(found.getOrderItems().get(0).getProduct()).isNotNull();
+                assertThat(found.getOrderItems().get(0).getProduct().getTitle()).isEqualTo("비건 쌀빵 1종");
+            }
+
+            @Test
+            @DisplayName("payment가 없는 주문도 leftJoin으로 결과가 반환된다")
+            void findById_returnsOrder_whenPaymentIsNull() {
+                // given
+                Order order = OrderFixture.defaultOrder()
+                    .seller(em.find(Seller.class, seller.getId()))
+                    .build();
+                em.persist(order);
+
+                OrderItem item = OrderItemFixture.defaultOrderItem()
+                    .order(order)
+                    .product(em.find(Product.class, product1.getId()))
+                    .build();
+                order.addOrderItem(item);
+                em.persist(item);
+
+                em.flush();
+                em.clear();
+
+                // when
+                Optional<Order> result = sut.findByIdWithFullAssociations(order.getId());
+
+                // then
+                assertThat(result).isPresent();
+                assertThat(result.get().getPayment()).isNull();
+                assertThat(result.get().getOrderItems()).hasSize(1);
+            }
+
+            @Test
+            @DisplayName("여러 orderItem이 있어도 distinct로 중복 없이 Order 하나가 반환된다")
+            void findById_returnsOneOrder_withMultipleOrderItems() {
+                // given
+                Order order = OrderFixture.defaultOrder()
+                    .seller(em.find(Seller.class, seller.getId()))
+                    .build();
+                em.persist(order);
+
+                OrderItem item1 = OrderItemFixture.defaultOrderItem()
+                    .order(order).product(em.find(Product.class, product1.getId())).build();
+                OrderItem item2 = OrderItemFixture.defaultOrderItem()
+                    .order(order).product(em.find(Product.class, product2.getId())).build();
+                order.addOrderItem(item1);
+                order.addOrderItem(item2);
+                em.persist(item1);
+                em.persist(item2);
+
+                em.flush();
+                em.clear();
+
+                // when
+                Optional<Order> result = sut.findByIdWithFullAssociations(order.getId());
+
+                // then
+                assertThat(result).isPresent();
+                assertThat(result.get().getOrderItems()).hasSize(2);
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class NotFound {
+
+            @Test
+            @DisplayName("존재하지 않는 orderId 조회 시 Optional.empty()를 반환한다")
+            void findById_returnsEmpty_whenOrderNotFound() {
+                // given
+                Long nonExistentOrderId = 999L;
+
+                // when
+                Optional<Order> result = sut.findByIdWithFullAssociations(nonExistentOrderId);
+
+                // then
+                assertThat(result).isEmpty();
+            }
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/repository/OrderRepositoryTest.java
@@ -13,6 +13,7 @@ import com.bbangle.bbangle.fixture.order.domain.OrderItemFixture;
 import com.bbangle.bbangle.fixture.payment.domain.PaymentFixture;
 import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.member.domain.Member;
 import com.bbangle.bbangle.order.domain.Order;
 import com.bbangle.bbangle.order.domain.OrderItem;
 import com.bbangle.bbangle.order.domain.model.OrderStatus;
@@ -56,6 +57,7 @@ class OrderRepositoryTest {
     private Board board;
     private Product product1;
     private Product product2;
+    private Member member;
 
     @BeforeEach
     void setUp() {
@@ -72,6 +74,9 @@ class OrderRepositoryTest {
         product2 = ProductFixture.create(board, "비건 현미빵 1종");
         em.persist(product1);
         em.persist(product2);
+
+        member = Member.builder().build();
+        em.persist(member);
 
         em.flush();
         em.clear();
@@ -91,6 +96,7 @@ class OrderRepositoryTest {
                 // given
                 Order order = OrderFixture.defaultOrder()
                     .seller(em.find(Seller.class, seller.getId()))
+                    .member(em.find(Member.class, member.getId()))
                     .build();
                 em.persist(order);
 
@@ -110,7 +116,7 @@ class OrderRepositoryTest {
                 em.clear();
 
                 // when
-                Optional<Order> result = sut.findByIdWithFullAssociations(order.getId());
+                Optional<Order> result = sut.findByIdWithFullAssociations(order.getId(), member.getId());
 
                 // then
                 assertThat(result).isPresent();
@@ -131,6 +137,7 @@ class OrderRepositoryTest {
                 // given
                 Order order = OrderFixture.defaultOrder()
                     .seller(em.find(Seller.class, seller.getId()))
+                    .member(em.find(Member.class, member.getId()))
                     .build();
                 em.persist(order);
 
@@ -145,7 +152,7 @@ class OrderRepositoryTest {
                 em.clear();
 
                 // when
-                Optional<Order> result = sut.findByIdWithFullAssociations(order.getId());
+                Optional<Order> result = sut.findByIdWithFullAssociations(order.getId(), member.getId());
 
                 // then
                 assertThat(result).isPresent();
@@ -159,6 +166,7 @@ class OrderRepositoryTest {
                 // given
                 Order order = OrderFixture.defaultOrder()
                     .seller(em.find(Seller.class, seller.getId()))
+                    .member(em.find(Member.class, member.getId()))
                     .build();
                 em.persist(order);
 
@@ -175,7 +183,7 @@ class OrderRepositoryTest {
                 em.clear();
 
                 // when
-                Optional<Order> result = sut.findByIdWithFullAssociations(order.getId());
+                Optional<Order> result = sut.findByIdWithFullAssociations(order.getId(), member.getId());
 
                 // then
                 assertThat(result).isPresent();
@@ -194,7 +202,37 @@ class OrderRepositoryTest {
                 Long nonExistentOrderId = 999L;
 
                 // when
-                Optional<Order> result = sut.findByIdWithFullAssociations(nonExistentOrderId);
+                Optional<Order> result = sut.findByIdWithFullAssociations(nonExistentOrderId, member.getId());
+
+                // then
+                assertThat(result).isEmpty();
+            }
+
+            @Test
+            @DisplayName("다른 회원의 주문 조회 시 Optional.empty()를 반환한다")
+            void findById_returnsEmpty_whenMemberDoesNotOwnOrder() {
+                // given
+                Member otherMember = Member.builder().build();
+                em.persist(otherMember);
+
+                Order order = OrderFixture.defaultOrder()
+                    .seller(em.find(Seller.class, seller.getId()))
+                    .member(em.find(Member.class, member.getId()))
+                    .build();
+                em.persist(order);
+
+                OrderItem item = OrderItemFixture.defaultOrderItem()
+                    .order(order)
+                    .product(em.find(Product.class, product1.getId()))
+                    .build();
+                order.addOrderItem(item);
+                em.persist(item);
+
+                em.flush();
+                em.clear();
+
+                // when
+                Optional<Order> result = sut.findByIdWithFullAssociations(order.getId(), otherMember.getId());
 
                 // then
                 assertThat(result).isEmpty();


### PR DESCRIPTION
## History

<!--연관된 이슈 없음-->

## 🚀 Major Changes & Explanations

* [feat] Payment 테이블에 카드 결제 상세 필드 추가 (Flyway V59)
  - `approval_number`, `card_type`(CardType enum), `card_number`, `installment` 컬럼 추가
  - `card_number`는 암호화 여부 결정 후 저장 처리 예정 (TODO 주석)

* [feat] 영수증 조회 API 구현 - `GET /api/v1/customer/orders/{orderId}/receipt`
  - `CustomerApiPath`에 `/orders/**` 인증 경로 추가 (`ROLE_CUSTOMER` 필요)
  - `OrderDSLRepository`에 `findByIdWithFullAssociations` 추가
    - payment(leftJoin), seller→store, orderItems→product fetchJoin
    - `fetchOne` 대신 `fetch()`로 컬렉션 join 시 NonUniqueResultException 방지
  - 취소(`CANCEL_APPROVED`), 반품(`RETURN_COMPLETED`) 항목은 합계금액에서 제외
  - 카드번호 마스킹 앞 6자리 + `*` + 뒤 4자리 (상수 기반, 길이 무관)

* [test] 컨트롤러 / 단위 / Repository 테스트 작성 (Nested 구조)
  - Fixture 확장: `MemberFixture`, `OrderFixture.createWithMemberAndSeller`, `OrderItemFixture.createWithProductAndStatus`, `ProductFixture.create(board, title, price)`

## 📷 Test Image

<!-- API 테스트 완료 (로컬 실행 확인) -->

## 💡 ETC

- `card_number` 암호화 방식 결정 필요 — 결정 후 `OrderReceiptService`의 TODO 제거 및 복호화 로직 추가
- 현재 `Payment.create()` 팩토리 메서드는 기존 호환성 유지 (새 카드 필드 미포함). PG 연동 시 확장 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 고객 주문 전자 영수증 조회 기능 추가: `/api/v1/customer/orders/{orderId}/receipt`에서 결제/구매/매장 정보를 제공
  * 영수증 조회에 해당하는 고객 API 경로 매칭 범위 확장
  * 결제 상세(승인번호, 카드유형/카드번호, 할부) 및 카드 유형 정보 노출

* **Bug Fixes**
  * 영수증 집계에서 취소/반품 주문 항목 제외

* **Tests**
  * 영수증 조회 컨트롤러/서비스/레포지토리 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->