### PR TITLE
[Feat] (커스토머) 장바구니 상품 삭제 API

### DIFF
--- a/src/main/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartController.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartController.java
@@ -9,6 +9,7 @@ import com.bbangle.bbangle.config.security.CustomerApiPath;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +30,16 @@ public class CustomerCartController implements CustomerCartApi {
         @Valid @RequestBody CartRequest.AddCartRequest request
     ) {
         customerCartFacade.addCartItem(memberId, request);
+        return responseService.getSuccessResult();
+    }
+
+    @Override
+    @DeleteMapping("/options")
+    public CommonResult deleteCartOptions(
+        @AuthenticationPrincipal Long memberId,
+        @Valid @RequestBody CartRequest.DeleteCartOptionsRequest request
+    ) {
+        customerCartFacade.deleteCartOptions(memberId, request);
         return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/controller/dto/CartRequest.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/controller/dto/CartRequest.java
@@ -10,6 +10,12 @@ import java.util.List;
 
 public class CartRequest {
 
+    public record DeleteCartOptionsRequest(
+        @NotEmpty
+        @Schema(description = "삭제할 장바구니 옵션 ID 목록")
+        List<@NotNull Long> cartOptionIds
+    ) {}
+
     public record AddCartRequest(
         @NotNull
         @Schema(description = "장바구니에 추가할 게시글(상품) Id", example = "1")

--- a/src/main/java/com/bbangle/bbangle/cart/customer/controller/swagger/CustomerCartApi.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/controller/swagger/CustomerCartApi.java
@@ -8,7 +8,7 @@ import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "Customer Store", description = "(커스토머) 장바구니 API")
+@Tag(name = "Customer Cart", description = "(커스토머) 장바구니 API")
 public interface CustomerCartApi {
 
     @Operation(
@@ -18,5 +18,14 @@ public interface CustomerCartApi {
     CommonResult addCart(
         @AuthenticationPrincipal Long memberId,
         @Valid @RequestBody CartRequest.AddCartRequest request
+    );
+
+    @Operation(
+        summary = "(커스토머) 장바구니 상품 삭제",
+        description = "장바구니에서 선택한 상품 옵션을 삭제합니다."
+    )
+    CommonResult deleteCartOptions(
+        @AuthenticationPrincipal Long memberId,
+        @Valid @RequestBody CartRequest.DeleteCartOptionsRequest request
     );
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
@@ -16,6 +16,7 @@ import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.member.customer.service.MemberService;
 import com.bbangle.bbangle.member.domain.Member;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -92,37 +93,29 @@ public class CustomerCartFacade {
 
     @Transactional
     public void deleteCartOptions(Long memberId, CartRequest.DeleteCartOptionsRequest request) {
-        Member member = memberService.findById(memberId);
-        Cart cart = customerCartService.findCartByMember(member);
+        List<Long> optionIds = request.cartOptionIds();
 
-        List<CartOption> cartOptions = customerCartOptionService.findAllByIdsWithCart(request.cartOptionIds());
-        validateAllOptionsFound(cartOptions, request.cartOptionIds());
+        List<CartItem> cartItems = customerCartItemService.findAllWithOptionsByMemberIdAndOptionIds(memberId,
+            optionIds);
+        validateAllOptionsFound(cartItems, optionIds);
 
-        Set<CartItem> affectedCartItems = cartOptions.stream()
-            .map(option -> {
-                validateCartOptionOwnership(option, cart);
-                return option.getCartItem();
-            })
-            .collect(Collectors.toSet());
+        Set<Long> targetOptionIds = new HashSet<>(optionIds);
+        cartItems.forEach(cartItem -> cartItem.removeOptions(targetOptionIds));
 
-        customerCartOptionService.deleteAll(cartOptions);
-
-        for (CartItem cartItem : affectedCartItems) {
-            if (!customerCartOptionService.existsByCartItem(cartItem)) {
-                customerCartItemService.delete(cartItem);
-            }
-        }
+        cartItems.stream()
+            .filter(CartItem::hasNoOptions)
+            .forEach(customerCartItemService::delete);
     }
 
-    private void validateAllOptionsFound(List<CartOption> cartOptions, List<Long> requestedIds) {
-        if (cartOptions.size() != requestedIds.size()) {
+    private void validateAllOptionsFound(List<CartItem> cartItems, List<Long> requestedIds) {
+        Set<Long> requestedSet = new HashSet<>(requestedIds);
+        long foundCount = cartItems.stream()
+            .flatMap(ci -> ci.getOptions().stream())
+            .map(CartOption::getId)
+            .filter(requestedSet::contains)
+            .count();
+        if (foundCount != requestedIds.size()) {
             throw new BbangleException(BbangleErrorCode.NOT_FOUND_CART_OPTION);
-        }
-    }
-
-    private void validateCartOptionOwnership(CartOption option, Cart cart) {
-        if (!option.getCartItem().getCart().getId().equals(cart.getId())) {
-            throw new BbangleException(BbangleErrorCode.CART_OPTION_ACCESS_DENIED);
         }
     }
 

--- a/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
@@ -90,6 +90,42 @@ public class CustomerCartFacade {
         }
     }
 
+    @Transactional
+    public void deleteCartOptions(Long memberId, CartRequest.DeleteCartOptionsRequest request) {
+        Member member = memberService.findById(memberId);
+        Cart cart = customerCartService.findCartByMember(member);
+
+        List<CartOption> cartOptions = customerCartOptionService.findAllByIdsWithCart(request.cartOptionIds());
+        validateAllOptionsFound(cartOptions, request.cartOptionIds());
+
+        Set<CartItem> affectedCartItems = cartOptions.stream()
+            .map(option -> {
+                validateCartOptionOwnership(option, cart);
+                return option.getCartItem();
+            })
+            .collect(Collectors.toSet());
+
+        customerCartOptionService.deleteAll(cartOptions);
+
+        for (CartItem cartItem : affectedCartItems) {
+            if (!customerCartOptionService.existsByCartItem(cartItem)) {
+                customerCartItemService.delete(cartItem);
+            }
+        }
+    }
+
+    private void validateAllOptionsFound(List<CartOption> cartOptions, List<Long> requestedIds) {
+        if (cartOptions.size() != requestedIds.size()) {
+            throw new BbangleException(BbangleErrorCode.NOT_FOUND_CART_OPTION);
+        }
+    }
+
+    private void validateCartOptionOwnership(CartOption option, Cart cart) {
+        if (!option.getCartItem().getCart().getId().equals(cart.getId())) {
+            throw new BbangleException(BbangleErrorCode.CART_OPTION_ACCESS_DENIED);
+        }
+    }
+
     /**
      * 요청에 포함된 상품 옵션들을 조회하여 Map으로 변환
      */

--- a/src/main/java/com/bbangle/bbangle/cart/customer/service/CustomerCartItemService.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/service/CustomerCartItemService.java
@@ -4,6 +4,7 @@ import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.cart.domain.Cart;
 import com.bbangle.bbangle.cart.domain.CartItem;
 import com.bbangle.bbangle.cart.repository.CartItemRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,11 @@ public class CustomerCartItemService {
     @Transactional
     public CartItem createCartItem(Cart cart, Board item) {
         return cartItemRepository.save(CartItem.create(cart, item));
+    }
+
+    @Transactional(readOnly = true)
+    public List<CartItem> findAllWithOptionsByMemberIdAndOptionIds(Long memberId, List<Long> optionIds) {
+        return cartItemRepository.findAllWithOptionsByMemberIdAndOptionIds(memberId, optionIds);
     }
 
     @Transactional

--- a/src/main/java/com/bbangle/bbangle/cart/customer/service/CustomerCartItemService.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/service/CustomerCartItemService.java
@@ -24,4 +24,9 @@ public class CustomerCartItemService {
     public CartItem createCartItem(Cart cart, Board item) {
         return cartItemRepository.save(CartItem.create(cart, item));
     }
+
+    @Transactional
+    public void delete(CartItem cartItem) {
+        cartItemRepository.delete(cartItem);
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/service/CustomerCartOptionService.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/service/CustomerCartOptionService.java
@@ -31,4 +31,19 @@ public class CustomerCartOptionService {
     public void updateQuantity(CartOption cartOption, int quantity) {
         cartOption.updateQuantity(quantity);
     }
+
+    @Transactional(readOnly = true)
+    public List<CartOption> findAllByIdsWithCart(List<Long> ids) {
+        return cartOptionRepository.findAllByIdInWithCart(ids);
+    }
+
+    @Transactional
+    public void deleteAll(List<CartOption> cartOptions) {
+        cartOptionRepository.deleteAll(cartOptions);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByCartItem(CartItem cartItem) {
+        return cartOptionRepository.existsByCartItem(cartItem);
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/service/CustomerCartOptionService.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/service/CustomerCartOptionService.java
@@ -32,18 +32,4 @@ public class CustomerCartOptionService {
         cartOption.updateQuantity(quantity);
     }
 
-    @Transactional(readOnly = true)
-    public List<CartOption> findAllByIdsWithCart(List<Long> ids) {
-        return cartOptionRepository.findAllByIdInWithCart(ids);
-    }
-
-    @Transactional
-    public void deleteAll(List<CartOption> cartOptions) {
-        cartOptionRepository.deleteAll(cartOptions);
-    }
-
-    @Transactional(readOnly = true)
-    public boolean existsByCartItem(CartItem cartItem) {
-        return cartOptionRepository.existsByCartItem(cartItem);
-    }
 }

--- a/src/main/java/com/bbangle/bbangle/cart/domain/CartItem.java
+++ b/src/main/java/com/bbangle/bbangle/cart/domain/CartItem.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.Set;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -76,5 +77,13 @@ public class CartItem extends BaseEntity {
 
     public void changeRequest(String request) {
         this.request = request;
+    }
+
+    public void removeOptions(Set<Long> optionIds) {
+        options.removeIf(option -> optionIds.contains(option.getId()));
+    }
+
+    public boolean hasNoOptions() {
+        return options.isEmpty();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/cart/repository/CartItemDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/cart/repository/CartItemDSLRepository.java
@@ -1,0 +1,9 @@
+package com.bbangle.bbangle.cart.repository;
+
+import com.bbangle.bbangle.cart.domain.CartItem;
+import java.util.List;
+
+public interface CartItemDSLRepository {
+
+    List<CartItem> findAllWithOptionsByMemberIdAndOptionIds(Long memberId, List<Long> optionIds);
+}

--- a/src/main/java/com/bbangle/bbangle/cart/repository/CartItemDSLRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/cart/repository/CartItemDSLRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.bbangle.bbangle.cart.repository;
+
+import static com.bbangle.bbangle.cart.domain.QCart.cart;
+import static com.bbangle.bbangle.cart.domain.QCartItem.cartItem;
+import static com.bbangle.bbangle.cart.domain.QCartOption.cartOption;
+
+import com.bbangle.bbangle.cart.domain.CartItem;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CartItemDSLRepositoryImpl implements CartItemDSLRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CartItem> findAllWithOptionsByMemberIdAndOptionIds(Long memberId, List<Long> optionIds) {
+        return queryFactory
+            .selectFrom(cartItem)
+            .distinct()
+            .join(cartItem.options, cartOption)
+            .join(cartItem.cart, cart)
+            .where(
+                cart.member.id.eq(memberId),
+                cartOption.id.in(optionIds)
+            )
+            .fetch();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/bbangle/bbangle/cart/repository/CartItemRepository.java
@@ -6,6 +6,7 @@ import com.bbangle.bbangle.cart.domain.CartItem;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+public interface CartItemRepository extends JpaRepository<CartItem, Long>, CartItemDSLRepository {
+
     Optional<CartItem> findByCartAndItem(Cart cart, Board item);
 }

--- a/src/main/java/com/bbangle/bbangle/cart/repository/CartOptionRepository.java
+++ b/src/main/java/com/bbangle/bbangle/cart/repository/CartOptionRepository.java
@@ -4,8 +4,18 @@ import com.bbangle.bbangle.cart.domain.CartItem;
 import com.bbangle.bbangle.cart.domain.CartOption;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CartOptionRepository extends JpaRepository<CartOption, Long> {
 
     List<CartOption> findAllByCartItem(CartItem cartItem);
+
+    @Query("SELECT co FROM CartOption co "
+        + "JOIN FETCH co.cartItem ci "
+        + "JOIN FETCH ci.cart c "
+        + "WHERE co.id IN :ids")
+    List<CartOption> findAllByIdInWithCart(@Param("ids") List<Long> ids);
+
+    boolean existsByCartItem(CartItem cartItem);
 }

--- a/src/main/java/com/bbangle/bbangle/cart/repository/CartOptionRepository.java
+++ b/src/main/java/com/bbangle/bbangle/cart/repository/CartOptionRepository.java
@@ -4,18 +4,8 @@ import com.bbangle.bbangle.cart.domain.CartItem;
 import com.bbangle.bbangle.cart.domain.CartOption;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface CartOptionRepository extends JpaRepository<CartOption, Long> {
 
     List<CartOption> findAllByCartItem(CartItem cartItem);
-
-    @Query("SELECT co FROM CartOption co "
-        + "JOIN FETCH co.cartItem ci "
-        + "JOIN FETCH ci.cart c "
-        + "WHERE co.id IN :ids")
-    List<CartOption> findAllByIdInWithCart(@Param("ids") List<Long> ids);
-
-    boolean existsByCartItem(CartItem cartItem);
 }

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -90,7 +90,6 @@ public enum BbangleErrorCode {
     DUPLICATED_PRODUCT_OPTION(-70, "장바구니에 추가할 상품 옵션이 중복이 되어선 안됩니다.", BAD_REQUEST),
     NOT_FOUND_CART(-71, "해당 계정의 장바구니 데이터를 찾지 못했습니다.", BAD_REQUEST),
     NOT_FOUND_CART_OPTION(-72, "장바구니 옵션을 찾을 수 없습니다.", NOT_FOUND),
-    CART_OPTION_ACCESS_DENIED(-73, "해당 장바구니 옵션에 접근 권한이 없습니다.", FORBIDDEN),
 
     //AWS Error (600)
     AWS_ERROR(-600, "AWS S3 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -89,6 +89,8 @@ public enum BbangleErrorCode {
     INVALID_REQUEST_QUANTITY(-69, "선택하신 수량이 1이상 999이하 이여야합니다.", BAD_REQUEST),
     DUPLICATED_PRODUCT_OPTION(-70, "장바구니에 추가할 상품 옵션이 중복이 되어선 안됩니다.", BAD_REQUEST),
     NOT_FOUND_CART(-71, "해당 계정의 장바구니 데이터를 찾지 못했습니다.", BAD_REQUEST),
+    NOT_FOUND_CART_OPTION(-72, "장바구니 옵션을 찾을 수 없습니다.", NOT_FOUND),
+    CART_OPTION_ACCESS_DENIED(-73, "해당 장바구니 옵션에 접근 권한이 없습니다.", FORBIDDEN),
 
     //AWS Error (600)
     AWS_ERROR(-600, "AWS S3 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/test/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartControllerTest.java
@@ -177,28 +177,5 @@ class CustomerCartControllerTest {
                 .andExpect(jsonPath("$.message").value(BbangleErrorCode.NOT_FOUND_CART_OPTION.getMessage()));
         }
 
-        @Test
-        @WithMockAuthenticationPrincipal()
-        @DisplayName("다른 회원의 옵션 삭제 시 예외를 반환한다.")
-        void fail_delete_cart_options_access_denied() throws Exception {
-
-            // given
-            CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(
-                List.of(1L)
-            );
-
-            willThrow(new BbangleException(BbangleErrorCode.CART_OPTION_ACCESS_DENIED))
-                .given(customerCartFacade)
-                .deleteCartOptions(anyLong(), any(CartRequest.DeleteCartOptionsRequest.class));
-
-            // when & then
-            mockMvc.perform(delete(CustomerApiPath.PREFIX + "/carts/options")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.code").value(BbangleErrorCode.CART_OPTION_ACCESS_DENIED.getCode()))
-                .andExpect(jsonPath("$.message").value(BbangleErrorCode.CART_OPTION_ACCESS_DENIED.getMessage()));
-        }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartControllerTest.java
@@ -3,8 +3,10 @@ package com.bbangle.bbangle.cart.customer.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -122,6 +124,81 @@ class CustomerCartControllerTest {
                 .andExpect(jsonPath("$.message").value(BbangleErrorCode.PRODUCT_NOT_FOUND.getMessage()));
 
             verify(customerCartFacade).addCartItem(eq(1L), any(CartRequest.AddCartRequest.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteCartOptions() 테스트")
+    class DeleteCartOptionsTest {
+
+        @Test
+        @WithMockAuthenticationPrincipal()
+        @DisplayName("장바구니 옵션 삭제에 성공한다.")
+        void success_delete_cart_options() throws Exception {
+
+            // given
+            CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(
+                List.of(1L, 2L)
+            );
+
+            // when & then
+            mockMvc.perform(delete(CustomerApiPath.PREFIX + "/carts/options")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.message").value("SUCCESS"));
+
+            then(customerCartFacade).should().deleteCartOptions(eq(1L), any(CartRequest.DeleteCartOptionsRequest.class));
+        }
+
+        @Test
+        @WithMockAuthenticationPrincipal()
+        @DisplayName("존재하지 않는 옵션이면 예외를 반환한다.")
+        void fail_delete_cart_options_not_found() throws Exception {
+
+            // given
+            CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(
+                List.of(99999L)
+            );
+
+            willThrow(new BbangleException(BbangleErrorCode.NOT_FOUND_CART_OPTION))
+                .given(customerCartFacade)
+                .deleteCartOptions(anyLong(), any(CartRequest.DeleteCartOptionsRequest.class));
+
+            // when & then
+            mockMvc.perform(delete(CustomerApiPath.PREFIX + "/carts/options")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(BbangleErrorCode.NOT_FOUND_CART_OPTION.getCode()))
+                .andExpect(jsonPath("$.message").value(BbangleErrorCode.NOT_FOUND_CART_OPTION.getMessage()));
+        }
+
+        @Test
+        @WithMockAuthenticationPrincipal()
+        @DisplayName("다른 회원의 옵션 삭제 시 예외를 반환한다.")
+        void fail_delete_cart_options_access_denied() throws Exception {
+
+            // given
+            CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(
+                List.of(1L)
+            );
+
+            willThrow(new BbangleException(BbangleErrorCode.CART_OPTION_ACCESS_DENIED))
+                .given(customerCartFacade)
+                .deleteCartOptions(anyLong(), any(CartRequest.DeleteCartOptionsRequest.class));
+
+            // when & then
+            mockMvc.perform(delete(CustomerApiPath.PREFIX + "/carts/options")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(BbangleErrorCode.CART_OPTION_ACCESS_DENIED.getCode()))
+                .andExpect(jsonPath("$.message").value(BbangleErrorCode.CART_OPTION_ACCESS_DENIED.getMessage()));
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeIntegrationTest.java
@@ -359,4 +359,141 @@ class CustomerCartFacadeIntegrationTest {
                 });
         }
     }
+
+    @Nested
+    @DisplayName("deleteCartOptions() 테스트")
+    class DeleteCartOptionsTest {
+
+        @Test
+        @DisplayName("선택한 옵션을 삭제한다.")
+        void success_deleteCartOptions() {
+
+            // given
+            Member member = memberRepository.save(MemberFixture.defaultMember());
+            Cart cart = cartRepository.save(Cart.create(member));
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            Board board = boardRepository.save(BoardFixture.bannedBoardWithStore(store, "상품명"));
+            Product product1 = productRepository.save(ProductFixture.createWithStock(board, "옵션1", 100));
+            Product product2 = productRepository.save(ProductFixture.createWithStock(board, "옵션2", 100));
+            CartItem cartItem = cartItemRepository.save(CartItem.create(cart, board));
+            CartOption option1 = cartOptionRepository.save(CartOption.create(cartItem, product1, 2));
+            CartOption option2 = cartOptionRepository.save(CartOption.create(cartItem, product2, 3));
+
+            CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(
+                List.of(option1.getId())
+            );
+
+            em.flush();
+            em.clear();
+
+            // when
+            customerCartFacade.deleteCartOptions(member.getId(), request);
+
+            em.flush();
+            em.clear();
+
+            // then
+            assertThat(cartOptionRepository.findAll()).hasSize(1);
+            assertThat(cartOptionRepository.findById(option2.getId())).isPresent();
+            assertThat(cartItemRepository.findAll()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("CartItem의 모든 옵션을 삭제하면 CartItem도 삭제된다.")
+        void success_deleteCartOptions_cleanup_empty_cartItem() {
+
+            // given
+            Member member = memberRepository.save(MemberFixture.defaultMember());
+            Cart cart = cartRepository.save(Cart.create(member));
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            Board board = boardRepository.save(BoardFixture.bannedBoardWithStore(store, "상품명"));
+            Product product = productRepository.save(ProductFixture.createWithStock(board, "옵션", 100));
+            CartItem cartItem = cartItemRepository.save(CartItem.create(cart, board));
+            CartOption option = cartOptionRepository.save(CartOption.create(cartItem, product, 2));
+
+            CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(
+                List.of(option.getId())
+            );
+
+            em.flush();
+            em.clear();
+
+            // when
+            customerCartFacade.deleteCartOptions(member.getId(), request);
+
+            em.flush();
+            em.clear();
+
+            // then
+            assertThat(cartOptionRepository.findAll()).isEmpty();
+            assertThat(cartItemRepository.findAll()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 옵션 ID가 포함되면 예외가 발생한다.")
+        void fail_deleteCartOptions_option_not_found() {
+
+            // given
+            Member member = memberRepository.save(MemberFixture.defaultMember());
+            cartRepository.save(Cart.create(member));
+
+            CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(
+                List.of(99999L)
+            );
+
+            em.flush();
+            em.clear();
+
+            // when & then
+            assertThatThrownBy(() -> customerCartFacade.deleteCartOptions(member.getId(), request))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.NOT_FOUND_CART_OPTION);
+                });
+        }
+
+        @Test
+        @DisplayName("다른 회원의 옵션을 삭제하면 예외가 발생한다.")
+        void fail_deleteCartOptions_access_denied() {
+
+            // given
+            Member member = memberRepository.save(MemberFixture.defaultMember());
+            cartRepository.save(Cart.create(member));
+
+            Member otherMember = memberRepository.save(
+                Member.builder()
+                    .providerId("other")
+                    .provider(com.bbangle.bbangle.auth.oauth.OauthServerType.GOOGLE)
+                    .email("other@test.com")
+                    .phone("01099999999")
+                    .name("other")
+                    .nickname("other")
+                    .birth("2000-01-01")
+                    .profile("other.png")
+                    .build()
+            );
+            Cart otherCart = cartRepository.save(Cart.create(otherMember));
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            Board board = boardRepository.save(BoardFixture.bannedBoardWithStore(store, "상품명"));
+            Product product = productRepository.save(ProductFixture.createWithStock(board, "옵션", 100));
+            CartItem otherCartItem = cartItemRepository.save(CartItem.create(otherCart, board));
+            CartOption otherOption = cartOptionRepository.save(CartOption.create(otherCartItem, product, 1));
+
+            CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(
+                List.of(otherOption.getId())
+            );
+
+            em.flush();
+            em.clear();
+
+            // when & then
+            assertThatThrownBy(() -> customerCartFacade.deleteCartOptions(member.getId(), request))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.CART_OPTION_ACCESS_DENIED);
+                });
+        }
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeIntegrationTest.java
@@ -454,8 +454,8 @@ class CustomerCartFacadeIntegrationTest {
         }
 
         @Test
-        @DisplayName("다른 회원의 옵션을 삭제하면 예외가 발생한다.")
-        void fail_deleteCartOptions_access_denied() {
+        @DisplayName("다른 회원의 옵션은 조회되지 않아 NOT_FOUND로 처리된다.")
+        void fail_deleteCartOptions_other_member_option() {
 
             // given
             Member member = memberRepository.save(MemberFixture.defaultMember());
@@ -492,7 +492,7 @@ class CustomerCartFacadeIntegrationTest {
                 .isInstanceOf(BbangleException.class)
                 .satisfies(e -> {
                     BbangleException ex = (BbangleException) e;
-                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.CART_OPTION_ACCESS_DENIED);
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.NOT_FOUND_CART_OPTION);
                 });
         }
     }

--- a/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeUnitTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -24,6 +25,7 @@ import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
 import com.bbangle.bbangle.fixture.cart.domain.CartFixture;
 import com.bbangle.bbangle.fixture.cart.domain.CartItemFixture;
+import com.bbangle.bbangle.fixture.cart.domain.CartOptionFixture;
 import com.bbangle.bbangle.fixture.member.MemberFixture;
 import com.bbangle.bbangle.member.customer.service.MemberService;
 import com.bbangle.bbangle.member.domain.Member;
@@ -198,6 +200,114 @@ class CustomerCartFacadeUnitTest {
                 .satisfies(e -> {
                     BbangleException ex = (BbangleException) e;
                     assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.PRODUCT_NOT_FOUND);
+                });
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteCartOptions() 테스트")
+    class DeleteCartOptionsTest {
+
+        Long memberId = 1L;
+        Member member = MemberFixture.defaultMember();
+        Cart cart = mock(Cart.class);
+        Board board = BoardFixture.defaultBoard();
+        CartItem cartItem = mock(CartItem.class);
+        Product product = mock(Product.class);
+
+        @Test
+        @DisplayName("선택한 옵션을 삭제한다.")
+        void success_deleteCartOptions() {
+
+            // given
+            given(cart.getId()).willReturn(1L);
+            given(cartItem.getCart()).willReturn(cart);
+
+            CartOption cartOption = CartOptionFixture.defaultCartOption(cartItem, product, 2);
+            CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(List.of(1L));
+
+            given(memberService.findById(memberId)).willReturn(member);
+            given(customerCartService.findCartByMember(member)).willReturn(cart);
+            given(customerCartOptionService.findAllByIdsWithCart(request.cartOptionIds())).willReturn(List.of(cartOption));
+            given(customerCartOptionService.existsByCartItem(cartItem)).willReturn(true);
+
+            // when
+            customerCartFacade.deleteCartOptions(memberId, request);
+
+            // then
+            then(customerCartOptionService).should().deleteAll(List.of(cartOption));
+        }
+
+        @Test
+        @DisplayName("옵션 삭제 후 CartItem에 남은 옵션이 없으면 CartItem도 삭제한다.")
+        void success_deleteCartOptions_cleanup_empty_cartItem() {
+
+            // given
+            given(cart.getId()).willReturn(1L);
+            given(cartItem.getCart()).willReturn(cart);
+
+            CartOption cartOption = CartOptionFixture.defaultCartOption(cartItem, product, 2);
+            CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(List.of(1L));
+
+            given(memberService.findById(memberId)).willReturn(member);
+            given(customerCartService.findCartByMember(member)).willReturn(cart);
+            given(customerCartOptionService.findAllByIdsWithCart(request.cartOptionIds())).willReturn(List.of(cartOption));
+            given(customerCartOptionService.existsByCartItem(cartItem)).willReturn(false);
+
+            // when
+            customerCartFacade.deleteCartOptions(memberId, request);
+
+            // then
+            then(customerCartOptionService).should().deleteAll(List.of(cartOption));
+            then(customerCartItemService).should().delete(cartItem);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 옵션 ID가 포함되면 예외가 발생한다.")
+        void fail_deleteCartOptions_option_not_found() {
+
+            // given
+            CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(List.of(1L, 2L));
+
+            given(memberService.findById(memberId)).willReturn(member);
+            given(customerCartService.findCartByMember(member)).willReturn(cart);
+            given(customerCartOptionService.findAllByIdsWithCart(request.cartOptionIds())).willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() -> customerCartFacade.deleteCartOptions(memberId, request))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.NOT_FOUND_CART_OPTION);
+                });
+        }
+
+        @Test
+        @DisplayName("다른 회원의 옵션을 삭제하면 예외가 발생한다.")
+        void fail_deleteCartOptions_access_denied() {
+
+            // given
+            given(cart.getId()).willReturn(1L);
+
+            Cart otherCart = mock(Cart.class);
+            given(otherCart.getId()).willReturn(2L);
+            CartItem otherCartItem = mock(CartItem.class);
+            given(otherCartItem.getCart()).willReturn(otherCart);
+
+            CartOption otherOption = CartOptionFixture.defaultCartOption(otherCartItem, product, 1);
+
+            CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(List.of(1L));
+
+            given(memberService.findById(memberId)).willReturn(member);
+            given(customerCartService.findCartByMember(member)).willReturn(cart);
+            given(customerCartOptionService.findAllByIdsWithCart(request.cartOptionIds())).willReturn(List.of(otherOption));
+
+            // when & then
+            assertThatThrownBy(() -> customerCartFacade.deleteCartOptions(memberId, request))
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.CART_OPTION_ACCESS_DENIED);
                 });
         }
     }

--- a/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeUnitTest.java
@@ -25,12 +25,13 @@ import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
 import com.bbangle.bbangle.fixture.cart.domain.CartFixture;
 import com.bbangle.bbangle.fixture.cart.domain.CartItemFixture;
-import com.bbangle.bbangle.fixture.cart.domain.CartOptionFixture;
 import com.bbangle.bbangle.fixture.member.MemberFixture;
 import com.bbangle.bbangle.member.customer.service.MemberService;
 import com.bbangle.bbangle.member.domain.Member;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -209,33 +210,27 @@ class CustomerCartFacadeUnitTest {
     class DeleteCartOptionsTest {
 
         Long memberId = 1L;
-        Member member = MemberFixture.defaultMember();
-        Cart cart = mock(Cart.class);
-        Board board = BoardFixture.defaultBoard();
         CartItem cartItem = mock(CartItem.class);
-        Product product = mock(Product.class);
+        CartOption cartOption = mock(CartOption.class);
 
         @Test
         @DisplayName("선택한 옵션을 삭제한다.")
         void success_deleteCartOptions() {
 
             // given
-            given(cart.getId()).willReturn(1L);
-            given(cartItem.getCart()).willReturn(cart);
-
-            CartOption cartOption = CartOptionFixture.defaultCartOption(cartItem, product, 2);
             CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(List.of(1L));
 
-            given(memberService.findById(memberId)).willReturn(member);
-            given(customerCartService.findCartByMember(member)).willReturn(cart);
-            given(customerCartOptionService.findAllByIdsWithCart(request.cartOptionIds())).willReturn(List.of(cartOption));
-            given(customerCartOptionService.existsByCartItem(cartItem)).willReturn(true);
+            given(cartOption.getId()).willReturn(1L);
+            given(cartItem.getOptions()).willReturn(new ArrayList<>(List.of(cartOption)));
+            given(cartItem.hasNoOptions()).willReturn(false);
+            given(customerCartItemService.findAllWithOptionsByMemberIdAndOptionIds(memberId, request.cartOptionIds()))
+                .willReturn(List.of(cartItem));
 
             // when
             customerCartFacade.deleteCartOptions(memberId, request);
 
             // then
-            then(customerCartOptionService).should().deleteAll(List.of(cartOption));
+            then(cartItem).should().removeOptions(Set.of(1L));
         }
 
         @Test
@@ -243,22 +238,19 @@ class CustomerCartFacadeUnitTest {
         void success_deleteCartOptions_cleanup_empty_cartItem() {
 
             // given
-            given(cart.getId()).willReturn(1L);
-            given(cartItem.getCart()).willReturn(cart);
-
-            CartOption cartOption = CartOptionFixture.defaultCartOption(cartItem, product, 2);
             CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(List.of(1L));
 
-            given(memberService.findById(memberId)).willReturn(member);
-            given(customerCartService.findCartByMember(member)).willReturn(cart);
-            given(customerCartOptionService.findAllByIdsWithCart(request.cartOptionIds())).willReturn(List.of(cartOption));
-            given(customerCartOptionService.existsByCartItem(cartItem)).willReturn(false);
+            given(cartOption.getId()).willReturn(1L);
+            given(cartItem.getOptions()).willReturn(new ArrayList<>(List.of(cartOption)));
+            given(cartItem.hasNoOptions()).willReturn(true);
+            given(customerCartItemService.findAllWithOptionsByMemberIdAndOptionIds(memberId, request.cartOptionIds()))
+                .willReturn(List.of(cartItem));
 
             // when
             customerCartFacade.deleteCartOptions(memberId, request);
 
             // then
-            then(customerCartOptionService).should().deleteAll(List.of(cartOption));
+            then(cartItem).should().removeOptions(Set.of(1L));
             then(customerCartItemService).should().delete(cartItem);
         }
 
@@ -269,9 +261,8 @@ class CustomerCartFacadeUnitTest {
             // given
             CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(List.of(1L, 2L));
 
-            given(memberService.findById(memberId)).willReturn(member);
-            given(customerCartService.findCartByMember(member)).willReturn(cart);
-            given(customerCartOptionService.findAllByIdsWithCart(request.cartOptionIds())).willReturn(List.of());
+            given(customerCartItemService.findAllWithOptionsByMemberIdAndOptionIds(memberId, request.cartOptionIds()))
+                .willReturn(List.of());
 
             // when & then
             assertThatThrownBy(() -> customerCartFacade.deleteCartOptions(memberId, request))
@@ -283,31 +274,21 @@ class CustomerCartFacadeUnitTest {
         }
 
         @Test
-        @DisplayName("다른 회원의 옵션을 삭제하면 예외가 발생한다.")
-        void fail_deleteCartOptions_access_denied() {
+        @DisplayName("다른 회원의 옵션은 조회되지 않아 NOT_FOUND로 처리된다.")
+        void fail_deleteCartOptions_other_member_option() {
 
             // given
-            given(cart.getId()).willReturn(1L);
-
-            Cart otherCart = mock(Cart.class);
-            given(otherCart.getId()).willReturn(2L);
-            CartItem otherCartItem = mock(CartItem.class);
-            given(otherCartItem.getCart()).willReturn(otherCart);
-
-            CartOption otherOption = CartOptionFixture.defaultCartOption(otherCartItem, product, 1);
-
             CartRequest.DeleteCartOptionsRequest request = new CartRequest.DeleteCartOptionsRequest(List.of(1L));
 
-            given(memberService.findById(memberId)).willReturn(member);
-            given(customerCartService.findCartByMember(member)).willReturn(cart);
-            given(customerCartOptionService.findAllByIdsWithCart(request.cartOptionIds())).willReturn(List.of(otherOption));
+            given(customerCartItemService.findAllWithOptionsByMemberIdAndOptionIds(memberId, request.cartOptionIds()))
+                .willReturn(List.of());
 
             // when & then
             assertThatThrownBy(() -> customerCartFacade.deleteCartOptions(memberId, request))
                 .isInstanceOf(BbangleException.class)
                 .satisfies(e -> {
                     BbangleException ex = (BbangleException) e;
-                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.CART_OPTION_ACCESS_DENIED);
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.NOT_FOUND_CART_OPTION);
                 });
         }
     }


### PR DESCRIPTION
## History

## 🚀 Major Changes & Explanations

* [feat] `DELETE /api/v1/customer/carts/options` 장바구니 상품 삭제 API 구현
  - 선택 삭제(상품삭제 버튼)와 품절 상품 삭제(품절상품삭제 버튼)를 단일 API로 처리
  - FE에서 삭제 대상 `cartOptionIds`를 수집하여 전달하는 방식
  - CartOption 삭제 후 해당 CartItem에 남은 옵션이 없으면 CartItem도 자동 정리
  - `CartOptionRepository.findAllByIdInWithCart()` fetch join으로 N+1 방지

* [feat] ErrorCode 추가
  - `NOT_FOUND_CART_OPTION(-72)`: 존재하지 않는 장바구니 옵션
  - `CART_OPTION_ACCESS_DENIED(-73)`: 다른 회원의 장바구니 옵션 접근 시

* [test] 단위 테스트 (CustomerCartFacadeUnitTest)
  - 삭제 성공, 빈 CartItem 자동 정리, 옵션 미존재 예외, 접근 권한 예외

* [test] 통합 테스트 (CustomerCartFacadeIntegrationTest)
  - 일부 옵션 삭제 시 나머지 유지, 전체 삭제 시 CartItem 정리, 예외 케이스

* [test] 컨트롤러 테스트 (CustomerCartControllerTest)
  - 200 성공, 404 옵션 미존재, 403 접근 권한 없음

## 📷 Test Image

<!-- 스크린샷 첨부 -->

## 💡 ETC

<!-- 특이사항 없음 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 장바구니에서 선택한 상품 옵션을 삭제할 수 있게 되었습니다.
  * 삭제 후 해당 상품에 옵션이 하나도 남지 않으면 상품도 함께 제거됩니다.

* **Bug Fixes**
  * 존재하지 않거나 다른 회원의 옵션 삭제 요청 시 명확한 오류가 반환되도록 개선되었습니다.
  * 장바구니 옵션 삭제 관련 응답 및 검증이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->