### PR TITLE
[Feature] (커스터머) 주문 취소 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/claim/customer/controller/CustomerCancelController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/customer/controller/CustomerCancelController.java
@@ -1,0 +1,34 @@
+package com.bbangle.bbangle.claim.customer.controller;
+
+import com.bbangle.bbangle.claim.customer.controller.dto.CustomerCancelRequest;
+import com.bbangle.bbangle.claim.customer.service.CustomerCancelService;
+import com.bbangle.bbangle.common.dto.CommonResult;
+import com.bbangle.bbangle.common.service.ResponseService;
+import com.bbangle.bbangle.config.security.CustomerApiPath;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping(CustomerApiPath.PREFIX + "/orders")
+@RestController
+public class CustomerCancelController {
+
+    private final ResponseService responseService;
+    private final CustomerCancelService customerCancelService;
+
+    @PatchMapping("/{orderId}/cancel")
+    public CommonResult requestCancel(
+        @PathVariable Long orderId,
+        @Valid @RequestBody CustomerCancelRequest request,
+        @AuthenticationPrincipal Long customerId
+    ) {
+        customerCancelService.requestCancel(orderId, customerId, request);
+        return responseService.getSuccessResult();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/claim/customer/controller/dto/CustomerCancelRequest.java
+++ b/src/main/java/com/bbangle/bbangle/claim/customer/controller/dto/CustomerCancelRequest.java
@@ -1,0 +1,18 @@
+package com.bbangle.bbangle.claim.customer.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record CustomerCancelRequest(
+    @Schema(description = "취소할 주문 상품 ID 목록", example = "[101, 102]")
+    @NotEmpty(message = "취소할 주문 상품은 최소 하나 이상 선택해야 합니다.")
+    List<Long> orderItemIds,
+
+    @Schema(description = "취소 사유", example = "단순 변심 / 다른 상품 재구매", maxLength = 500)
+    @NotBlank(message = "취소 사유는 필수입니다.")
+    @Size(max = 500, message = "취소 사유는 500자 이하로 입력해주세요.")
+    String reason
+) {}

--- a/src/main/java/com/bbangle/bbangle/claim/customer/service/CustomerCancelService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/customer/service/CustomerCancelService.java
@@ -1,0 +1,71 @@
+package com.bbangle.bbangle.claim.customer.service;
+
+import com.bbangle.bbangle.claim.customer.controller.dto.CustomerCancelRequest;
+import com.bbangle.bbangle.claim.domain.CancelRequest;
+import com.bbangle.bbangle.claim.domain.constant.CancelRequestStatus;
+import com.bbangle.bbangle.claim.repository.CancelRequestRepository;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.OrderItemHistory;
+import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
+import com.bbangle.bbangle.order.repository.OrderItemRepository;
+import com.bbangle.bbangle.order.repository.OrderRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CustomerCancelService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final CancelRequestRepository cancelRequestRepository;
+    private final OrderItemHistoryRepository orderItemHistoryRepository;
+
+    @Transactional
+    public void requestCancel(Long orderId, Long customerId, CustomerCancelRequest request) {
+        Order order = orderRepository.findByIdWithMember(orderId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.getMember().getId().equals(customerId)) {
+            throw new BbangleException(BbangleErrorCode.ORDER_ACCESS_DENIED);
+        }
+
+        List<Long> uniqueOrderItemIds = request.orderItemIds().stream()
+            .distinct()
+            .toList();
+
+        List<OrderItem> orderItems = orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, uniqueOrderItemIds);
+
+        if (orderItems.size() != uniqueOrderItemIds.size()) {
+            throw new BbangleException(BbangleErrorCode.ORDER_ITEM_NOT_FOUND);
+        }
+
+        // 취소 가능 상태 전면 검증 (All-or-Nothing 정책: 하나라도 불가하면 전체 실패)
+        if (orderItems.stream().anyMatch(item -> !item.canRequestCancel())) {
+            throw new BbangleException(BbangleErrorCode.CLAIM_INVALID_STATUS);
+        }
+
+        // 전체 유효성 확인 후 상태 전이 실행
+        orderItems.forEach(OrderItem::requestCancel);
+
+        List<CancelRequest> cancelRequestsToSave = orderItems.stream()
+            .map(orderItem -> CancelRequest.builder()
+                .orderItem(orderItem)
+                .detailReason(request.reason())
+                .status(CancelRequestStatus.REQUESTED)
+                .build())
+            .toList();
+
+        List<OrderItemHistory> historiesToSave = orderItems.stream()
+            .map(OrderItemHistory::create)
+            .toList();
+
+        cancelRequestRepository.saveAll(cancelRequestsToSave);
+        orderItemHistoryRepository.saveAll(historiesToSave);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -1,6 +1,9 @@
 package com.bbangle.bbangle.order.domain;
 
 import static com.bbangle.bbangle.order.domain.model.OrderStatus.CANCEL_REQUESTED;
+import static com.bbangle.bbangle.order.domain.model.OrderStatus.ORDER_CONFIRMED;
+import static com.bbangle.bbangle.order.domain.model.OrderStatus.IN_PRODUCTION;
+import static com.bbangle.bbangle.order.domain.model.OrderStatus.PAYMENT_COMPLETED;
 import static com.bbangle.bbangle.order.domain.model.OrderStatus.RETURN_REQUESTED;
 
 import com.bbangle.bbangle.board.domain.Product;
@@ -126,6 +129,20 @@ public class OrderItem extends BaseEntity {
             throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
         }
         this.orderStatus = OrderStatus.SHIPPED;
+    }
+
+    public boolean canRequestCancel() {
+        return this.orderStatus == PAYMENT_COMPLETED
+            || this.orderStatus == ORDER_CONFIRMED
+            || this.orderStatus == IN_PRODUCTION;
+    }
+
+    public boolean requestCancel() {
+        if (!canRequestCancel()) {
+            return false;
+        }
+        this.orderStatus = CANCEL_REQUESTED;
+        return true;
     }
 
     public boolean canRequestReturn() {

--- a/src/test/java/com/bbangle/bbangle/claim/customer/service/CustomerCancelServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/customer/service/CustomerCancelServiceTest.java
@@ -1,0 +1,200 @@
+package com.bbangle.bbangle.claim.customer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.bbangle.bbangle.claim.customer.controller.dto.CustomerCancelRequest;
+import com.bbangle.bbangle.claim.repository.CancelRequestRepository;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.order.OrderItemFixture;
+import com.bbangle.bbangle.fixture.order.domain.OrderFixture;
+import com.bbangle.bbangle.member.domain.Member;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderItemHistoryRepository;
+import com.bbangle.bbangle.order.repository.OrderItemRepository;
+import com.bbangle.bbangle.order.repository.OrderRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("[단위 테스트] CustomerCancelService - requestCancel")
+@ExtendWith(MockitoExtension.class)
+class CustomerCancelServiceTest {
+
+    @InjectMocks
+    private CustomerCancelService sut;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private OrderItemRepository orderItemRepository;
+
+    @Mock
+    private CancelRequestRepository cancelRequestRepository;
+
+    @Mock
+    private OrderItemHistoryRepository orderItemHistoryRepository;
+
+    @Nested
+    @DisplayName("성공 시나리오")
+    class SuccessScenarios {
+
+        @Test
+        @DisplayName("취소 가능한 상태의 주문 상품으로 취소 요청 시 CANCEL_REQUESTED로 전이되고 CancelRequest·OrderItemHistory가 누락 없이 저장된다")
+        void givenCancellableOrderItems_whenRequestCancel_thenSavedSuccessfully() {
+            // given
+            Long orderId = 1L;
+            Long customerId = 100L;
+
+            Order order = orderWithMember(orderId, customerId);
+
+            OrderItem orderItem1 = OrderItemFixture.withId(
+                OrderItemFixture.orderItemWithStatus(OrderStatus.PAYMENT_COMPLETED), 101L);
+            OrderItem orderItem2 = OrderItemFixture.withId(
+                OrderItemFixture.orderItemWithStatus(OrderStatus.ORDER_CONFIRMED), 102L);
+
+            CustomerCancelRequest request = new CustomerCancelRequest(
+                List.of(101L, 102L),
+                "단순 변심 / 다른 상품 재구매"
+            );
+
+            given(orderRepository.findByIdWithMember(orderId)).willReturn(Optional.of(order));
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(101L, 102L)))
+                .willReturn(List.of(orderItem1, orderItem2));
+
+            // when
+            sut.requestCancel(orderId, customerId, request);
+
+            // then
+            assertThat(orderItem1.getOrderStatus()).isEqualTo(OrderStatus.CANCEL_REQUESTED);
+            assertThat(orderItem2.getOrderStatus()).isEqualTo(OrderStatus.CANCEL_REQUESTED);
+            then(cancelRequestRepository).should(times(1)).saveAll(anyList());
+            then(orderItemHistoryRepository).should(times(1)).saveAll(anyList());
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 시나리오")
+    class FailureScenarios {
+
+        @Test
+        @DisplayName("타인의 주문 ID로 취소를 시도하면 ORDER_ACCESS_DENIED 예외가 발생한다")
+        void givenOtherCustomersOrder_whenRequestCancel_thenThrowsOrderAccessDenied() {
+            // given
+            Long orderId = 1L;
+            Long actualOwnerId = 100L;
+            Long otherCustomerId = 999L;
+
+            Order order = orderWithMember(orderId, actualOwnerId);
+
+            CustomerCancelRequest request = new CustomerCancelRequest(
+                List.of(101L),
+                "취소 사유"
+            );
+
+            given(orderRepository.findByIdWithMember(orderId)).willReturn(Optional.of(order));
+
+            // when & then
+            assertThatThrownBy(() -> sut.requestCancel(orderId, otherCustomerId, request))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.ORDER_ACCESS_DENIED);
+
+            then(orderItemRepository).should(never()).findByOrderIdAndIdInWithOrder(orderId, List.of(101L));
+            then(cancelRequestRepository).should(never()).saveAll(anyList());
+            then(orderItemHistoryRepository).should(never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("배송 중(SHIPPED) 상태의 주문 상품으로 취소를 시도하면 CLAIM_INVALID_STATUS 예외가 발생한다 (Pre-Validation 단계에서 컷팅)")
+        void givenShippedOrderItem_whenRequestCancel_thenThrowsClaimInvalidStatus() {
+            // given
+            Long orderId = 1L;
+            Long customerId = 100L;
+
+            Order order = orderWithMember(orderId, customerId);
+
+            OrderItem shippedItem = OrderItemFixture.withId(
+                OrderItemFixture.orderItemWithStatus(OrderStatus.SHIPPED), 101L);
+
+            CustomerCancelRequest request = new CustomerCancelRequest(
+                List.of(101L),
+                "취소 사유"
+            );
+
+            given(orderRepository.findByIdWithMember(orderId)).willReturn(Optional.of(order));
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(101L)))
+                .willReturn(List.of(shippedItem));
+
+            // when & then
+            assertThatThrownBy(() -> sut.requestCancel(orderId, customerId, request))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            assertThat(shippedItem.getOrderStatus()).isEqualTo(OrderStatus.SHIPPED);
+            then(cancelRequestRepository).should(never()).saveAll(anyList());
+            then(orderItemHistoryRepository).should(never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("이미 취소된(CANCEL_APPROVED) 주문 상품으로 취소를 시도하면 CLAIM_INVALID_STATUS 예외가 발생한다 (Pre-Validation 단계에서 컷팅)")
+        void givenCancelApprovedOrderItem_whenRequestCancel_thenThrowsClaimInvalidStatus() {
+            // given
+            Long orderId = 1L;
+            Long customerId = 100L;
+
+            Order order = orderWithMember(orderId, customerId);
+
+            OrderItem cancelledItem = OrderItemFixture.withId(
+                OrderItemFixture.orderItemWithStatus(OrderStatus.CANCEL_APPROVED), 101L);
+
+            CustomerCancelRequest request = new CustomerCancelRequest(
+                List.of(101L),
+                "취소 사유"
+            );
+
+            given(orderRepository.findByIdWithMember(orderId)).willReturn(Optional.of(order));
+            given(orderItemRepository.findByOrderIdAndIdInWithOrder(orderId, List.of(101L)))
+                .willReturn(List.of(cancelledItem));
+
+            // when & then
+            assertThatThrownBy(() -> sut.requestCancel(orderId, customerId, request))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.CLAIM_INVALID_STATUS);
+
+            then(cancelRequestRepository).should(never()).saveAll(anyList());
+            then(orderItemHistoryRepository).should(never()).saveAll(anyList());
+        }
+    }
+
+    private Order orderWithMember(Long orderId, Long memberId) {
+        Member member = mock(Member.class);
+        given(member.getId()).willReturn(memberId);
+
+        Order order = OrderFixture.defaultOrder()
+            .member(member)
+            .build();
+        ReflectionTestUtils.setField(order, "id", orderId);
+
+        return order;
+    }
+}


### PR DESCRIPTION
## History

* #711 

## 🚀 Major Changes & Explanations
   
 - 주문 취소 (PATCH /api/v1/customer/orders/{orderId}/cancel): 구매자가 본인이 주문한 상품 배송 전에 취소 사유와 대상 주문 상품 목록을 전달하여 취소를 신청하는 엔드포인트 추가
    - 정상 요청 시 전체 유효성 선검증을 통과한 후 최종 취소 상태로 
    -  OrderItem엔티티의 @Version 낙관적 락 메커니즘을 적용
    - 주문 소유자 검증 시 findByIdWithMember, 상품 조회 시 findByOrderIdAndIdInWithOrder 페치 조인 사용
    - 별도의 추가 필드 없이, 상태 변경 시점에 기존 OrderItemHistory.create(orderItem)메서드만 호출
    - **성공 시나리오**: 본인의 정상 주문 건에 대해 올바른 주문 상품 ID들과 사유 입력 시, 선검증 통과 후 취소 상태 전이 및 OrderItemHistory가 정상 적재되는지 검증
    - **실패 시나리오**: 타인의 주문에 접근할 경우 권한 예외 검증, 이미 배송 중이거나 완료된 건 등 취소가 불가능한 상태에서 시도할 경우 CLAIM_INVALID_STATUS 예외가 선검증 단계에서 정확히 컷팅되는지 검증