### PR TITLE
[Feature] (커스터머) 반품 요청 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/claim/customer/controller/CustomerReturnController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/customer/controller/CustomerReturnController.java
@@ -1,0 +1,34 @@
+package com.bbangle.bbangle.claim.customer.controller;
+
+import com.bbangle.bbangle.claim.customer.controller.dto.CustomerReturnRequest;
+import com.bbangle.bbangle.claim.customer.service.CustomerReturnService;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.CustomerApiPath;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping(CustomerApiPath.PREFIX + "/orders")
+@RestController
+public class CustomerReturnController {
+
+    private final ResponseService responseService;
+    private final CustomerReturnService customerReturnService;
+
+    @PatchMapping("/{orderId}/return")
+    public CommonResult requestReturn(
+        @PathVariable Long orderId,
+        @Valid @RequestBody CustomerReturnRequest request,
+        @AuthenticationPrincipal Long customerId
+    ) {
+        customerReturnService.requestReturn(orderId, customerId, request);
+        return responseService.getSuccessResult();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/claim/customer/controller/dto/CustomerReturnRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/customer/controller/dto/CustomerReturnRequest.java
@@ -1,0 +1,16 @@
+package com.bbangle.bbangle.claim.customer.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record CustomerReturnRequest(
+    @Schema(description = "반품 신청할 주문 상품 ID 목록", example = "[201, 202]")
+    @NotEmpty(message = "반품할 주문 상품은 최소 하나 이상 선택해야 합니다.")
+    List<Long> orderItemIds,
+
+    @Schema(description = "반품 사유", example = "단순 변심 / 사이즈 불일치", maxLength = 500)
+    @NotBlank(message = "반품 사유는 필수입니다.")
+    String reason
+) {}

--- a/src/main/java/com/bbangle/bbangle/claim/customer/controller/dto/CustomerReturnRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/customer/controller/dto/CustomerReturnRequest.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.claim.customer.controller.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record CustomerReturnRequest(
@@ -12,5 +13,6 @@ public record CustomerReturnRequest(
 
     @Schema(description = "반품 사유", example = "단순 변심 / 사이즈 불일치", maxLength = 500)
     @NotBlank(message = "반품 사유는 필수입니다.")
+    @Size(max = 500, message = "반품 사유는 500자 이하로 입력해주세요.")
     String reason
 ) {}

--- a/src/main/java/com/bbangle/bbangle/claim/customer/service/CustomerReturnService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/customer/service/CustomerReturnService.java
@@ -1,0 +1,67 @@
+package com.bbangle.bbangle.claim.customer.service;
+
+import com.bbangle.bbangle.claim.customer.controller.dto.CustomerReturnRequest;
+import com.bbangle.bbangle.claim.domain.ReturnRequest;
+import com.bbangle.bbangle.claim.domain.constant.ReturnRequestRequestStatus;
+import com.bbangle.bbangle.claim.repository.ReturnRequestRepository;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.OrderItemHistory;
+import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
+import com.bbangle.bbangle.order.repository.OrderItemRepository;
+import com.bbangle.bbangle.order.repository.OrderRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CustomerReturnService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final ReturnRequestRepository returnRequestRepository;
+    private final OrderItemHistoryRepository orderItemHistoryRepository;
+
+    @Transactional
+    public void requestReturn(Long orderId, Long customerId, CustomerReturnRequest request) {
+        Order order = orderRepository.findById(orderId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.getMember().getId().equals(customerId)) {
+            throw new BbangleException(BbangleErrorCode.ORDER_ACCESS_DENIED);
+        }
+
+        List<Long> uniqueOrderItemIds = request.orderItemIds().stream()
+            .distinct()
+            .toList();
+
+        List<OrderItem> orderItems = orderItemRepository.findByOrderIdAndIdIn(orderId, uniqueOrderItemIds);
+
+        if (orderItems.size() != uniqueOrderItemIds.size()) {
+            throw new BbangleException(BbangleErrorCode.ORDER_ITEM_NOT_FOUND);
+        }
+
+        List<ReturnRequest> returnRequestsToSave = new ArrayList<>();
+        List<OrderItemHistory> historiesToSave = new ArrayList<>();
+
+        for (OrderItem orderItem : orderItems) {
+            if (!orderItem.requestReturn()) {
+                throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
+            }
+            returnRequestsToSave.add(ReturnRequest.builder()
+                .orderItem(orderItem)
+                .detailReason(request.reason())
+                .status(ReturnRequestRequestStatus.REQUESTED)
+                .build());
+            historiesToSave.add(OrderItemHistory.create(orderItem));
+        }
+
+        returnRequestRepository.saveAll(returnRequestsToSave);
+        orderItemHistoryRepository.saveAll(historiesToSave);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/claim/customer/service/CustomerReturnService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/customer/service/CustomerReturnService.java
@@ -12,7 +12,6 @@ import com.bbangle.bbangle.order.domain.OrderItemHistory;
 import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
 import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.order.repository.OrderRepository;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,7 +28,7 @@ public class CustomerReturnService {
 
     @Transactional
     public void requestReturn(Long orderId, Long customerId, CustomerReturnRequest request) {
-        Order order = orderRepository.findById(orderId)
+        Order order = orderRepository.findByIdWithMember(orderId)
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
 
         if (!order.getMember().getId().equals(customerId)) {
@@ -40,26 +39,31 @@ public class CustomerReturnService {
             .distinct()
             .toList();
 
-        List<OrderItem> orderItems = orderItemRepository.findByOrderIdAndIdIn(orderId, uniqueOrderItemIds);
+        List<OrderItem> orderItems = orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, uniqueOrderItemIds);
 
         if (orderItems.size() != uniqueOrderItemIds.size()) {
             throw new BbangleException(BbangleErrorCode.ORDER_ITEM_NOT_FOUND);
         }
 
-        List<ReturnRequest> returnRequestsToSave = new ArrayList<>();
-        List<OrderItemHistory> historiesToSave = new ArrayList<>();
+        // 반품 가능 상태 전면 검증 (All-or-Nothing 정책: 하나라도 불가하면 전체 실패)
+        if (orderItems.stream().anyMatch(item -> !item.canRequestReturn())) {
+            throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
+        }
 
-        for (OrderItem orderItem : orderItems) {
-            if (!orderItem.requestReturn()) {
-                throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
-            }
-            returnRequestsToSave.add(ReturnRequest.builder()
+        // 전체 유효성 확인 후 상태 전이 실행
+        orderItems.forEach(OrderItem::requestReturn);
+
+        List<ReturnRequest> returnRequestsToSave = orderItems.stream()
+            .map(orderItem -> ReturnRequest.builder()
                 .orderItem(orderItem)
                 .detailReason(request.reason())
                 .status(ReturnRequestRequestStatus.REQUESTED)
-                .build());
-            historiesToSave.add(OrderItemHistory.create(orderItem));
-        }
+                .build())
+            .toList();
+
+        List<OrderItemHistory> historiesToSave = orderItems.stream()
+            .map(OrderItemHistory::create)
+            .toList();
 
         returnRequestRepository.saveAll(returnRequestsToSave);
         orderItemHistoryRepository.saveAll(historiesToSave);

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -128,8 +128,12 @@ public class OrderItem extends BaseEntity {
         this.orderStatus = OrderStatus.SHIPPED;
     }
 
+    public boolean canRequestReturn() {
+        return this.orderStatus == OrderStatus.SHIPPED || this.orderStatus == OrderStatus.PURCHASE_CONFIRMED;
+    }
+
     public boolean requestReturn() {
-        if (this.orderStatus != OrderStatus.SHIPPED && this.orderStatus != OrderStatus.PURCHASE_CONFIRMED) {
+        if (!canRequestReturn()) {
             return false;
         }
         this.orderStatus = RETURN_REQUESTED;

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderRepository.java
@@ -1,7 +1,13 @@
 package com.bbangle.bbangle.order.repository;
 
 import com.bbangle.bbangle.order.domain.Order;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderRepository extends JpaRepository<Order, Long>, OrderDSLRepository {
+
+    @Query("SELECT o FROM Order o JOIN FETCH o.member WHERE o.id = :id")
+    Optional<Order> findByIdWithMember(@Param("id") Long id);
 }

--- a/src/test/java/com/bbangle/bbangle/claim/customer/service/CustomerReturnServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/customer/service/CustomerReturnServiceTest.java
@@ -1,0 +1,209 @@
+package com.bbangle.bbangle.claim.customer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.bbangle.bbangle.claim.customer.controller.dto.CustomerReturnRequest;
+import com.bbangle.bbangle.claim.repository.ReturnRequestRepository;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.order.OrderItemFixture;
+import com.bbangle.bbangle.member.domain.Member;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
+import com.bbangle.bbangle.order.repository.OrderItemRepository;
+import com.bbangle.bbangle.order.repository.OrderRepository;
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("[단위 테스트] CustomerReturnService - requestReturn")
+@ExtendWith(MockitoExtension.class)
+class CustomerReturnServiceTest {
+
+    @InjectMocks
+    private CustomerReturnService sut;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private OrderItemRepository orderItemRepository;
+
+    @Mock
+    private ReturnRequestRepository returnRequestRepository;
+
+    @Mock
+    private OrderItemHistoryRepository orderItemHistoryRepository;
+
+    @Nested
+    @DisplayName("성공 시나리오")
+    class SuccessScenarios {
+
+        @Test
+        @DisplayName("SHIPPED 상태의 주문 상품으로 반품 요청 시 RETURN_REQUESTED로 전이되고 ReturnRequest·OrderItemHistory가 누락 없이 저장된다")
+        void givenShippedOrderItems_whenRequestReturn_thenSavedSuccessfully() {
+            // given
+            Long orderId = 1L;
+            Long customerId = 100L;
+
+            Order order = orderWithMember(orderId, customerId);
+
+            OrderItem orderItem1 = OrderItemFixture.orderItemWithStatus(OrderStatus.SHIPPED);
+            ReflectionTestUtils.setField(orderItem1, "id", 201L);
+
+            OrderItem orderItem2 = OrderItemFixture.orderItemWithStatus(OrderStatus.PURCHASE_CONFIRMED);
+            ReflectionTestUtils.setField(orderItem2, "id", 202L);
+
+            CustomerReturnRequest request = new CustomerReturnRequest(
+                List.of(201L, 202L),
+                "단순 변심 / 사이즈 불일치"
+            );
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(orderItemRepository.findByOrderIdAndIdIn(orderId, List.of(201L, 202L)))
+                .willReturn(List.of(orderItem1, orderItem2));
+
+            // when
+            sut.requestReturn(orderId, customerId, request);
+
+            // then
+            assertThat(orderItem1.getOrderStatus()).isEqualTo(OrderStatus.RETURN_REQUESTED);
+            assertThat(orderItem2.getOrderStatus()).isEqualTo(OrderStatus.RETURN_REQUESTED);
+            then(returnRequestRepository).should(times(1)).saveAll(anyList());
+            then(orderItemHistoryRepository).should(times(1)).saveAll(anyList());
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 시나리오")
+    class FailureScenarios {
+
+        @Test
+        @DisplayName("타인의 주문 ID로 반품을 시도하면 ORDER_ACCESS_DENIED 예외가 발생한다")
+        void givenOtherCustomersOrder_whenRequestReturn_thenThrowsOrderAccessDenied() {
+            // given
+            Long orderId = 1L;
+            Long actualOwnerId = 100L;
+            Long otherCustomerId = 999L;
+
+            Order order = orderWithMember(orderId, actualOwnerId);
+
+            CustomerReturnRequest request = new CustomerReturnRequest(
+                List.of(201L),
+                "반품 사유"
+            );
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when & then
+            assertThatThrownBy(() -> sut.requestReturn(orderId, otherCustomerId, request))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.ORDER_ACCESS_DENIED);
+
+            then(orderItemRepository).should(never()).findByOrderIdAndIdIn(orderId, List.of(201L));
+            then(returnRequestRepository).should(never()).saveAll(anyList());
+            then(orderItemHistoryRepository).should(never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("반품 불가 상태(PAYMENT_COMPLETED)의 주문 상품으로 반품 시도 시 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void givenInvalidStatusOrderItem_whenRequestReturn_thenThrowsClaimInvalidStatus() {
+            // given
+            Long orderId = 1L;
+            Long customerId = 100L;
+
+            Order order = orderWithMember(orderId, customerId);
+
+            OrderItem invalidItem = OrderItemFixture.orderItemWithStatus(OrderStatus.PAYMENT_COMPLETED);
+            ReflectionTestUtils.setField(invalidItem, "id", 201L);
+
+            CustomerReturnRequest request = new CustomerReturnRequest(
+                List.of(201L),
+                "반품 사유"
+            );
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(orderItemRepository.findByOrderIdAndIdIn(orderId, List.of(201L)))
+                .willReturn(List.of(invalidItem));
+
+            // when & then
+            assertThatThrownBy(() -> sut.requestReturn(orderId, customerId, request))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            assertThat(invalidItem.getOrderStatus()).isEqualTo(OrderStatus.PAYMENT_COMPLETED);
+            then(returnRequestRepository).should(never()).saveAll(anyList());
+            then(orderItemHistoryRepository).should(never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("이미 취소된(CANCEL_APPROVED) 주문 상품으로 반품 시도 시 CLAIM_INVALID_STATUS 예외가 발생한다")
+        void givenCancelledOrderItem_whenRequestReturn_thenThrowsClaimInvalidStatus() {
+            // given
+            Long orderId = 1L;
+            Long customerId = 100L;
+
+            Order order = orderWithMember(orderId, customerId);
+
+            OrderItem cancelledItem = OrderItemFixture.orderItemWithStatus(OrderStatus.CANCEL_APPROVED);
+            ReflectionTestUtils.setField(cancelledItem, "id", 201L);
+
+            CustomerReturnRequest request = new CustomerReturnRequest(
+                List.of(201L),
+                "반품 사유"
+            );
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(orderItemRepository.findByOrderIdAndIdIn(orderId, List.of(201L)))
+                .willReturn(List.of(cancelledItem));
+
+            // when & then
+            assertThatThrownBy(() -> sut.requestReturn(orderId, customerId, request))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(returnRequestRepository).should(never()).saveAll(anyList());
+            then(orderItemHistoryRepository).should(never()).saveAll(anyList());
+        }
+    }
+
+    private Order orderWithMember(Long orderId, Long memberId) {
+        Member member = newEntity(Member.class);
+        ReflectionTestUtils.setField(member, "id", memberId);
+
+        Order order = newEntity(Order.class);
+        ReflectionTestUtils.setField(order, "id", orderId);
+        ReflectionTestUtils.setField(order, "member", member);
+
+        return order;
+    }
+
+    private <T> T newEntity(Class<T> clazz) {
+        try {
+            Constructor<T> constructor = clazz.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/claim/customer/service/CustomerReturnServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/customer/service/CustomerReturnServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
@@ -13,6 +14,7 @@ import com.bbangle.bbangle.claim.repository.ReturnRequestRepository;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.order.OrderItemFixture;
+import com.bbangle.bbangle.fixture.order.domain.OrderFixture;
 import com.bbangle.bbangle.member.domain.Member;
 import com.bbangle.bbangle.order.domain.Order;
 import com.bbangle.bbangle.order.domain.OrderItem;
@@ -20,7 +22,6 @@ import com.bbangle.bbangle.order.domain.model.OrderStatus;
 import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
 import com.bbangle.bbangle.order.repository.OrderItemRepository;
 import com.bbangle.bbangle.order.repository.OrderRepository;
-import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -64,19 +65,18 @@ class CustomerReturnServiceTest {
 
             Order order = orderWithMember(orderId, customerId);
 
-            OrderItem orderItem1 = OrderItemFixture.orderItemWithStatus(OrderStatus.SHIPPED);
-            ReflectionTestUtils.setField(orderItem1, "id", 201L);
-
-            OrderItem orderItem2 = OrderItemFixture.orderItemWithStatus(OrderStatus.PURCHASE_CONFIRMED);
-            ReflectionTestUtils.setField(orderItem2, "id", 202L);
+            OrderItem orderItem1 = OrderItemFixture.withId(
+                OrderItemFixture.orderItemWithStatus(OrderStatus.SHIPPED), 201L);
+            OrderItem orderItem2 = OrderItemFixture.withId(
+                OrderItemFixture.orderItemWithStatus(OrderStatus.PURCHASE_CONFIRMED), 202L);
 
             CustomerReturnRequest request = new CustomerReturnRequest(
                 List.of(201L, 202L),
                 "단순 변심 / 사이즈 불일치"
             );
 
-            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
-            given(orderItemRepository.findByOrderIdAndIdIn(orderId, List.of(201L, 202L)))
+            given(orderRepository.findByIdWithMember(orderId)).willReturn(Optional.of(order));
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(201L, 202L)))
                 .willReturn(List.of(orderItem1, orderItem2));
 
             // when
@@ -109,7 +109,7 @@ class CustomerReturnServiceTest {
                 "반품 사유"
             );
 
-            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(orderRepository.findByIdWithMember(orderId)).willReturn(Optional.of(order));
 
             // when & then
             assertThatThrownBy(() -> sut.requestReturn(orderId, otherCustomerId, request))
@@ -117,7 +117,7 @@ class CustomerReturnServiceTest {
                 .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
                 .isEqualTo(BbangleErrorCode.ORDER_ACCESS_DENIED);
 
-            then(orderItemRepository).should(never()).findByOrderIdAndIdIn(orderId, List.of(201L));
+            then(orderItemRepository).should(never()).findByOrderIdAndIdInWithOrder(orderId, List.of(201L));
             then(returnRequestRepository).should(never()).saveAll(anyList());
             then(orderItemHistoryRepository).should(never()).saveAll(anyList());
         }
@@ -131,16 +131,16 @@ class CustomerReturnServiceTest {
 
             Order order = orderWithMember(orderId, customerId);
 
-            OrderItem invalidItem = OrderItemFixture.orderItemWithStatus(OrderStatus.PAYMENT_COMPLETED);
-            ReflectionTestUtils.setField(invalidItem, "id", 201L);
+            OrderItem invalidItem = OrderItemFixture.withId(
+                OrderItemFixture.orderItemWithStatus(OrderStatus.PAYMENT_COMPLETED), 201L);
 
             CustomerReturnRequest request = new CustomerReturnRequest(
                 List.of(201L),
                 "반품 사유"
             );
 
-            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
-            given(orderItemRepository.findByOrderIdAndIdIn(orderId, List.of(201L)))
+            given(orderRepository.findByIdWithMember(orderId)).willReturn(Optional.of(order));
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(201L)))
                 .willReturn(List.of(invalidItem));
 
             // when & then
@@ -163,16 +163,16 @@ class CustomerReturnServiceTest {
 
             Order order = orderWithMember(orderId, customerId);
 
-            OrderItem cancelledItem = OrderItemFixture.orderItemWithStatus(OrderStatus.CANCEL_APPROVED);
-            ReflectionTestUtils.setField(cancelledItem, "id", 201L);
+            OrderItem cancelledItem = OrderItemFixture.withId(
+                OrderItemFixture.orderItemWithStatus(OrderStatus.CANCEL_APPROVED), 201L);
 
             CustomerReturnRequest request = new CustomerReturnRequest(
                 List.of(201L),
                 "반품 사유"
             );
 
-            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
-            given(orderItemRepository.findByOrderIdAndIdIn(orderId, List.of(201L)))
+            given(orderRepository.findByIdWithMember(orderId)).willReturn(Optional.of(order));
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(201L)))
                 .willReturn(List.of(cancelledItem));
 
             // when & then
@@ -187,23 +187,14 @@ class CustomerReturnServiceTest {
     }
 
     private Order orderWithMember(Long orderId, Long memberId) {
-        Member member = newEntity(Member.class);
-        ReflectionTestUtils.setField(member, "id", memberId);
+        Member member = mock(Member.class);
+        given(member.getId()).willReturn(memberId);
 
-        Order order = newEntity(Order.class);
+        Order order = OrderFixture.defaultOrder()
+            .member(member)
+            .build();
         ReflectionTestUtils.setField(order, "id", orderId);
-        ReflectionTestUtils.setField(order, "member", member);
 
         return order;
-    }
-
-    private <T> T newEntity(Class<T> clazz) {
-        try {
-            Constructor<T> constructor = clazz.getDeclaredConstructor();
-            constructor.setAccessible(true);
-            return constructor.newInstance();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }


### PR DESCRIPTION
## History

* #709 

## 🚀 Major Changes & Explanations

- **고객 반품 요청 API 구현**
    - **반품 요청 (PATCH `/api/v1/customer/orders/{orderId}/return`)**: 구매자가 본인이 주문한 상품에 대해 반품 사유(`reason`)와 대상 주문 상품 목록(`orderItemIds`)을 전달하여 반품을 신청하는 엔드포인트 추가
    - 정상 요청 시 반품(Return) 클레임 엔티티가 생성되며 상태는 반품 요청 대기(`RETURN_REQUESTED`)로 전이
- **Service Unit Test 작성 (JUnit5 기반)**
    - **성공 시나리오**: 본인의 정상 주문 건에 대해 올바른 주문 상품 ID들과 사유 입력 시, 반품 상태 전이 및 `OrderItemHistory`가 정상 적재되는지 검증
    - **실패 시나리오**: 타인의 주문에 접근할 경우 권한 예외 검증, 반품이 불가능한 주문 상태(예: 이미 취소됨, 결제 대기 중 등)에서 시도할 경우 `CLAIM_INVALID_STATUS` 예외가 정확히 발생하는지 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 고객 주문 반품 요청 기능이 추가되었습니다. 배송 완료 또는 구매 확정 상태의 주문에 대해 반품을 요청할 수 있으며, 반품 사유를 입력하여 제출합니다. 동일 주문 내 여러 상품을 선택하여 한 번에 반품을 접수할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->