### PR TITLE
[Feat] 주문목록조회 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -177,6 +177,8 @@ public enum BbangleErrorCode {
     EXCHANGE_NOT_ALLOWED(-783, "교환 요청이 불가능한 상태입니다.", BAD_REQUEST),
     DELIVERY_NOT_FOUND(-784, "해당 주문상품의 배송 정보를 찾을 수 없습니다.", NOT_FOUND),
     DELIVERY_MODIFY_NOT_ALLOWED(-785, "현재 배송 상태에서는 운송장을 수정할 수 없습니다.", BAD_REQUEST),
+    CUSTOMER_ORDER_UNAUTHORIZED(-786, "주문 조회를 위해 로그인이 필요합니다.", UNAUTHORIZED),
+    CUSTOMER_ORDER_MEMBER_NOT_FOUND(-787, "존재하지 않는 회원의 주문 조회 요청입니다.", NOT_FOUND),
 
     // Settlement Error(801 ~ 820)
     SETTLEMENT_NOT_FOUND(-802, "존재하지 않는 정산 내역입니다.", NOT_FOUND),

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderApi.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderApi.java
@@ -1,0 +1,22 @@
+package com.bbangle.bbangle.order.customer.controller;
+
+import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+
+@Tag(name = "Customer Order", description = "(소비자) 주문 API")
+public interface CustomerOrderApi {
+
+    @Operation(
+        summary = "(소비자) 주문목록 조회",
+        description = "인증된 회원의 주문을 주문일 최신순으로 페이징 조회합니다. "
+            + "각 주문상품의 진행 단계(일반/반품/교환/취소)와 탭별 카운트(statusCounts)가 포함됩니다."
+    )
+    SingleResult<CustomerOrderPageResponse> getOrders(
+        Long memberId,
+        @ParameterObject Pageable pageable
+    );
+}

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderController.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderController.java
@@ -1,0 +1,44 @@
+package com.bbangle.bbangle.order.customer.controller;
+
+import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.CustomerApiPath;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderPageResponse;
+import com.bbangle.bbangle.order.customer.service.CustomerOrderService;
+import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderSearchCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(CustomerApiPath.PREFIX + "/orders")
+public class CustomerOrderController implements CustomerOrderApi {
+
+    private final ResponseService responseService;
+    private final CustomerOrderService customerOrderService;
+
+    /**
+     * 소비자 주문목록 조회. 기본 정렬은 주문일(orderDate) 최신순입니다.
+     */
+    @Override
+    @GetMapping
+    public SingleResult<CustomerOrderPageResponse> getOrders(
+        @AuthenticationPrincipal Long memberId,
+        @PageableDefault(size = 10, sort = "orderDate", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        CustomerOrderSearchCommand command = CustomerOrderSearchCommand.builder()
+            .memberId(memberId)
+            .pageable(pageable)
+            .build();
+
+        CustomerOrderPageResponse response = customerOrderService.getOrders(command);
+
+        return responseService.getSingleResult(response);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/dto/response/CustomerOrderResponse.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/dto/response/CustomerOrderResponse.java
@@ -1,0 +1,98 @@
+package com.bbangle.bbangle.order.customer.controller.dto.response;
+
+import com.bbangle.bbangle.common.page.BbanglePageResponse;
+import com.bbangle.bbangle.order.domain.model.CustomerOrderCategory;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.seller.controller.model.PaymentInfo;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 소비자 주문목록 조회 응답 모음.
+ */
+public class CustomerOrderResponse {
+
+    @Schema(description = "소비자 주문목록 조회 응답 (페이지 + 탭 카운트)")
+    public record CustomerOrderPageResponse(
+        @Schema(description = "주문 목록 페이지")
+        BbanglePageResponse<CustomerOrderInfo> orders,
+
+        @Schema(description = "탭별 카운트")
+        CustomerOrderStatusCounts statusCounts
+    ) {
+
+    }
+
+    @Schema(description = "소비자 주문 탭별 카운트")
+    public record CustomerOrderStatusCounts(
+        @Schema(description = "전체", example = "27") long total,
+        @Schema(description = "진행중 (결제완료~배송완료, 구매확정 전)", example = "12") long inProgress,
+        @Schema(description = "구매확정", example = "10") long purchased,
+        @Schema(description = "취소", example = "2") long canceled,
+        @Schema(description = "반품", example = "2") long returned,
+        @Schema(description = "교환", example = "1") long exchanged
+    ) {
+
+        public static CustomerOrderStatusCounts of(
+            long inProgress,
+            long purchased,
+            long canceled,
+            long returned,
+            long exchanged
+        ) {
+            long total = inProgress + purchased + canceled + returned + exchanged;
+            return new CustomerOrderStatusCounts(total, inProgress, purchased, canceled, returned, exchanged);
+        }
+    }
+
+    @Schema(description = "주문 단위 정보 (날짜별 그룹핑 키 orderDate 포함)")
+    public record CustomerOrderInfo(
+        @Schema(description = "주문 ID") Long orderId,
+        @Schema(description = "주문번호") String orderNumber,
+        @Schema(description = "주문일", example = "2025-06-14")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate orderDate,
+        @Schema(description = "총 주문금액") Long totalAmount,
+        @Schema(description = "결제 정보") PaymentInfo paymentInfo,
+        @Schema(description = "주문 상품 목록") List<CustomerOrderItemInfo> orderItems
+    ) {
+
+    }
+
+    @Schema(description = "주문 상품 정보 + 진행 단계")
+    public record CustomerOrderItemInfo(
+        @Schema(description = "주문상품 ID") Long orderItemId,
+        @Schema(description = "게시글명") String boardTitle,
+        @Schema(description = "상품명") String productName,
+        @Schema(description = "수량") Integer quantity,
+        @Schema(description = "단가") Long unitPrice,
+        @Schema(description = "상품 총액") Long totalPrice,
+        @Schema(description = "주문 상태(원천 enum)") OrderStatus orderStatus,
+        @Schema(description = "배송 상태") String deliveryStatus,
+        @Schema(description = "택배사") String courierCompany,
+        @Schema(description = "운송장 번호") String trackingNumber,
+        @Schema(description = "진행 단계 정보") CustomerOrderProgress progress
+    ) {
+
+    }
+
+    @Schema(description = "소비자 화면 진행 단계 정보")
+    public record CustomerOrderProgress(
+        @Schema(description = "주문 유형") CustomerOrderCategory category,
+        @Schema(description = "현재 단계 라벨", example = "배송완료") String currentStep,
+        @Schema(description = "현재 단계 인덱스 (0부터, 분기/종료 상태는 -1)", example = "3") int currentStepIndex,
+        @Schema(description = "해당 유형의 전체 진행 단계 라벨") List<String> steps
+    ) {
+
+        public static CustomerOrderProgress of(
+            CustomerOrderCategory category,
+            String currentStep,
+            int currentStepIndex,
+            List<String> steps
+        ) {
+            return new CustomerOrderProgress(category, currentStep, currentStepIndex, steps);
+        }
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/customer/repository/CustomerOrderRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/repository/CustomerOrderRepository.java
@@ -1,6 +1,8 @@
 package com.bbangle.bbangle.order.customer.repository;
 
 import com.bbangle.bbangle.common.page.BbanglePageResponse;
+import com.bbangle.bbangle.board.domain.QBoard;
+import com.bbangle.bbangle.board.domain.QProduct;
 import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderSearchCommand;
 import com.bbangle.bbangle.order.domain.Order;
 import com.bbangle.bbangle.order.domain.QOrder;
@@ -32,11 +34,13 @@ public class CustomerOrderRepository {
     private final JPAQueryFactory queryFactory;
     private final QOrder order = QOrder.order;
     private final QOrderItem orderItem = QOrderItem.orderItem;
+    private final QProduct product = QProduct.product;
+    private final QBoard board = QBoard.board;
 
     /**
      * 회원의 주문을 주문일(orderDate) 최신순으로 페이징 조회합니다.
      * fetchJoin + 페이징 시 카테시안 곱 문제를 피하기 위해 2단계로 조회합니다.
-     * 1) ID만 페이징 조회 → 2) 해당 ID로 orderItems/payment fetchJoin 조회 후 정렬 순서 복원
+     * 1) ID만 페이징 조회 → 2) 해당 ID로 orderItems/product/board/payment fetchJoin 조회 후 정렬 순서 복원
      */
     public BbanglePageResponse<Order> searchCustomerOrderList(CustomerOrderSearchCommand command) {
         Pageable pageable = command.pageable();
@@ -103,6 +107,8 @@ public class CustomerOrderRepository {
             .selectFrom(order)
             .distinct()
             .leftJoin(order.orderItems, orderItem).fetchJoin()
+            .leftJoin(orderItem.product, product).fetchJoin()
+            .leftJoin(product.board, board).fetchJoin()
             .leftJoin(order.payment).fetchJoin()
             .where(order.id.in(orderIds))
             .fetch();

--- a/src/main/java/com/bbangle/bbangle/order/customer/repository/CustomerOrderRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/repository/CustomerOrderRepository.java
@@ -1,0 +1,124 @@
+package com.bbangle.bbangle.order.customer.repository;
+
+import com.bbangle.bbangle.common.page.BbanglePageResponse;
+import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderSearchCommand;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.QOrder;
+import com.bbangle.bbangle.order.domain.QOrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 소비자 주문목록 조회 전용 QueryDSL 리포지토리.
+ * 판매자 조회 로직({@code OrderDSLRepository})과 분리하여 소비자 관점 쿼리만 담습니다.
+ * 현재는 별도 필터 없이 인증 회원의 주문을 주문일 최신순으로 페이징 조회합니다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class CustomerOrderRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QOrder order = QOrder.order;
+    private final QOrderItem orderItem = QOrderItem.orderItem;
+
+    /**
+     * 회원의 주문을 주문일(orderDate) 최신순으로 페이징 조회합니다.
+     * fetchJoin + 페이징 시 카테시안 곱 문제를 피하기 위해 2단계로 조회합니다.
+     * 1) ID만 페이징 조회 → 2) 해당 ID로 orderItems/payment fetchJoin 조회 후 정렬 순서 복원
+     */
+    public BbanglePageResponse<Order> searchCustomerOrderList(CustomerOrderSearchCommand command) {
+        Pageable pageable = command.pageable();
+
+        List<Long> orderIds = fetchCustomerOrderIds(command.memberId(), pageable);
+        List<Order> orders = fetchOrdersWithDetails(orderIds);
+        Long total = fetchCustomerTotalCount(command.memberId());
+
+        return BbanglePageResponse.of(new PageImpl<>(orders, pageable, total));
+    }
+
+    /**
+     * 회원의 주문을 OrderStatus 별로 집계합니다. (탭 배지용 카운트)
+     */
+    public Map<OrderStatus, Long> countByCustomerOrderStatus(CustomerOrderSearchCommand command) {
+        var countExpr = orderItem.id.countDistinct();
+
+        List<Tuple> results = queryFactory
+            .select(orderItem.orderStatus, countExpr)
+            .from(order)
+            .leftJoin(order.orderItems, orderItem)
+            .where(order.member.id.eq(command.memberId()))
+            .groupBy(orderItem.orderStatus)
+            .fetch();
+
+        Map<OrderStatus, Long> countMap = new EnumMap<>(OrderStatus.class);
+        for (Tuple tuple : results) {
+            OrderStatus status = tuple.get(orderItem.orderStatus);
+            Long count = tuple.get(countExpr);
+            if (status != null && count != null) {
+                countMap.put(status, count);
+            }
+        }
+        return countMap;
+    }
+
+    private List<Long> fetchCustomerOrderIds(Long memberId, Pageable pageable) {
+        return queryFactory
+            .select(order.id)
+            .from(order)
+            .where(order.member.id.eq(memberId))
+            .orderBy(order.orderDate.desc(), order.id.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+    }
+
+    private Long fetchCustomerTotalCount(Long memberId) {
+        Long total = queryFactory
+            .select(order.count())
+            .from(order)
+            .where(order.member.id.eq(memberId))
+            .fetchOne();
+
+        return total != null ? total : 0L;
+    }
+
+    private List<Order> fetchOrdersWithDetails(List<Long> orderIds) {
+        if (orderIds == null || orderIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Order> orders = queryFactory
+            .selectFrom(order)
+            .distinct()
+            .leftJoin(order.orderItems, orderItem).fetchJoin()
+            .leftJoin(order.payment).fetchJoin()
+            .where(order.id.in(orderIds))
+            .fetch();
+
+        return restoreOriginalOrder(orders, orderIds);
+    }
+
+    // fetchJoin 이후 흐트러진 결과 순서를 1단계 orderIds 정렬 순서로 복원합니다.
+    private List<Order> restoreOriginalOrder(List<Order> orders, List<Long> orderIds) {
+        Map<Long, Order> orderMap = orders.stream()
+            .collect(Collectors.toMap(Order::getId, Function.identity()));
+
+        return orderIds.stream()
+            .distinct()
+            .map(orderMap::get)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/customer/service/CustomerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/service/CustomerOrderService.java
@@ -1,0 +1,180 @@
+package com.bbangle.bbangle.order.customer.service;
+
+import com.bbangle.bbangle.common.page.BbanglePageResponse;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.member.repository.MemberRepository;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderInfo;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderItemInfo;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderPageResponse;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderProgress;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderStatusCounts;
+import com.bbangle.bbangle.order.customer.repository.CustomerOrderRepository;
+import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderSearchCommand;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderDelivery;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderDeliveryRepository;
+import com.bbangle.bbangle.order.seller.controller.model.PaymentInfo;
+import com.bbangle.bbangle.payment.domain.Payment;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomerOrderService {
+
+    private final CustomerOrderRepository customerOrderRepository;
+    private final OrderDeliveryRepository orderDeliveryRepository;
+    private final MemberRepository memberRepository;
+
+    // 진행중 탭: 결제완료~상품발송 (구매확정 이전 일반 상태)
+    private static final Set<OrderStatus> IN_PROGRESS_GROUP = Set.of(
+        OrderStatus.PAYMENT_COMPLETED,
+        OrderStatus.ORDER_CONFIRMED,
+        OrderStatus.IN_PRODUCTION,
+        OrderStatus.SHIPPED
+    );
+
+    /**
+     * 소비자 주문목록 조회.
+     * 인증된 회원의 주문을 주문일 기준 최신순으로 페이징 조회하고,
+     * 각 주문상품의 (주문상태 + 배송상태) 조합을 소비자 화면 진행단계로 변환하여 반환합니다.
+     */
+    @Transactional(readOnly = true)
+    public CustomerOrderPageResponse getOrders(CustomerOrderSearchCommand command) {
+        validateMember(command.memberId());
+
+        BbanglePageResponse<Order> orderPage = customerOrderRepository.searchCustomerOrderList(command);
+        Map<OrderStatus, Long> statusCountMap = customerOrderRepository.countByCustomerOrderStatus(command);
+
+        // orderItems 는 fetchJoin 으로 초기화되어 있어야 합니다.
+        Map<Long, OrderDelivery> latestDeliveryMap = fetchLatestDeliveries(orderPage.content());
+
+        List<CustomerOrderInfo> orderInfos = orderPage.content().stream()
+            .map(order -> buildOrderInfo(order, latestDeliveryMap))
+            .toList();
+
+        BbanglePageResponse<CustomerOrderInfo> ordersPage = new BbanglePageResponse<>(
+            orderInfos,
+            orderPage.page(),
+            orderPage.size(),
+            orderPage.totalPages(),
+            orderPage.totalElements());
+
+        CustomerOrderStatusCounts statusCounts = buildStatusCounts(statusCountMap);
+
+        return new CustomerOrderPageResponse(ordersPage, statusCounts);
+    }
+
+    /**
+     * 주문 조회 요청자(회원) 검증.
+     * - memberId 가 없으면(미인증) 401, 존재하지 않는 회원이면 404 로 응답합니다.
+     */
+    private void validateMember(Long memberId) {
+        if (memberId == null) {
+            throw new BbangleException(BbangleErrorCode.CUSTOMER_ORDER_UNAUTHORIZED);
+        }
+        if (!memberRepository.existsById(memberId)) {
+            throw new BbangleException(BbangleErrorCode.CUSTOMER_ORDER_MEMBER_NOT_FOUND);
+        }
+    }
+
+    private CustomerOrderInfo buildOrderInfo(Order order, Map<Long, OrderDelivery> deliveryMap) {
+        List<CustomerOrderItemInfo> items = order.getOrderItems().stream()
+            .map(item -> buildOrderItemInfo(item, deliveryMap.get(item.getId())))
+            .toList();
+
+        Payment payment = order.getPayment();
+        PaymentInfo paymentInfo = null;
+        if (payment != null) {
+            paymentInfo = PaymentInfo.of(
+                payment.getPaymentStatus() != null ? payment.getPaymentStatus().getDescription() : null,
+                payment.getPaymentMethod() != null ? payment.getPaymentMethod().getDescription() : null,
+                payment.getPaidAt());
+        }
+
+        return new CustomerOrderInfo(
+            order.getId(),
+            order.getOrderNumber(),
+            order.getOrderDate() != null ? order.getOrderDate().toLocalDate() : null,
+            order.getTotalAmount() != null ? order.getTotalAmount().longValue() : null,
+            paymentInfo,
+            items
+        );
+    }
+
+    private CustomerOrderItemInfo buildOrderItemInfo(OrderItem item, OrderDelivery delivery) {
+        OrderDeliveryStatus deliveryStatus = delivery != null ? delivery.getStatus() : null;
+
+        String deliveryStatusLabel = deliveryStatus != null ? deliveryStatus.getDescription() : null;
+        String courierCompany = null;
+        String trackingNumber = null;
+        if (delivery != null && delivery.getShipping() != null) {
+            courierCompany = delivery.getShipping().getCourierName();
+            trackingNumber = delivery.getShipping().getTrackingNumber();
+        }
+
+        CustomerOrderProgress progress = CustomerOrderStepMapper.resolve(item.getOrderStatus(), deliveryStatus);
+
+        return new CustomerOrderItemInfo(
+            item.getId(),
+            item.getProduct() != null && item.getProduct().getBoard() != null
+                ? item.getProduct().getBoard().getTitle() : null,
+            item.getProduct() != null ? item.getProduct().getTitle() : null,
+            item.getQuantity(),
+            item.getUnitPrice() != null ? item.getUnitPrice().longValue() : null,
+            item.getTotalPrice() != null ? item.getTotalPrice().longValue() : null,
+            item.getOrderStatus(),
+            deliveryStatusLabel,
+            courierCompany,
+            trackingNumber,
+            progress
+        );
+    }
+
+    private CustomerOrderStatusCounts buildStatusCounts(Map<OrderStatus, Long> countMap) {
+        return CustomerOrderStatusCounts.of(
+            sumCounts(countMap, IN_PROGRESS_GROUP),
+            sumCounts(countMap, Set.of(OrderStatus.PURCHASE_CONFIRMED)),
+            sumCounts(countMap, OrderStatus.CANCELLED_GROUP),
+            sumCounts(countMap, OrderStatus.RETURNED_GROUP),
+            sumCounts(countMap, OrderStatus.EXCHANGED_GROUP)
+        );
+    }
+
+    private long sumCounts(Map<OrderStatus, Long> countMap, Set<OrderStatus> statuses) {
+        return statuses.stream()
+            .mapToLong(status -> countMap.getOrDefault(status, 0L))
+            .sum();
+    }
+
+    private Map<Long, OrderDelivery> fetchLatestDeliveries(List<Order> orders) {
+        List<Long> orderItemIds = orders.stream()
+            .flatMap(order -> order.getOrderItems().stream())
+            .map(OrderItem::getId)
+            .toList();
+
+        if (orderItemIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return orderDeliveryRepository.findLatestByOrderItemIds(orderItemIds).stream()
+            .collect(Collectors.toMap(
+                delivery -> delivery.getOrderItem().getId(),
+                Function.identity(),
+                (existing, replacement) -> existing
+            ));
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/customer/service/CustomerOrderStepMapper.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/service/CustomerOrderStepMapper.java
@@ -1,0 +1,129 @@
+package com.bbangle.bbangle.order.customer.service;
+
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderProgress;
+import com.bbangle.bbangle.order.domain.model.CustomerOrderCategory;
+import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import java.util.List;
+
+/**
+ * (orderStatus, deliveryStatus) → 소비자 화면 진행 단계({@link CustomerOrderProgress}) 변환기.
+ *
+ * <p>화면 단계는 두 enum 의 조합으로 결정됩니다.
+ * <ul>
+ *   <li>일반: 결제완료 → 상품제작중 → 상품발송 → 배송완료 → 구매확정</li>
+ *   <li>반품: 반품신청 → 반품승인 → 상품회수중 → 상품확인중 → 반품완료 (거절/반려/보류는 분기)</li>
+ *   <li>교환: 교환신청 → 교환승인 → 상품회수중 → 상품확인중 → 교환진행 → 상품발송 → 배송완료 → 교환완료
+ *       (거절/반려/보류는 분기)</li>
+ *   <li>취소: 취소요청 → 취소완료 (거절은 분기)</li>
+ * </ul>
+ *
+ * <p>"배송완료"는 OrderStatus 에 없는 값으로, 상품발송 상태이면서 배송상태가 {@code DELIVERED} 일 때로 판정합니다.
+ * 분기/종료 상태(거절·반려·보류)는 happy-path 인덱스를 {@code -1} 로 두고 현재 라벨만 별도로 노출합니다.
+ */
+public final class CustomerOrderStepMapper {
+
+    private CustomerOrderStepMapper() {
+    }
+
+    // 분기/종료 상태 표시용 인덱스 (happy-path 위에 있지 않음)
+    private static final int BRANCH_INDEX = -1;
+
+    private static final List<String> NORMAL_STEPS =
+        List.of("결제완료", "상품제작중", "상품발송", "배송완료", "구매확정");
+
+    private static final List<String> RETURN_STEPS =
+        List.of("반품신청", "반품승인", "상품회수중", "상품확인중", "반품완료");
+
+    private static final List<String> EXCHANGE_STEPS =
+        List.of("교환신청", "교환승인", "상품회수중", "상품확인중", "교환진행", "상품발송", "배송완료", "교환완료");
+
+    private static final List<String> CANCEL_STEPS =
+        List.of("취소요청", "취소완료");
+
+    public static CustomerOrderProgress resolve(OrderStatus orderStatus, OrderDeliveryStatus deliveryStatus) {
+        CustomerOrderCategory category = CustomerOrderCategory.from(orderStatus);
+        boolean delivered = deliveryStatus == OrderDeliveryStatus.DELIVERED;
+
+        return switch (category) {
+            case NORMAL -> normalProgress(orderStatus, delivered);
+            case RETURN -> returnProgress(orderStatus);
+            case EXCHANGE -> exchangeProgress(orderStatus, delivered);
+            case CANCEL -> cancelProgress(orderStatus);
+        };
+    }
+
+    private static CustomerOrderProgress normalProgress(OrderStatus status, boolean delivered) {
+        int index;
+        String label;
+        switch (status) {
+            case PAYMENT_COMPLETED -> {
+                index = 0;
+                label = "결제완료";
+            }
+            // 발주확인(ORDER_CONFIRMED)은 판매자 내부 단계이므로 소비자에게는 "상품제작중"으로 노출
+            case ORDER_CONFIRMED, IN_PRODUCTION -> {
+                index = 1;
+                label = "상품제작중";
+            }
+            case SHIPPED -> {
+                index = delivered ? 3 : 2;
+                label = delivered ? "배송완료" : "상품발송";
+            }
+            case PURCHASE_CONFIRMED -> {
+                index = 4;
+                label = "구매확정";
+            }
+            default -> {
+                index = 0;
+                label = NORMAL_STEPS.get(0);
+            }
+        }
+        return CustomerOrderProgress.of(CustomerOrderCategory.NORMAL, label, index, NORMAL_STEPS);
+    }
+
+    private static CustomerOrderProgress returnProgress(OrderStatus status) {
+        int index = switch (status) {
+            case RETURN_REQUESTED -> 0;
+            case RETURN_APPROVED -> 1;
+            case RETURN_PICKUP_IN_PROGRESS -> 2;
+            case RETURN_INSPECTION, RETURN_PROCESSING -> 3;
+            case RETURN_COMPLETED -> 4;
+            // 반품거절/반품반려/반품보류 → 분기 (happy-path 밖)
+            default -> BRANCH_INDEX;
+        };
+        return CustomerOrderProgress.of(
+            CustomerOrderCategory.RETURN, status.getDescription(), index, RETURN_STEPS);
+    }
+
+    private static CustomerOrderProgress exchangeProgress(OrderStatus status, boolean delivered) {
+        int index;
+        String label = status.getDescription();
+        switch (status) {
+            case EXCHANGE_REQUEST -> index = 0;
+            case EXCHANGE_APPROVED -> index = 1;
+            case EXCHANGE_ITEM_COLLECTED -> index = 2;
+            case EXCHANGE_ITEM_INSPECTING -> index = 3;
+            case EXCHANGE_IN_PROGRESS -> index = 4;
+            case EXCHANGE_ITEM_SHIPPED -> {
+                index = delivered ? 6 : 5;
+                label = delivered ? "배송완료" : "상품발송";
+            }
+            case EXCHANGE_COMPLETED -> index = 7;
+            // 교환거절/교환반려/교환보류 → 분기 (happy-path 밖)
+            default -> index = BRANCH_INDEX;
+        }
+        return CustomerOrderProgress.of(CustomerOrderCategory.EXCHANGE, label, index, EXCHANGE_STEPS);
+    }
+
+    private static CustomerOrderProgress cancelProgress(OrderStatus status) {
+        int index = switch (status) {
+            case CANCEL_REQUESTED -> 0;
+            case CANCEL_APPROVED -> 1;
+            // 취소반려 → 분기
+            default -> BRANCH_INDEX;
+        };
+        return CustomerOrderProgress.of(
+            CustomerOrderCategory.CANCEL, status.getDescription(), index, CANCEL_STEPS);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/customer/service/model/CustomerOrderCommand.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/service/model/CustomerOrderCommand.java
@@ -1,0 +1,23 @@
+package com.bbangle.bbangle.order.customer.service.model;
+
+import lombok.Builder;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * 소비자 주문 관련 커맨드(Command) 모음.
+ * Controller → Service 로 요청 정보를 전달하는 불변 값 객체(record)입니다.
+ */
+public class CustomerOrderCommand {
+
+    /**
+     * 소비자 주문목록 조회 커맨드.
+     * 인증된 회원(memberId)의 주문을 주문일 기준 최신순으로 페이징 조회할 때 사용합니다.
+     */
+    @Builder
+    public record CustomerOrderSearchCommand(
+        Long memberId,
+        Pageable pageable
+    ) {
+
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/domain/model/CustomerOrderCategory.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/model/CustomerOrderCategory.java
@@ -1,0 +1,42 @@
+package com.bbangle.bbangle.order.domain.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 소비자 주문목록 화면에서 사용하는 주문 유형(탭) 구분.
+ * 세분화된 {@link OrderStatus} 를 소비자 관점의 4개 카테고리로 묶습니다.
+ */
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "소비자 주문 유형")
+public enum CustomerOrderCategory {
+
+    NORMAL("일반"),
+    RETURN("반품"),
+    EXCHANGE("교환"),
+    CANCEL("취소");
+
+    private final String description;
+
+    /**
+     * OrderStatus 를 소비자 화면 카테고리로 변환합니다.
+     * 취소/반품/교환 그룹에 속하지 않는 상태는 모두 일반(NORMAL)으로 간주합니다.
+     */
+    public static CustomerOrderCategory from(OrderStatus status) {
+        if (status == null) {
+            return NORMAL;
+        }
+        if (OrderStatus.CANCELLED_GROUP.contains(status)) {
+            return CANCEL;
+        }
+        if (OrderStatus.RETURNED_GROUP.contains(status)) {
+            return RETURN;
+        }
+        if (OrderStatus.EXCHANGED_GROUP.contains(status)) {
+            return EXCHANGE;
+        }
+        return NORMAL;
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderControllerSliceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderControllerSliceTest.java
@@ -1,0 +1,165 @@
+package com.bbangle.bbangle.order.customer.controller;
+
+import static com.bbangle.bbangle.common.service.ResponseService.CommonResponse.SUCCESS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
+import com.bbangle.bbangle.common.page.BbanglePageResponse;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.JsonDataEncoder;
+import com.bbangle.bbangle.config.security.SecurityConfig;
+import com.bbangle.bbangle.config.security.jwt.TestJwtPropertiesConfig;
+import com.bbangle.bbangle.config.security.jwt.TokenProvider;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.exception.GlobalControllerAdvice;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderInfo;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderItemInfo;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderPageResponse;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderProgress;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderStatusCounts;
+import com.bbangle.bbangle.order.customer.service.CustomerOrderService;
+import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderSearchCommand;
+import com.bbangle.bbangle.order.domain.model.CustomerOrderCategory;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@DisplayName("[컨트롤러] CustomerOrderController")
+@Import({
+    TestSlackAdaptorConfig.class,
+    JsonDataEncoder.class,
+    TokenProvider.class,
+    TestJwtPropertiesConfig.class,
+    ResponseService.class,
+    SecurityConfig.class
+})
+@WebMvcTest(controllers = CustomerOrderController.class)
+class CustomerOrderControllerSliceTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @SpyBean
+    private ResponseService responseService;
+
+    @SpyBean
+    private GlobalControllerAdvice globalControllerAdvice;
+
+    @MockBean
+    private CustomerOrderService customerOrderService;
+
+    private static UsernamePasswordAuthenticationToken memberAuth(Long memberId) {
+        return new UsernamePasswordAuthenticationToken(
+            memberId, "N/A", List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    @DisplayName("주문목록 조회 API - 성공(데이터 있음)")
+    @Test
+    void givenAuthenticatedMember_whenGetOrders_thenReturnsOrders() throws Exception {
+        // given
+        Long memberId = 1L;
+
+        CustomerOrderProgress progress = CustomerOrderProgress.of(
+            CustomerOrderCategory.NORMAL, "배송완료", 3,
+            List.of("결제완료", "상품제작중", "상품발송", "배송완료", "구매확정"));
+        CustomerOrderItemInfo item = new CustomerOrderItemInfo(
+            10L, "저당 베이글 세트", "저칼로리 베이글", 2, 4700L, 9400L,
+            OrderStatus.SHIPPED, "배송완료", "CJ대한통운", "123-456", progress);
+        CustomerOrderInfo orderInfo = new CustomerOrderInfo(
+            1L, "ORDER-2025-06-14-00001", LocalDate.of(2025, 6, 14), 9400L, null, List.of(item));
+
+        CustomerOrderPageResponse mockResponse = new CustomerOrderPageResponse(
+            new BbanglePageResponse<>(List.of(orderInfo), 0, 10, 1, 1L),
+            CustomerOrderStatusCounts.of(1L, 0L, 0L, 0L, 0L));
+
+        given(customerOrderService.getOrders(any(CustomerOrderSearchCommand.class)))
+            .willReturn(mockResponse);
+
+        // when & then
+        mvc.perform(get("/api/v1/customer/orders")
+                .with(authentication(memberAuth(memberId)))
+                .param("page", "0")
+                .param("size", "10")
+                .param("sort", "orderDate,desc"))
+
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.result.orders.content").isArray())
+            .andExpect(jsonPath("$.result.orders.content.length()").value(1))
+            .andExpect(jsonPath("$.result.orders.content[0].orderNumber").value("ORDER-2025-06-14-00001"))
+            .andExpect(jsonPath("$.result.orders.content[0].orderDate").value("2025-06-14"))
+            .andExpect(jsonPath("$.result.orders.content[0].orderItems[0].progress.currentStep").value("배송완료"))
+            .andExpect(jsonPath("$.result.orders.content[0].orderItems[0].progress.currentStepIndex").value(3))
+            .andExpect(jsonPath("$.result.statusCounts.total").value(1))
+            .andExpect(jsonPath("$.result.statusCounts.inProgress").value(1));
+
+        then(customerOrderService).should(times(1)).getOrders(any(CustomerOrderSearchCommand.class));
+        then(responseService).should(times(1)).getSingleResult(mockResponse);
+    }
+
+    @DisplayName("주문목록 조회 API - 성공(빈 결과)")
+    @Test
+    void givenNoOrders_whenGetOrders_thenReturnsEmptyPage() throws Exception {
+        // given
+        CustomerOrderPageResponse mockResponse = new CustomerOrderPageResponse(
+            new BbanglePageResponse<>(Collections.emptyList(), 0, 10, 0, 0L),
+            CustomerOrderStatusCounts.of(0L, 0L, 0L, 0L, 0L));
+
+        given(customerOrderService.getOrders(any(CustomerOrderSearchCommand.class)))
+            .willReturn(mockResponse);
+
+        // when & then
+        mvc.perform(get("/api/v1/customer/orders")
+                .with(authentication(memberAuth(1L))))
+
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.result.orders.content").isArray())
+            .andExpect(jsonPath("$.result.orders.totalElements").value(0))
+            .andExpect(jsonPath("$.result.statusCounts.total").value(0));
+
+        then(customerOrderService).should(times(1)).getOrders(any(CustomerOrderSearchCommand.class));
+    }
+
+    @DisplayName("주문목록 조회 API - 실패(존재하지 않는 회원)")
+    @Test
+    void givenNonExistingMember_whenGetOrders_thenReturns4xx() throws Exception {
+        // given
+        given(customerOrderService.getOrders(any(CustomerOrderSearchCommand.class)))
+            .willThrow(new BbangleException(BbangleErrorCode.CUSTOMER_ORDER_MEMBER_NOT_FOUND));
+
+        // when & then
+        mvc.perform(get("/api/v1/customer/orders")
+                .with(authentication(memberAuth(999L))))
+
+            .andExpect(status().is4xxClientError())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value(BbangleErrorCode.CUSTOMER_ORDER_MEMBER_NOT_FOUND.getCode()))
+            .andExpect(jsonPath("$.message").value(BbangleErrorCode.CUSTOMER_ORDER_MEMBER_NOT_FOUND.getMessage()));
+
+        then(globalControllerAdvice).should(times(1))
+            .handleBbangleException(any(), any(BbangleException.class));
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/order/customer/service/CustomerOrderServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/customer/service/CustomerOrderServiceIntegrationTest.java
@@ -1,0 +1,242 @@
+package com.bbangle.bbangle.order.customer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.board.repository.BoardRepository;
+import com.bbangle.bbangle.board.repository.ProductRepository;
+import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
+import com.bbangle.bbangle.fixture.board.domain.ProductFixture;
+import com.bbangle.bbangle.fixture.order.domain.OrderFixture;
+import com.bbangle.bbangle.fixture.order.domain.OrderItemFixture;
+import com.bbangle.bbangle.fixture.payment.domain.PaymentFixture;
+import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.member.domain.Member;
+import com.bbangle.bbangle.member.repository.MemberRepository;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderInfo;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderPageResponse;
+import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderSearchCommand;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.CustomerOrderCategory;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderItemRepository;
+import com.bbangle.bbangle.order.repository.OrderRepository;
+import com.bbangle.bbangle.payment.repository.PaymentRepository;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.repository.StoreRepository;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[통합테스트] CustomerOrderServiceIntegrationTest")
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class CustomerOrderServiceIntegrationTest {
+
+    @Autowired
+    private CustomerOrderService customerOrderService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private OrderItemRepository orderItemRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Member member;
+    private Product product;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(Member.builder()
+            .email("buyer@bbangle.com")
+            .name("홍길동")
+            .nickname("길동")
+            .build());
+
+        Store store = storeRepository.save(StoreFixture.defaultStore());
+        Board board = boardRepository.save(BoardFixture.defaultBoardWithStore(store, "저당 베이글 세트"));
+        product = productRepository.save(ProductFixture.create(board, "저칼로리 베이글"));
+    }
+
+    private Order persistOrder(String orderNumber, LocalDateTime orderDate, OrderStatus status) {
+        Order order = OrderFixture.createOrderWithNumber(orderNumber).toBuilder()
+            .orderDate(orderDate)
+            .totalAmount(50000)
+            .member(member)
+            .build();
+        order = orderRepository.save(order);
+
+        OrderItem orderItem = OrderItemFixture.defaultOrderItem()
+            .orderStatus(status)
+            .product(product)
+            .build();
+        order.addOrderItem(orderItem);
+        orderItemRepository.save(orderItem);
+
+        paymentRepository.save(PaymentFixture.createDefaultPayment(order));
+        return order;
+    }
+
+    @DisplayName("회원의 주문을 주문일 최신순으로 조회한다")
+    @Test
+    void getOrders_returnsMemberOrdersInLatestDateOrder() {
+        // given
+        persistOrder("ORDER-2025-06-10-00001", LocalDateTime.of(2025, 6, 10, 10, 0), OrderStatus.PAYMENT_COMPLETED);
+        persistOrder("ORDER-2025-06-12-00002", LocalDateTime.of(2025, 6, 12, 10, 0), OrderStatus.SHIPPED);
+        em.flush();
+        em.clear();
+
+        CustomerOrderSearchCommand command = CustomerOrderSearchCommand.builder()
+            .memberId(member.getId())
+            .pageable(PageRequest.of(0, 10))
+            .build();
+
+        // when
+        CustomerOrderPageResponse result = customerOrderService.getOrders(command);
+
+        // then
+        assertThat(result.orders().totalElements()).isEqualTo(2L);
+        assertThat(result.orders().content()).hasSize(2);
+        // 최신순(2025-06-12 먼저)
+        assertThat(result.orders().content().get(0).orderNumber()).isEqualTo("ORDER-2025-06-12-00002");
+        assertThat(result.orders().content().get(1).orderNumber()).isEqualTo("ORDER-2025-06-10-00001");
+
+        CustomerOrderInfo first = result.orders().content().get(0);
+        assertThat(first.orderDate()).isEqualTo(LocalDate.of(2025, 6, 12));
+        assertThat(first.totalAmount()).isEqualTo(50000L);
+        assertThat(first.paymentInfo()).isNotNull();
+        assertThat(first.orderItems()).hasSize(1);
+
+        var item = first.orderItems().get(0);
+        assertThat(item.boardTitle()).isEqualTo("저당 베이글 세트");
+        assertThat(item.productName()).isEqualTo("저칼로리 베이글");
+        assertThat(item.orderStatus()).isEqualTo(OrderStatus.SHIPPED);
+        assertThat(item.progress().category()).isEqualTo(CustomerOrderCategory.NORMAL);
+        // 배송정보 없음 → 상품발송 단계(index 2)
+        assertThat(item.progress().currentStepIndex()).isEqualTo(2);
+    }
+
+    @DisplayName("탭별 카운트(statusCounts)를 집계한다")
+    @Test
+    void getOrders_aggregatesStatusCounts() {
+        // given
+        persistOrder("ORDER-A", LocalDateTime.of(2025, 6, 1, 10, 0), OrderStatus.PAYMENT_COMPLETED);
+        persistOrder("ORDER-B", LocalDateTime.of(2025, 6, 2, 10, 0), OrderStatus.PURCHASE_CONFIRMED);
+        persistOrder("ORDER-C", LocalDateTime.of(2025, 6, 3, 10, 0), OrderStatus.RETURN_REQUESTED);
+        em.flush();
+        em.clear();
+
+        CustomerOrderSearchCommand command = CustomerOrderSearchCommand.builder()
+            .memberId(member.getId())
+            .pageable(PageRequest.of(0, 10))
+            .build();
+
+        // when
+        CustomerOrderPageResponse result = customerOrderService.getOrders(command);
+
+        // then
+        var counts = result.statusCounts();
+        assertThat(counts.total()).isEqualTo(3L);
+        assertThat(counts.inProgress()).isEqualTo(1L);
+        assertThat(counts.purchased()).isEqualTo(1L);
+        assertThat(counts.returned()).isEqualTo(1L);
+        assertThat(counts.canceled()).isZero();
+        assertThat(counts.exchanged()).isZero();
+    }
+
+    @DisplayName("다른 회원의 주문은 조회되지 않는다")
+    @Test
+    void getOrders_excludesOtherMembersOrders() {
+        // given
+        persistOrder("ORDER-MINE", LocalDateTime.of(2025, 6, 1, 10, 0), OrderStatus.PAYMENT_COMPLETED);
+
+        Member other = memberRepository.save(Member.builder()
+            .email("other@bbangle.com").name("타인").nickname("타인").build());
+        Order otherOrder = OrderFixture.createOrderWithNumber("ORDER-OTHER").toBuilder()
+            .orderDate(LocalDateTime.of(2025, 6, 2, 10, 0))
+            .member(other)
+            .build();
+        otherOrder = orderRepository.save(otherOrder);
+        OrderItem otherItem = OrderItemFixture.defaultOrderItem().product(product).build();
+        otherOrder.addOrderItem(otherItem);
+        orderItemRepository.save(otherItem);
+        em.flush();
+        em.clear();
+
+        CustomerOrderSearchCommand command = CustomerOrderSearchCommand.builder()
+            .memberId(member.getId())
+            .pageable(PageRequest.of(0, 10))
+            .build();
+
+        // when
+        CustomerOrderPageResponse result = customerOrderService.getOrders(command);
+
+        // then
+        assertThat(result.orders().totalElements()).isEqualTo(1L);
+        assertThat(result.orders().content().get(0).orderNumber()).isEqualTo("ORDER-MINE");
+    }
+
+    @DisplayName("존재하지 않는 회원이 조회하면 예외가 발생한다")
+    @Test
+    void getOrders_throwsWhenMemberNotFound() {
+        // given
+        CustomerOrderSearchCommand command = CustomerOrderSearchCommand.builder()
+            .memberId(-1L)
+            .pageable(PageRequest.of(0, 10))
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> customerOrderService.getOrders(command))
+            .isInstanceOf(BbangleException.class)
+            .hasFieldOrPropertyWithValue("bbangleErrorCode",
+                BbangleErrorCode.CUSTOMER_ORDER_MEMBER_NOT_FOUND);
+    }
+
+    @DisplayName("memberId 가 없으면 미인증 예외가 발생한다")
+    @Test
+    void getOrders_throwsWhenMemberIdNull() {
+        // given
+        CustomerOrderSearchCommand command = CustomerOrderSearchCommand.builder()
+            .memberId(null)
+            .pageable(PageRequest.of(0, 10))
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> customerOrderService.getOrders(command))
+            .isInstanceOf(BbangleException.class)
+            .hasFieldOrPropertyWithValue("bbangleErrorCode",
+                BbangleErrorCode.CUSTOMER_ORDER_UNAUTHORIZED);
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/order/customer/service/CustomerOrderStepMapperTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/customer/service/CustomerOrderStepMapperTest.java
@@ -1,0 +1,166 @@
+package com.bbangle.bbangle.order.customer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderProgress;
+import com.bbangle.bbangle.order.domain.model.CustomerOrderCategory;
+import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[단위테스트] CustomerOrderStepMapper")
+class CustomerOrderStepMapperTest {
+
+    @Nested
+    @DisplayName("일반(NORMAL) 플로우")
+    class Normal {
+
+        @Test
+        @DisplayName("결제완료 → index 0")
+        void paymentCompleted() {
+            CustomerOrderProgress progress =
+                CustomerOrderStepMapper.resolve(OrderStatus.PAYMENT_COMPLETED, null);
+
+            assertThat(progress.category()).isEqualTo(CustomerOrderCategory.NORMAL);
+            assertThat(progress.currentStep()).isEqualTo("결제완료");
+            assertThat(progress.currentStepIndex()).isEqualTo(0);
+            assertThat(progress.steps())
+                .containsExactly("결제완료", "상품제작중", "상품발송", "배송완료", "구매확정");
+        }
+
+        @Test
+        @DisplayName("발주확인(ORDER_CONFIRMED)은 소비자 화면에서 '상품제작중'으로 노출 → index 1")
+        void orderConfirmedShownAsInProduction() {
+            CustomerOrderProgress progress =
+                CustomerOrderStepMapper.resolve(OrderStatus.ORDER_CONFIRMED, null);
+
+            assertThat(progress.currentStep()).isEqualTo("상품제작중");
+            assertThat(progress.currentStepIndex()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("상품발송 + 배송 미완료 → 상품발송 index 2")
+        void shippedNotDelivered() {
+            CustomerOrderProgress progress =
+                CustomerOrderStepMapper.resolve(OrderStatus.SHIPPED, OrderDeliveryStatus.DELIVERING);
+
+            assertThat(progress.currentStep()).isEqualTo("상품발송");
+            assertThat(progress.currentStepIndex()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("상품발송 + 배송완료 → 배송완료 index 3")
+        void shippedAndDelivered() {
+            CustomerOrderProgress progress =
+                CustomerOrderStepMapper.resolve(OrderStatus.SHIPPED, OrderDeliveryStatus.DELIVERED);
+
+            assertThat(progress.currentStep()).isEqualTo("배송완료");
+            assertThat(progress.currentStepIndex()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("구매확정 → index 4")
+        void purchaseConfirmed() {
+            CustomerOrderProgress progress =
+                CustomerOrderStepMapper.resolve(OrderStatus.PURCHASE_CONFIRMED, OrderDeliveryStatus.DELIVERED);
+
+            assertThat(progress.currentStep()).isEqualTo("구매확정");
+            assertThat(progress.currentStepIndex()).isEqualTo(4);
+        }
+    }
+
+    @Nested
+    @DisplayName("반품(RETURN) 플로우")
+    class Return {
+
+        @Test
+        @DisplayName("반품신청 → index 0")
+        void requested() {
+            CustomerOrderProgress progress =
+                CustomerOrderStepMapper.resolve(OrderStatus.RETURN_REQUESTED, null);
+
+            assertThat(progress.category()).isEqualTo(CustomerOrderCategory.RETURN);
+            assertThat(progress.currentStepIndex()).isEqualTo(0);
+            assertThat(progress.steps())
+                .containsExactly("반품신청", "반품승인", "상품회수중", "상품확인중", "반품완료");
+        }
+
+        @Test
+        @DisplayName("반품완료 → index 4")
+        void completed() {
+            CustomerOrderProgress progress =
+                CustomerOrderStepMapper.resolve(OrderStatus.RETURN_COMPLETED, null);
+
+            assertThat(progress.currentStepIndex()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("반품거절/반품반려는 분기(종료) → index -1")
+        void rejectedIsBranch() {
+            assertThat(CustomerOrderStepMapper.resolve(OrderStatus.RETURN_REJECTED, null).currentStepIndex())
+                .isEqualTo(-1);
+            assertThat(CustomerOrderStepMapper.resolve(OrderStatus.RETURN_RETURNED, null).currentStepIndex())
+                .isEqualTo(-1);
+        }
+    }
+
+    @Nested
+    @DisplayName("교환(EXCHANGE) 플로우")
+    class Exchange {
+
+        @Test
+        @DisplayName("교환신청 → index 0, 단계 8개")
+        void requested() {
+            CustomerOrderProgress progress =
+                CustomerOrderStepMapper.resolve(OrderStatus.EXCHANGE_REQUEST, null);
+
+            assertThat(progress.category()).isEqualTo(CustomerOrderCategory.EXCHANGE);
+            assertThat(progress.currentStepIndex()).isEqualTo(0);
+            assertThat(progress.steps()).hasSize(8)
+                .containsExactly("교환신청", "교환승인", "상품회수중", "상품확인중", "교환진행", "상품발송", "배송완료", "교환완료");
+        }
+
+        @Test
+        @DisplayName("재배송 상품발송 + 배송완료 → 배송완료 index 6")
+        void reshipDelivered() {
+            CustomerOrderProgress progress =
+                CustomerOrderStepMapper.resolve(OrderStatus.EXCHANGE_ITEM_SHIPPED, OrderDeliveryStatus.DELIVERED);
+
+            assertThat(progress.currentStep()).isEqualTo("배송완료");
+            assertThat(progress.currentStepIndex()).isEqualTo(6);
+        }
+
+        @Test
+        @DisplayName("교환완료 → index 7")
+        void completed() {
+            CustomerOrderProgress progress =
+                CustomerOrderStepMapper.resolve(OrderStatus.EXCHANGE_COMPLETED, null);
+
+            assertThat(progress.currentStepIndex()).isEqualTo(7);
+        }
+
+        @Test
+        @DisplayName("교환반려는 분기 → index -1")
+        void returnedIsBranch() {
+            assertThat(CustomerOrderStepMapper.resolve(OrderStatus.EXCHANGE_RETURNED, null).currentStepIndex())
+                .isEqualTo(-1);
+        }
+    }
+
+    @Nested
+    @DisplayName("취소(CANCEL) 플로우")
+    class Cancel {
+
+        @Test
+        @DisplayName("취소요청 → CANCEL 카테고리 index 0")
+        void requested() {
+            CustomerOrderProgress progress =
+                CustomerOrderStepMapper.resolve(OrderStatus.CANCEL_REQUESTED, null);
+
+            assertThat(progress.category()).isEqualTo(CustomerOrderCategory.CANCEL);
+            assertThat(progress.currentStepIndex()).isEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/seller/service/SellerOrderServiceIntegrationTest.java
@@ -33,6 +33,7 @@ import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.repository.StoreRepository;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -173,7 +174,9 @@ public class SellerOrderServiceIntegrationTest {
         assertThat(response.sellerId()).isEqualTo(seller.getId());
 
         // 결제 정보 검증
+        // DB는 timestamp를 마이크로초까지만 저장하므로(메모리 엔티티는 나노초), 마이크로초 기준으로 비교
         assertThat(response.paymentInfo()).isNotNull();
-        assertThat(response.paymentInfo().paidAt()).isEqualTo(payment.getPaidAt());
+        assertThat(response.paymentInfo().paidAt().truncatedTo(ChronoUnit.MICROS))
+            .isEqualTo(payment.getPaidAt().truncatedTo(ChronoUnit.MICROS));
     }
 }


### PR DESCRIPTION

## 🚀 Major Changes & Explanations

- API: GET /api/v1/customer/orders
    - 인증 회원(@AuthenticationPrincipal Long memberId)의 주문만 조회
    - 기본 정렬: orderDate DESC (2단계 페이징으로 fetchJoin 카테시안 곱 방지)
  - 진행 단계 변환 (CustomerOrderStepMapper)
    - (주문상태 + 배송상태) 조합 → 소비자 화면 단계로 변환
    - 일반: 결제완료 → 상품제작중 → 상품발송 → 배송완료 → 구매확정
    - 반품: 반품신청 → 승인 → 회수중 → 확인중 → 완료 (거절/반려는 분기)
    - 교환: 신청 → 승인 → 회수중 → 확인중 → 진행 → 발송 → 배송완료 → 완료
    - 배송완료는 배송상태(DELIVERED)로 판정, 발주확인은 화면상 "상품제작중"으로 노출
  - 탭별 카운트: 진행중 / 구매확정 / 취소 / 반품 / 교환 집계
  - 리포지토리 분리: CustomerOrderRepository(QueryDSL) 신규 — 공용 OrderDSLRepository 미수정
  - 예외 처리: CustomerOrderService에서 회원 검증

  테스트

  - 단위(CustomerOrderStepMapperTest): 일반/반품/교환/취소 단계 매핑
  - 슬라이스(CustomerOrderControllerSliceTest): 성공/빈결과/예외 응답
  - 통합(CustomerOrderServiceIntegrationTest): 최신순 조회, 탭 카운트, 타인 주문 제외, 회원 검증 예외

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 고객 주문 목록 조회 API 추가(주문일 최신순 페이징)
  * 각 주문의 배송 상태와 진행 단계(카테고리/스텝) 및 주문 상태 탭 카운트 제공
  * 비인증 또는 존재하지 않는 회원 주문 조회 시 명확한 오류 코드로 응답

* **Tests**
  * 고객 주문 목록 조회 통합/단위 테스트 추가(성공/빈 결과/실패 케이스)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->