### PR TITLE
[Fix] (판매자) 셀러 승인 시 충전금 잔액 자동 생성

### DIFF
--- a/src/main/java/com/bbangle/bbangle/charge/repository/ChargeBalanceRepository.java
+++ b/src/main/java/com/bbangle/bbangle/charge/repository/ChargeBalanceRepository.java
@@ -12,6 +12,8 @@ public interface ChargeBalanceRepository extends JpaRepository<ChargeBalance, Lo
 
   Optional<ChargeBalance> findBySellerId(Long sellerId);
 
+  boolean existsBySellerId(Long sellerId);
+
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT cb FROM ChargeBalance cb WHERE cb.seller.id = :sellerId")
   Optional<ChargeBalance> findBySellerIdWithLock(@Param("sellerId") Long sellerId);

--- a/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
@@ -1,5 +1,7 @@
 package com.bbangle.bbangle.store.admin.service;
 
+import com.bbangle.bbangle.charge.domain.ChargeBalance;
+import com.bbangle.bbangle.charge.repository.ChargeBalanceRepository;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.seller.admin.controller.dto.AdminSellerRequest.StoreApplicationApprove;
@@ -48,6 +50,7 @@ public class AdminStoreService {
     private final StoreRepository storeRepository;
     private final SellerRepository sellerRepository;
     private final StoreApplicationRepository storeApplicationRepository;
+    private final ChargeBalanceRepository chargeBalanceRepository;
     private final AdminStoreMapper adminStoreMapper;
 
     @Transactional
@@ -247,6 +250,11 @@ public class AdminStoreService {
 
         application.getSeller().registerStore(store, command.sellerName());
         application.approve();
+
+        if (!chargeBalanceRepository.existsBySellerId(application.getSeller().getId())) {
+            chargeBalanceRepository.save(ChargeBalance.create(application.getSeller()));
+        }
+
         return RegisterApproveResult.builder()
             .storeApplication(application)
             .store(store)

--- a/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServicePartialSuccessTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServicePartialSuccessTest.java
@@ -5,8 +5,11 @@ import static com.bbangle.bbangle.fixture.store.domain.StoreFixture.NEW_IDENTIFI
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.bbangle.bbangle.charge.domain.ChargeBalance;
+import com.bbangle.bbangle.charge.repository.ChargeBalanceRepository;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.charge.domain.ChargeBalanceFixture;
 import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreApplicationFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
@@ -20,6 +23,8 @@ import com.bbangle.bbangle.store.domain.StoreApplication;
 import com.bbangle.bbangle.store.domain.model.StoreApprovalStatus;
 import com.bbangle.bbangle.store.repository.StoreApplicationRepository;
 import com.bbangle.bbangle.store.repository.StoreRepository;
+import java.math.BigDecimal;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,15 +49,19 @@ class AdminStoreServicePartialSuccessTest {
     @Autowired
     private StoreApplicationRepository storeApplicationRepository;
 
+    @Autowired
+    private ChargeBalanceRepository chargeBalanceRepository;
+
     @AfterEach
     void tearDown() {
+        chargeBalanceRepository.deleteAll();
         storeApplicationRepository.deleteAll();
         sellerRepository.deleteAll();
         storeRepository.deleteAll();
     }
 
     @Test
-    @DisplayName("store가 없으면 createStore 후 승인 처리")
+    @DisplayName("store가 없으면 createStore 후 승인 처리 및 충전금 생성")
     void success_registerApprove_createStore() {
 
         // given
@@ -72,16 +81,19 @@ class AdminStoreServicePartialSuccessTest {
         Store savedStore = storeRepository.findById(result.store().getId()).orElseThrow();
         Seller savedSeller = sellerRepository.findById(seller.getId()).orElseThrow();
         StoreApplication savedApplication = storeApplicationRepository.findById(application.getId()).orElseThrow();
+        Optional<ChargeBalance> chargeBalance = chargeBalanceRepository.findBySellerId(seller.getId());
 
         assertThat(savedStore.getId()).isNotNull();
         assertThat(savedStore.getIdentifier()).isEqualTo(NEW_IDENTIFIER);
         assertThat(savedSeller.getCertificationStatus()).isEqualTo(CertificationStatus.APPROVED);
         assertThat(savedSeller.getStore().getId()).isEqualTo(savedStore.getId());
         assertThat(savedApplication.getStatus()).isEqualTo(StoreApprovalStatus.APPROVE);
+        assertThat(chargeBalance).isPresent();
+        assertThat(chargeBalance.get().getBalance()).isEqualByComparingTo(BigDecimal.ZERO);
     }
 
     @Test
-    @DisplayName("store가 있으면 updateStore 후 승인 처리")
+    @DisplayName("store가 있으면 updateStore 후 승인 처리 및 충전금 생성")
     void success_registerApprove_updateStore() {
 
         // given
@@ -108,7 +120,6 @@ class AdminStoreServicePartialSuccessTest {
             .sellerName("updatedSeller")
             .build();
 
-
         // when
         adminStoreService.registerApprove(application.getId(), command);
 
@@ -116,6 +127,7 @@ class AdminStoreServicePartialSuccessTest {
         Store updatedStore = storeRepository.findById(store.getId()).orElseThrow();
         Seller updatedSeller = sellerRepository.findById(seller.getId()).orElseThrow();
         StoreApplication updatedApplication = storeApplicationRepository.findById(application.getId()).orElseThrow();
+        Optional<ChargeBalance> chargeBalance = chargeBalanceRepository.findBySellerId(seller.getId());
 
         assertThat(updatedStore.getId()).isEqualTo(store.getId());
         assertThat(updatedStore.getIdentifier()).isEqualTo(NEW_IDENTIFIER);
@@ -123,6 +135,35 @@ class AdminStoreServicePartialSuccessTest {
         assertThat(updatedSeller.getCertificationStatus()).isEqualTo(CertificationStatus.APPROVED);
         assertThat(updatedSeller.getStore().getId()).isEqualTo(updatedStore.getId());
         assertThat(updatedApplication.getStatus()).isEqualTo(StoreApprovalStatus.APPROVE);
+        assertThat(chargeBalance).isPresent();
+        assertThat(chargeBalance.get().getBalance()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("충전금이 이미 존재하는 셀러를 재승인해도 충전금이 중복 생성되지 않는다")
+    void success_registerApprove_doesNotCreateDuplicate_whenBalanceAlreadyExists() {
+
+        // given
+        Seller seller = sellerRepository.save(SellerFixture.defaultSeller(CertificationStatus.PENDING));
+        chargeBalanceRepository.save(ChargeBalanceFixture.createDefault(seller));
+
+        StoreApplication application = storeApplicationRepository
+            .save(StoreApplicationFixture.defaultStoreApplication(seller, null));
+        StoreApplicationApprove command = StoreApplicationApprove.builder()
+            .applicationId(application.getId())
+            .identifier(NEW_IDENTIFIER)
+            .sellerName("newSellerName")
+            .build();
+
+        // when
+        adminStoreService.registerApprove(application.getId(), command);
+
+        // then
+        long count = chargeBalanceRepository.findAll().stream()
+            .filter(cb -> cb.getSeller().getId().equals(seller.getId()))
+            .count();
+
+        assertThat(count).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceUnitTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.bbangle.bbangle.charge.domain.ChargeBalance;
+import com.bbangle.bbangle.charge.repository.ChargeBalanceRepository;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.seller.domain.SellerFixture;
@@ -88,6 +90,9 @@ class AdminStoreServiceUnitTest {
 
     @Mock
     private StoreApplicationRepository storeApplicationRepository;
+
+    @Mock
+    private ChargeBalanceRepository chargeBalanceRepository;
 
     @Mock
     private AdminStoreMapper adminStoreMapper;
@@ -568,7 +573,7 @@ class AdminStoreServiceUnitTest {
     class RegisterApproveTest {
 
         @Test
-        @DisplayName("store가 없으면 createStore 호출 후 승인 처리")
+        @DisplayName("store가 없으면 createStore 호출 후 승인 처리 및 충전금 생성")
         void success_registerApprove_createStore() {
 
             // given
@@ -579,6 +584,7 @@ class AdminStoreServiceUnitTest {
 
             given(storeApplicationRepository.findByIdWithDetails(applicationId)).willReturn(Optional.of(application));
             given(storeRepository.save(any(Store.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(chargeBalanceRepository.existsBySellerId(any())).willReturn(false);
 
             StoreApplicationApprove command = StoreApplicationApprove.builder()
                 .applicationId(applicationId)
@@ -595,10 +601,11 @@ class AdminStoreServiceUnitTest {
             assertThat(result.seller().getCertificationStatus()).isEqualTo(CertificationStatus.APPROVED);
             assertThat(result.storeApplication().getStatus()).isEqualTo(StoreApprovalStatus.APPROVE);
             assertThat(result.seller().getStore()).isEqualTo(result.store());
+            then(chargeBalanceRepository).should().save(any(ChargeBalance.class));
         }
 
         @Test
-        @DisplayName("store가 있으면 updateStore 호출 후 승인 처리")
+        @DisplayName("store가 있으면 updateStore 호출 후 승인 처리 및 충전금 생성")
         void success_registerApprove_updateStore() {
 
             // given
@@ -610,6 +617,7 @@ class AdminStoreServiceUnitTest {
 
             given(storeApplicationRepository.findByIdWithDetails(applicationId)).willReturn(Optional.of(application));
             given(sellerRepository.existsByStore_Id(store.getId())).willReturn(false);
+            given(chargeBalanceRepository.existsBySellerId(any())).willReturn(false);
 
             StoreApplicationApprove command = StoreApplicationApprove.builder()
                 .applicationId(applicationId)
@@ -629,6 +637,34 @@ class AdminStoreServiceUnitTest {
             assertThat(result.seller().getCertificationStatus()).isEqualTo(CertificationStatus.APPROVED);
             assertThat(result.storeApplication().getStatus()).isEqualTo(StoreApprovalStatus.APPROVE);
             assertThat(result.seller().getStore()).isEqualTo(result.store());
+            then(chargeBalanceRepository).should().save(any(ChargeBalance.class));
+        }
+
+        @Test
+        @DisplayName("셀러에 충전금이 이미 존재하면 새로 생성하지 않는다")
+        void success_registerApprove_doesNotCreateBalance_whenAlreadyExists() {
+
+            // given
+            long applicationId = 1L;
+
+            Seller seller = SellerFixture.defaultSeller();
+            StoreApplication application = StoreApplicationFixture.defaultStoreApplication(seller, null);
+
+            given(storeApplicationRepository.findByIdWithDetails(applicationId)).willReturn(Optional.of(application));
+            given(storeRepository.save(any(Store.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(chargeBalanceRepository.existsBySellerId(any())).willReturn(true);
+
+            StoreApplicationApprove command = StoreApplicationApprove.builder()
+                .applicationId(applicationId)
+                .identifier(DEFAULT_IDENTIFIER)
+                .sellerName(seller.getName())
+                .build();
+
+            // when
+            adminStoreService.registerApprove(applicationId, command);
+
+            // then
+            then(chargeBalanceRepository).should(never()).save(any(ChargeBalance.class));
         }
 
         @Test


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->

## 🚀 Major Changes & Explanations

### 문제
셀러 충전금 조회 API(`GET /api/v1/seller/charge-balance`)에서 `CHARGE_BALANCE_NOT_FOUND` 에러가 발생.
`SellerChargeService.getChargeBalance()`가 `ChargeBalance` 레코드를 `orElseThrow`로 조회하는데, 셀러 승인 시점에 `ChargeBalance`가 생성되지 않아 레코드 자체가 없었기 때문.

### 원인
`ChargeBalance.create(Seller seller)` 팩토리 메서드는 존재했으나, 이를 호출하는 코드가 없었음.

### 수정 내용
* [fix] `AdminStoreService.registerApprove()`에서 셀러 승인 완료 후 `ChargeBalance` 자동 생성
  - 셀러가 공식 활성화되는 유일한 진입점(`registerApprove`)에서 생성
  - `REQUIRES_NEW` 트랜잭션 내에서 처리되어 스토어 등록과 원자적으로 처리됨
  - `existsBySellerId()` 체크로 재승인 케이스 시 중복 생성 방지
* [feat] `ChargeBalanceRepository`에 `existsBySellerId()` 메서드 추가
* [test] `AdminStoreServiceUnitTest` - `registerApprove()` 테스트에 `ChargeBalance` 생성 검증 및 중복 방지 케이스 추가
* [test] `AdminStoreServicePartialSuccessTest` - `registerApprove()` 통합 테스트에 `ChargeBalance` 생성 여부 및 잔액(0원) 검증, 중복 생성 방지 케이스 추가

## 📷 Test Image

<!-- 테스트 통과 스크린샷 -->

## 💡 ETC

충전금 생성 시점: **관리자가 셀러 입점 신청을 승인하는 순간** (`AdminStoreService.registerApprove()`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 판매자 승인 시 충전 잔액이 자동으로 초기화되어 생성됩니다. 동일한 판매자에 대한 중복 생성은 방지됩니다.

* **Tests**
  * 판매자 승인 프로세스에서 충전 잔액 생성을 검증하는 테스트 추가 및 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->