### PR TITLE
[FEAT] 주문상세조회 API 구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -183,6 +183,7 @@ public enum BbangleErrorCode {
     DELIVERY_MODIFY_NOT_ALLOWED(-785, "현재 배송 상태에서는 운송장을 수정할 수 없습니다.", BAD_REQUEST),
     CUSTOMER_ORDER_UNAUTHORIZED(-786, "주문 조회를 위해 로그인이 필요합니다.", UNAUTHORIZED),
     CUSTOMER_ORDER_MEMBER_NOT_FOUND(-787, "존재하지 않는 회원의 주문 조회 요청입니다.", NOT_FOUND),
+    CUSTOMER_ORDER_NOT_FOUND(-788, "존재하지 않거나 접근할 수 없는 주문입니다.", NOT_FOUND),
 
     // Settlement Error(801 ~ 820)
     SETTLEMENT_NOT_FOUND(-802, "존재하지 않는 정산 내역입니다.", NOT_FOUND),

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderApi.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderApi.java
@@ -1,8 +1,10 @@
 package com.bbangle.bbangle.order.customer.controller;
 
 import com.bbangle.bbangle.common.dto.SingleResult;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerOrderDetail;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -18,5 +20,15 @@ public interface CustomerOrderApi {
     SingleResult<CustomerOrderPageResponse> getOrders(
         Long memberId,
         @ParameterObject Pageable pageable
+    );
+
+    @Operation(
+        summary = "(소비자) 주문 상세 조회",
+        description = "인증된 회원 본인 소유의 단일 주문 상세를 조회합니다. "
+            + "결제금액(반품·취소 제외), 배송지, 주문상품별 진행 단계와 상태 뱃지/할인율/태그를 포함합니다."
+    )
+    SingleResult<CustomerOrderDetail> getOrderDetail(
+        Long memberId,
+        @Parameter(description = "주문 ID", example = "1") Long orderId
     );
 }

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderController.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderController.java
@@ -3,8 +3,10 @@ package com.bbangle.bbangle.order.customer.controller;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.CustomerApiPath;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerOrderDetail;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderPageResponse;
 import com.bbangle.bbangle.order.customer.service.CustomerOrderService;
+import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderDetailCommand;
 import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderSearchCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +14,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,6 +41,25 @@ public class CustomerOrderController implements CustomerOrderApi {
             .build();
 
         CustomerOrderPageResponse response = customerOrderService.getOrders(command);
+
+        return responseService.getSingleResult(response);
+    }
+
+    /**
+     * 소비자 주문 상세 조회. 본인 소유의 단일 주문만 조회할 수 있습니다.
+     */
+    @Override
+    @GetMapping("/{orderId}")
+    public SingleResult<CustomerOrderDetail> getOrderDetail(
+        @AuthenticationPrincipal Long memberId,
+        @PathVariable Long orderId
+    ) {
+        CustomerOrderDetailCommand command = CustomerOrderDetailCommand.builder()
+            .memberId(memberId)
+            .orderId(orderId)
+            .build();
+
+        CustomerOrderDetail response = customerOrderService.getOrderDetail(command);
 
         return responseService.getSingleResult(response);
     }

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/dto/response/CustomerOrderDetailResponse.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/dto/response/CustomerOrderDetailResponse.java
@@ -1,0 +1,93 @@
+package com.bbangle.bbangle.order.customer.controller.dto.response;
+
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderProgress;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.seller.controller.model.PaymentInfo;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 소비자 주문 상세 조회 응답.
+ *
+ * <p>화면 구성(노출 항목)에 맞춰 4개 블록으로 구성됩니다.
+ * <ul>
+ *   <li>헤더: 주문일자/주문번호</li>
+ *   <li>① 결제 금액({@link CustomerPaymentSummary}): 상품금액/할인/배송비/최종결제금액/영수증</li>
+ *   <li>② 배송지({@link CustomerDeliveryInfo}): 배송지명/주소/연락처/요청사항/배송지변경 가능여부</li>
+ *   <li>상품({@link CustomerOrderDetailItem}): 스토어/상품/상태뱃지/가격/태그/배송조회</li>
+ * </ul>
+ */
+public class CustomerOrderDetailResponse {
+
+    @Schema(description = "소비자 주문 상세 응답")
+    public record CustomerOrderDetail(
+        @Schema(description = "주문 ID", example = "1") Long orderId,
+        @Schema(description = "주문번호", example = "ORDER-2025-05-13-00001") String orderNumber,
+        @Schema(description = "주문일자", example = "2025-05-13")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate orderDate,
+        @Schema(description = "① 결제 금액") CustomerPaymentSummary payment,
+        @Schema(description = "② 배송지") CustomerDeliveryInfo delivery,
+        @Schema(description = "주문 상품 목록") List<CustomerOrderDetailItem> orderItems
+    ) {
+
+    }
+
+    /**
+     * ① 결제 금액 블록.
+     * 금액 집계는 정책에 따라 <b>반품·취소 상품 금액을 제외</b>하고 계산합니다.
+     */
+    @Schema(description = "결제 금액 정보 (반품·취소 금액 제외)")
+    public record CustomerPaymentSummary(
+        @Schema(description = "상품금액(정가 합계)", example = "26100") long productAmount,
+        @Schema(description = "상품 할인금액", example = "1700") long productDiscountAmount,
+        @Schema(description = "배송비", example = "0") long deliveryFee,
+        @Schema(description = "최종 결제금액", example = "24400") long finalPaymentAmount,
+        @Schema(description = "총 할인 합계 금액", example = "1700") long totalDiscountAmount,
+        @Schema(description = "총 할인 합계 문구", example = "총 1,700원 할인 받았어요") String totalDiscountMessage,
+        @Schema(description = "영수증 보기 노출 여부 (반품·취소 제외 결제건 존재 시 true)") boolean receiptViewable,
+        @Schema(description = "결제 정보(상태/수단/결제일)") PaymentInfo paymentInfo
+    ) {
+
+    }
+
+    /**
+     * ② 배송지 블록.
+     * 주문 내 배송 정보는 일괄 처리되므로 대표 배송정보 1건으로 노출합니다.
+     */
+    @Schema(description = "배송지 정보")
+    public record CustomerDeliveryInfo(
+        @Schema(description = "배송지명(수령인)", example = "홍길동") String recipientName,
+        @Schema(description = "주소(기본+상세)", example = "서울특별시 강남구 테헤란로 123 101동 1001호") String address,
+        @Schema(description = "우편번호", example = "06234") String zipCode,
+        @Schema(description = "연락처", example = "010-1234-5678") String phone,
+        @Schema(description = "배송 요청사항", example = "부재 시 경비실에 맡겨주세요") String deliveryMemo,
+        @Schema(description = "배송지 변경 가능 여부 (결제완료 상품 존재 시 true)") boolean addressChangeable
+    ) {
+
+    }
+
+    @Schema(description = "주문 상품 정보 + 진행 단계")
+    public record CustomerOrderDetailItem(
+        @Schema(description = "주문상품 ID", example = "10") Long orderItemId,
+        @Schema(description = "스토어명", example = "비건빵빵이네") String storeName,
+        @Schema(description = "상품명(게시글명)", example = "저당 베이글 세트") String boardTitle,
+        @Schema(description = "옵션(상품명)", example = "저칼로리 베이글") String productName,
+        @Schema(description = "상태 뱃지", example = "상품발송") String statusBadge,
+        @Schema(description = "주문 상태(원천 enum)") OrderStatus orderStatus,
+        @Schema(description = "정가(단가)", example = "5800") long productPrice,
+        @Schema(description = "판매가(할인 단가)", example = "4700") long unitPrice,
+        @Schema(description = "할인율(%)", example = "19") int discountRate,
+        @Schema(description = "수량", example = "2") Integer quantity,
+        @Schema(description = "상품 총액(판매가×수량)", example = "9400") long totalPrice,
+        @Schema(description = "상품 태그", example = "[\"고단백\", \"글루텐프리\"]") List<String> tags,
+        @Schema(description = "배송조회 버튼 노출 여부 (운송장 등록 시 true)") boolean deliveryTrackable,
+        @Schema(description = "택배사", example = "CJ대한통운") String courierCompany,
+        @Schema(description = "운송장 번호", example = "123-456-789") String trackingNumber,
+        @Schema(description = "진행 단계 정보") CustomerOrderProgress progress
+    ) {
+
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/customer/repository/CustomerOrderRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/repository/CustomerOrderRepository.java
@@ -3,11 +3,13 @@ package com.bbangle.bbangle.order.customer.repository;
 import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.board.domain.QBoard;
 import com.bbangle.bbangle.board.domain.QProduct;
+import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderDetailCommand;
 import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderSearchCommand;
 import com.bbangle.bbangle.order.domain.Order;
 import com.bbangle.bbangle.order.domain.QOrder;
 import com.bbangle.bbangle.order.domain.QOrderItem;
 import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.store.domain.QStore;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Collections;
@@ -15,6 +17,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +39,7 @@ public class CustomerOrderRepository {
     private final QOrderItem orderItem = QOrderItem.orderItem;
     private final QProduct product = QProduct.product;
     private final QBoard board = QBoard.board;
+    private final QStore store = QStore.store;
 
     /**
      * 회원의 주문을 주문일(orderDate) 최신순으로 페이징 조회합니다.
@@ -50,6 +54,32 @@ public class CustomerOrderRepository {
         Long total = fetchCustomerTotalCount(command.memberId());
 
         return BbanglePageResponse.of(new PageImpl<>(orders, pageable, total));
+    }
+
+    /**
+     * 회원 소유의 단일 주문 상세를 조회합니다. (소유권 검증 포함)
+     *
+     * <p>단일 컬렉션({@code orderItems})만 fetchJoin 하고 나머지는 to-one 연관이므로
+     * 카테시안 곱 없이 한 번의 쿼리로 주문상품/상품/게시글/스토어/결제를 로딩합니다.
+     * 배송정보(OrderDelivery)는 주문상품 1:N 컬렉션이라 함께 fetchJoin 하지 않고
+     * 서비스 계층에서 {@code findLatestByOrderItemIds} 로 별도 일괄 로딩하여 N+1 을 방지합니다.
+     */
+    public Optional<Order> findCustomerOrderDetail(CustomerOrderDetailCommand command) {
+        Order result = queryFactory
+            .selectFrom(order)
+            .distinct()
+            .leftJoin(order.orderItems, orderItem).fetchJoin()
+            .leftJoin(orderItem.product, product).fetchJoin()
+            .leftJoin(product.board, board).fetchJoin()
+            .leftJoin(product.store, store).fetchJoin()
+            .leftJoin(order.payment).fetchJoin()
+            .where(
+                order.id.eq(command.orderId()),
+                order.member.id.eq(command.memberId())
+            )
+            .fetchOne();
+
+        return Optional.ofNullable(result);
     }
 
     /**

--- a/src/main/java/com/bbangle/bbangle/order/customer/service/CustomerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/service/CustomerOrderService.java
@@ -3,13 +3,21 @@ package com.bbangle.bbangle.order.customer.service;
 import com.bbangle.bbangle.common.page.BbanglePageResponse;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.delivery.domain.Receiver;
+import com.bbangle.bbangle.delivery.domain.Shipping;
 import com.bbangle.bbangle.member.repository.MemberRepository;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerDeliveryInfo;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerOrderDetail;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerOrderDetailItem;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerPaymentSummary;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderInfo;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderItemInfo;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderPageResponse;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderProgress;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderStatusCounts;
 import com.bbangle.bbangle.order.customer.repository.CustomerOrderRepository;
+import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderDetailCommand;
 import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderSearchCommand;
 import com.bbangle.bbangle.order.domain.Order;
 import com.bbangle.bbangle.order.domain.OrderDelivery;
@@ -20,6 +28,7 @@ import com.bbangle.bbangle.order.repository.OrderDeliveryRepository;
 import com.bbangle.bbangle.order.seller.controller.model.PaymentInfo;
 import com.bbangle.bbangle.payment.domain.Payment;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,6 +55,16 @@ public class CustomerOrderService {
         OrderStatus.IN_PRODUCTION,
         OrderStatus.SHIPPED
     );
+
+    // 결제금액/영수증 집계에서 제외할 상태 (정책: 반품·취소 금액 제외)
+    private static final Set<OrderStatus> EXCLUDED_FROM_PAYMENT;
+
+    static {
+        EnumSet<OrderStatus> excluded = EnumSet.noneOf(OrderStatus.class);
+        excluded.addAll(OrderStatus.CANCELLED_GROUP);
+        excluded.addAll(OrderStatus.RETURNED_GROUP);
+        EXCLUDED_FROM_PAYMENT = Collections.unmodifiableSet(excluded);
+    }
 
     /**
      * 소비자 주문목록 조회.
@@ -76,6 +95,177 @@ public class CustomerOrderService {
         CustomerOrderStatusCounts statusCounts = buildStatusCounts(statusCountMap);
 
         return new CustomerOrderPageResponse(ordersPage, statusCounts);
+    }
+
+    /**
+     * 소비자 주문 상세 조회.
+     * 본인 소유의 단일 주문을 조회하여 결제금액(반품·취소 제외)/배송지/상품 진행단계를 조립합니다.
+     */
+    @Transactional(readOnly = true)
+    public CustomerOrderDetail getOrderDetail(CustomerOrderDetailCommand command) {
+        validateMember(command.memberId());
+
+        Order order = customerOrderRepository.findCustomerOrderDetail(command)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.CUSTOMER_ORDER_NOT_FOUND));
+
+        Map<Long, OrderDelivery> latestDeliveryMap = fetchLatestDeliveries(List.of(order));
+
+        List<CustomerOrderDetailItem> items = order.getOrderItems().stream()
+            .map(item -> buildDetailItem(item, latestDeliveryMap.get(item.getId())))
+            .toList();
+
+        CustomerPaymentSummary payment = buildPaymentSummary(order);
+        CustomerDeliveryInfo delivery = buildDeliveryInfo(order, latestDeliveryMap);
+
+        return new CustomerOrderDetail(
+            order.getId(),
+            order.getOrderNumber(),
+            order.getOrderDate() != null ? order.getOrderDate().toLocalDate() : null,
+            payment,
+            delivery,
+            items
+        );
+    }
+
+    /**
+     * ① 결제 금액 블록 조립.
+     * 정책에 따라 반품·취소 상태의 주문상품 금액은 집계에서 제외합니다.
+     */
+    private CustomerPaymentSummary buildPaymentSummary(Order order) {
+        List<OrderItem> payableItems = order.getOrderItems().stream()
+            .filter(item -> !EXCLUDED_FROM_PAYMENT.contains(item.getOrderStatus()))
+            .toList();
+
+        long productAmount = payableItems.stream()
+            .mapToLong(item -> (long) safeInt(item.getProductPrice()) * safeInt(item.getQuantity()))
+            .sum();
+        long discountAmount = payableItems.stream()
+            .mapToLong(item ->
+                (long) (safeInt(item.getProductPrice()) - safeInt(item.getUnitPrice())) * safeInt(item.getQuantity()))
+            .sum();
+        // 결제 가능한 상품이 하나도 없으면(전체 반품·취소) 배송비도 청구하지 않습니다.
+        long deliveryFee = payableItems.isEmpty() ? 0L : safeInt(order.getDeliveryFee());
+        long finalAmount = productAmount - discountAmount + deliveryFee;
+
+        Payment payment = order.getPayment();
+        PaymentInfo paymentInfo = null;
+        if (payment != null) {
+            paymentInfo = PaymentInfo.of(
+                payment.getPaymentStatus() != null ? payment.getPaymentStatus().getDescription() : null,
+                payment.getPaymentMethod() != null ? payment.getPaymentMethod().getDescription() : null,
+                payment.getPaidAt());
+        }
+
+        boolean receiptViewable = payment != null && !payableItems.isEmpty();
+        String discountMessage = discountAmount > 0
+            ? String.format("총 %,d원 할인 받았어요", discountAmount)
+            : null;
+
+        return new CustomerPaymentSummary(
+            productAmount,
+            discountAmount,
+            deliveryFee,
+            finalAmount,
+            discountAmount,
+            discountMessage,
+            receiptViewable,
+            paymentInfo
+        );
+    }
+
+    /**
+     * ② 배송지 블록 조립.
+     * 주문 내 배송은 일괄 처리되므로 대표 배송정보 1건을 사용합니다.
+     * 배송지 변경 버튼은 결제완료 상태의 상품이 하나라도 있을 때만 활성화합니다.
+     */
+    private CustomerDeliveryInfo buildDeliveryInfo(Order order, Map<Long, OrderDelivery> deliveryMap) {
+        boolean addressChangeable = order.getOrderItems().stream()
+            .anyMatch(item -> item.getOrderStatus() == OrderStatus.PAYMENT_COMPLETED);
+
+        OrderDelivery representative = order.getOrderItems().stream()
+            .map(item -> deliveryMap.get(item.getId()))
+            .filter(delivery -> delivery != null && delivery.getReceiver() != null)
+            .findFirst()
+            .orElse(null);
+
+        if (representative == null) {
+            return new CustomerDeliveryInfo(null, null, null, null, null, addressChangeable);
+        }
+
+        Receiver receiver = representative.getReceiver();
+        Shipping shipping = representative.getShipping();
+
+        return new CustomerDeliveryInfo(
+            receiver.getRecipientName(),
+            joinAddress(receiver.getRecipientAddress(), receiver.getRecipientAddressDetail()),
+            receiver.getRecipientZipCode(),
+            receiver.getRecipientPhone1(),
+            shipping != null ? shipping.getDeliveryMemo() : null,
+            addressChangeable
+        );
+    }
+
+    private CustomerOrderDetailItem buildDetailItem(OrderItem item, OrderDelivery delivery) {
+        OrderDeliveryStatus deliveryStatus = delivery != null ? delivery.getStatus() : null;
+
+        String courierCompany = null;
+        String trackingNumber = null;
+        if (delivery != null && delivery.getShipping() != null) {
+            courierCompany = delivery.getShipping().getCourierName();
+            trackingNumber = delivery.getShipping().getTrackingNumber();
+        }
+        boolean deliveryTrackable = courierCompany != null && trackingNumber != null;
+
+        Product product = item.getProduct();
+        String storeName = product != null && product.getStore() != null ? product.getStore().getName() : null;
+        String boardTitle = product != null && product.getBoard() != null ? product.getBoard().getTitle() : null;
+        String productName = product != null ? product.getTitle() : null;
+        List<String> tags = product != null ? product.getTags() : Collections.emptyList();
+
+        int productPrice = safeInt(item.getProductPrice());
+        int unitPrice = safeInt(item.getUnitPrice());
+
+        CustomerOrderProgress progress = CustomerOrderStepMapper.resolve(item.getOrderStatus(), deliveryStatus);
+
+        return new CustomerOrderDetailItem(
+            item.getId(),
+            storeName,
+            boardTitle,
+            productName,
+            progress.currentStep(),
+            item.getOrderStatus(),
+            productPrice,
+            unitPrice,
+            calculateDiscountRate(productPrice, unitPrice),
+            item.getQuantity(),
+            safeInt(item.getTotalPrice()),
+            tags,
+            deliveryTrackable,
+            courierCompany,
+            trackingNumber,
+            progress
+        );
+    }
+
+    private int calculateDiscountRate(int productPrice, int unitPrice) {
+        if (productPrice <= 0 || unitPrice >= productPrice) {
+            return 0;
+        }
+        return (int) Math.round((productPrice - unitPrice) * 100.0 / productPrice);
+    }
+
+    private String joinAddress(String address, String addressDetail) {
+        if (address == null) {
+            return addressDetail;
+        }
+        if (addressDetail == null || addressDetail.isBlank()) {
+            return address;
+        }
+        return address + " " + addressDetail;
+    }
+
+    private int safeInt(Integer value) {
+        return value != null ? value : 0;
     }
 
     /**

--- a/src/main/java/com/bbangle/bbangle/order/customer/service/model/CustomerOrderCommand.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/service/model/CustomerOrderCommand.java
@@ -20,4 +20,16 @@ public class CustomerOrderCommand {
     ) {
 
     }
+
+    /**
+     * 소비자 주문 상세 조회 커맨드.
+     * 인증된 회원(memberId)이 본인 소유의 단일 주문(orderId) 상세를 조회할 때 사용합니다.
+     */
+    @Builder
+    public record CustomerOrderDetailCommand(
+        Long memberId,
+        Long orderId
+    ) {
+
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderControllerSliceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderControllerSliceTest.java
@@ -20,12 +20,17 @@ import com.bbangle.bbangle.config.security.jwt.TokenProvider;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.exception.GlobalControllerAdvice;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerDeliveryInfo;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerOrderDetail;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerOrderDetailItem;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerPaymentSummary;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderInfo;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderItemInfo;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderPageResponse;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderProgress;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderStatusCounts;
 import com.bbangle.bbangle.order.customer.service.CustomerOrderService;
+import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderDetailCommand;
 import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderSearchCommand;
 import com.bbangle.bbangle.order.domain.model.CustomerOrderCategory;
 import com.bbangle.bbangle.order.domain.model.OrderStatus;
@@ -71,7 +76,7 @@ class CustomerOrderControllerSliceTest {
 
     private static UsernamePasswordAuthenticationToken memberAuth(Long memberId) {
         return new UsernamePasswordAuthenticationToken(
-            memberId, "N/A", List.of(new SimpleGrantedAuthority("ROLE_USER")));
+            memberId, "N/A", List.of(new SimpleGrantedAuthority("ROLE_CUSTOMER")));
     }
 
     @DisplayName("주문목록 조회 API - 성공(데이터 있음)")
@@ -158,6 +163,71 @@ class CustomerOrderControllerSliceTest {
             .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.code").value(BbangleErrorCode.CUSTOMER_ORDER_MEMBER_NOT_FOUND.getCode()))
             .andExpect(jsonPath("$.message").value(BbangleErrorCode.CUSTOMER_ORDER_MEMBER_NOT_FOUND.getMessage()));
+
+        then(globalControllerAdvice).should(times(1))
+            .handleBbangleException(any(), any(BbangleException.class));
+    }
+
+    @DisplayName("주문 상세 조회 API - 성공")
+    @Test
+    void givenAuthenticatedMember_whenGetOrderDetail_thenReturnsDetail() throws Exception {
+        // given
+        Long memberId = 1L;
+        Long orderId = 5L;
+
+        CustomerOrderProgress progress = CustomerOrderProgress.of(
+            CustomerOrderCategory.NORMAL, "상품발송", 2,
+            List.of("결제완료", "상품제작중", "상품발송", "배송완료", "구매확정"));
+        CustomerOrderDetailItem item = new CustomerOrderDetailItem(
+            10L, "비건빵빵이네", "저당 베이글 세트", "저칼로리 베이글", "상품발송",
+            OrderStatus.SHIPPED, 5800L, 4700L, 19, 2, 9400L,
+            List.of("고단백", "글루텐프리"), true, "CJ대한통운", "123-456-789", progress);
+        CustomerPaymentSummary payment = new CustomerPaymentSummary(
+            11600L, 2200L, 2500L, 11900L, 2200L, "총 2,200원 할인 받았어요", true, null);
+        CustomerDeliveryInfo delivery = new CustomerDeliveryInfo(
+            "홍길동", "서울특별시 강남구 테헤란로 123 101동 1001호", "06234",
+            "010-1234-5678", "부재 시 경비실에 맡겨주세요", true);
+        CustomerOrderDetail mockResponse = new CustomerOrderDetail(
+            orderId, "ORDER-2025-05-13-00001", LocalDate.of(2025, 5, 13), payment, delivery, List.of(item));
+
+        given(customerOrderService.getOrderDetail(any(CustomerOrderDetailCommand.class)))
+            .willReturn(mockResponse);
+
+        // when & then
+        mvc.perform(get("/api/v1/customer/orders/{orderId}", orderId)
+                .with(authentication(memberAuth(memberId))))
+
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.result.orderNumber").value("ORDER-2025-05-13-00001"))
+            .andExpect(jsonPath("$.result.orderDate").value("2025-05-13"))
+            .andExpect(jsonPath("$.result.payment.finalPaymentAmount").value(11900))
+            .andExpect(jsonPath("$.result.payment.totalDiscountMessage").value("총 2,200원 할인 받았어요"))
+            .andExpect(jsonPath("$.result.payment.receiptViewable").value(true))
+            .andExpect(jsonPath("$.result.delivery.addressChangeable").value(true))
+            .andExpect(jsonPath("$.result.orderItems[0].storeName").value("비건빵빵이네"))
+            .andExpect(jsonPath("$.result.orderItems[0].statusBadge").value("상품발송"))
+            .andExpect(jsonPath("$.result.orderItems[0].discountRate").value(19))
+            .andExpect(jsonPath("$.result.orderItems[0].deliveryTrackable").value(true));
+
+        then(customerOrderService).should(times(1)).getOrderDetail(any(CustomerOrderDetailCommand.class));
+    }
+
+    @DisplayName("주문 상세 조회 API - 실패(존재하지 않거나 접근 불가 주문)")
+    @Test
+    void givenInaccessibleOrder_whenGetOrderDetail_thenReturns4xx() throws Exception {
+        // given
+        given(customerOrderService.getOrderDetail(any(CustomerOrderDetailCommand.class)))
+            .willThrow(new BbangleException(BbangleErrorCode.CUSTOMER_ORDER_NOT_FOUND));
+
+        // when & then
+        mvc.perform(get("/api/v1/customer/orders/{orderId}", 999L)
+                .with(authentication(memberAuth(1L))))
+
+            .andExpect(status().is4xxClientError())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value(BbangleErrorCode.CUSTOMER_ORDER_NOT_FOUND.getCode()));
 
         then(globalControllerAdvice).should(times(1))
             .handleBbangleException(any(), any(BbangleException.class));

--- a/src/test/java/com/bbangle/bbangle/order/customer/service/CustomerOrderDetailServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/customer/service/CustomerOrderDetailServiceIntegrationTest.java
@@ -1,0 +1,249 @@
+package com.bbangle.bbangle.order.customer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bbangle.bbangle.board.domain.Board;
+import com.bbangle.bbangle.board.domain.Product;
+import com.bbangle.bbangle.board.repository.BoardRepository;
+import com.bbangle.bbangle.board.repository.ProductRepository;
+import com.bbangle.bbangle.delivery.domain.Receiver;
+import com.bbangle.bbangle.delivery.domain.Sender;
+import com.bbangle.bbangle.delivery.domain.Shipping;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.board.domain.BoardFixture;
+import com.bbangle.bbangle.fixture.order.domain.OrderFixture;
+import com.bbangle.bbangle.fixture.payment.domain.PaymentFixture;
+import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
+import com.bbangle.bbangle.member.domain.Member;
+import com.bbangle.bbangle.member.repository.MemberRepository;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerOrderDetail;
+import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerOrderDetailItem;
+import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderDetailCommand;
+import com.bbangle.bbangle.order.domain.Order;
+import com.bbangle.bbangle.order.domain.OrderDelivery;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderDeliveryRepository;
+import com.bbangle.bbangle.order.repository.OrderItemRepository;
+import com.bbangle.bbangle.order.repository.OrderRepository;
+import com.bbangle.bbangle.payment.repository.PaymentRepository;
+import com.bbangle.bbangle.store.domain.Store;
+import com.bbangle.bbangle.store.repository.StoreRepository;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[통합테스트] CustomerOrderDetailServiceIntegrationTest")
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class CustomerOrderDetailServiceIntegrationTest {
+
+    @Autowired
+    private CustomerOrderService customerOrderService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private OrderItemRepository orderItemRepository;
+
+    @Autowired
+    private OrderDeliveryRepository orderDeliveryRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Member member;
+    private Store store;
+    private Product product;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(Member.builder()
+            .email("buyer@bbangle.com")
+            .name("홍길동")
+            .nickname("길동")
+            .build());
+
+        store = storeRepository.save(StoreFixture.defaultStore("비건빵빵이네"));
+        Board board = boardRepository.save(BoardFixture.defaultBoardWithStore(store, "저당 베이글 세트"));
+        product = productRepository.save(Product.builder()
+            .board(board)
+            .store(store)
+            .title("저칼로리 베이글")
+            .price(5800)
+            .highProteinTag(true)
+            .glutenFreeTag(true)
+            .build());
+    }
+
+    private OrderItem buildItem(OrderStatus status, int productPrice, int unitPrice, int quantity) {
+        return OrderItem.builder()
+            .product(product)
+            .quantity(quantity)
+            .productPrice(productPrice)
+            .unitPrice(unitPrice)
+            .totalPrice(unitPrice * quantity)
+            .orderStatus(status)
+            .orderDeliveryStatus(OrderDeliveryStatus.PREPARING)
+            .build();
+    }
+
+    private void attachDelivery(OrderItem item, OrderDeliveryStatus status, String courier, String tracking) {
+        OrderDelivery delivery = OrderDelivery.create(
+            Sender.of("비건빵빵이네", "027778888", "서울 마포구", "1층", "04000"),
+            Receiver.of("홍길동", "01012345678", null,
+                "서울특별시 강남구 테헤란로 123", "101동 1001호", "06234"),
+            courier != null ? Shipping.of(courier, tracking) : Shipping.empty(),
+            status,
+            item);
+        item.addOrderDelivery(delivery);
+        orderDeliveryRepository.save(delivery);
+    }
+
+    @DisplayName("주문 상세 조회 시 결제금액은 반품·취소 상품을 제외하고 집계한다")
+    @Test
+    void getOrderDetail_excludesReturnedAndCanceledFromPayment() {
+        // given
+        Order order = OrderFixture.createOrderWithNumber("ORDER-2025-05-13-00001").toBuilder()
+            .orderDate(LocalDateTime.of(2025, 5, 13, 10, 0))
+            .deliveryFee(2500)
+            .member(member)
+            .build();
+        order = orderRepository.save(order);
+
+        OrderItem normal = buildItem(OrderStatus.SHIPPED, 5800, 4700, 2);     // 결제 대상
+        OrderItem returned = buildItem(OrderStatus.RETURN_REQUESTED, 9000, 9000, 1); // 제외
+        order.addOrderItem(normal);
+        order.addOrderItem(returned);
+        orderItemRepository.save(normal);
+        orderItemRepository.save(returned);
+
+        attachDelivery(normal, OrderDeliveryStatus.DELIVERING, "CJ대한통운", "123-456-789");
+
+        paymentRepository.save(PaymentFixture.createDefaultPayment(order));
+        Long orderId = order.getId();
+        em.flush();
+        em.clear();
+
+        // when
+        CustomerOrderDetail detail = customerOrderService.getOrderDetail(
+            CustomerOrderDetailCommand.builder().memberId(member.getId()).orderId(orderId).build());
+
+        // then - 헤더
+        assertThat(detail.orderNumber()).isEqualTo("ORDER-2025-05-13-00001");
+        assertThat(detail.orderDate()).isEqualTo("2025-05-13");
+
+        // then - 결제 금액 (반품 상품 9000원 제외)
+        assertThat(detail.payment().productAmount()).isEqualTo(5800L * 2);   // 11600
+        assertThat(detail.payment().productDiscountAmount()).isEqualTo((5800L - 4700L) * 2); // 2200
+        assertThat(detail.payment().deliveryFee()).isEqualTo(2500L);
+        assertThat(detail.payment().finalPaymentAmount()).isEqualTo(11600L - 2200L + 2500L); // 11900
+        assertThat(detail.payment().totalDiscountMessage()).isEqualTo("총 2,200원 할인 받았어요");
+        assertThat(detail.payment().receiptViewable()).isTrue();
+        assertThat(detail.payment().paymentInfo()).isNotNull();
+
+        // then - 상품
+        assertThat(detail.orderItems()).hasSize(2);
+        CustomerOrderDetailItem normalItem = detail.orderItems().stream()
+            .filter(i -> i.orderStatus() == OrderStatus.SHIPPED)
+            .findFirst().orElseThrow();
+        assertThat(normalItem.storeName()).isEqualTo("비건빵빵이네");
+        assertThat(normalItem.boardTitle()).isEqualTo("저당 베이글 세트");
+        assertThat(normalItem.productName()).isEqualTo("저칼로리 베이글");
+        assertThat(normalItem.statusBadge()).isEqualTo("상품발송");
+        assertThat(normalItem.discountRate()).isEqualTo(19); // round(1100/5800*100)
+        assertThat(normalItem.tags()).contains("highProtein", "glutenFree");
+        assertThat(normalItem.deliveryTrackable()).isTrue();
+        assertThat(normalItem.courierCompany()).isEqualTo("CJ대한통운");
+        assertThat(normalItem.progress().category().name()).isEqualTo("NORMAL");
+    }
+
+    @DisplayName("결제완료 상품이 있으면 배송지 변경이 가능하다")
+    @Test
+    void getOrderDetail_addressChangeableWhenPaymentCompletedExists() {
+        // given
+        Order order = OrderFixture.createOrderWithNumber("ORDER-2025-05-14-00001").toBuilder()
+            .orderDate(LocalDateTime.of(2025, 5, 14, 10, 0))
+            .member(member)
+            .build();
+        order = orderRepository.save(order);
+
+        OrderItem paid = buildItem(OrderStatus.PAYMENT_COMPLETED, 5800, 4700, 1);
+        order.addOrderItem(paid);
+        orderItemRepository.save(paid);
+        attachDelivery(paid, OrderDeliveryStatus.PREPARING, null, null);
+        Long orderId = order.getId();
+        em.flush();
+        em.clear();
+
+        // when
+        CustomerOrderDetail detail = customerOrderService.getOrderDetail(
+            CustomerOrderDetailCommand.builder().memberId(member.getId()).orderId(orderId).build());
+
+        // then
+        assertThat(detail.delivery().addressChangeable()).isTrue();
+        assertThat(detail.delivery().recipientName()).isEqualTo("홍길동");
+        assertThat(detail.delivery().address()).isEqualTo("서울특별시 강남구 테헤란로 123 101동 1001호");
+        assertThat(detail.delivery().phone()).isEqualTo("01012345678");
+    }
+
+    @DisplayName("타인의 주문을 조회하면 CUSTOMER_ORDER_NOT_FOUND 예외가 발생한다")
+    @Test
+    void getOrderDetail_throwsWhenNotOwner() {
+        // given
+        Member other = memberRepository.save(Member.builder()
+            .email("other@bbangle.com").name("타인").nickname("타인").build());
+        Order order = OrderFixture.createOrderWithNumber("ORDER-2025-05-15-00001").toBuilder()
+            .orderDate(LocalDateTime.of(2025, 5, 15, 10, 0))
+            .member(other)
+            .build();
+        order = orderRepository.save(order);
+        OrderItem item = buildItem(OrderStatus.PAYMENT_COMPLETED, 5800, 4700, 1);
+        order.addOrderItem(item);
+        orderItemRepository.save(item);
+        Long orderId = order.getId();
+        em.flush();
+        em.clear();
+
+        // when & then
+        assertThatThrownBy(() -> customerOrderService.getOrderDetail(
+            CustomerOrderDetailCommand.builder().memberId(member.getId()).orderId(orderId).build()))
+            .isInstanceOf(BbangleException.class)
+            .hasFieldOrPropertyWithValue("bbangleErrorCode", BbangleErrorCode.CUSTOMER_ORDER_NOT_FOUND);
+    }
+
+    @DisplayName("존재하지 않는 주문을 조회하면 CUSTOMER_ORDER_NOT_FOUND 예외가 발생한다")
+    @Test
+    void getOrderDetail_throwsWhenNotExists() {
+        assertThatThrownBy(() -> customerOrderService.getOrderDetail(
+            CustomerOrderDetailCommand.builder().memberId(member.getId()).orderId(999999L).build()))
+            .isInstanceOf(BbangleException.class)
+            .hasFieldOrPropertyWithValue("bbangleErrorCode", BbangleErrorCode.CUSTOMER_ORDER_NOT_FOUND);
+    }
+}


### PR DESCRIPTION


## 🚀 Major Changes & Explanations

 - `GET /api/v1/customer/orders/{orderId}`
- 인증된 회원 **본인 소유 주문만** 조회 (아니면 `CUSTOMER_ORDER_NOT_FOUND`)

### 화면 노출 항목 → 응답 매핑
- **헤더**: 주문일자, 주문번호
- **① 결제 금액**: 상품금액 / 상품할인금액 / 배송비 / 최종결제금액 / 총 할인 문구 / 영수증 노출여부
- **② 배송지**: 배송지명 / 주소 / 연락처 / 배송요청사항 / 배송지변경 가능여부
- **상품**: 스토어명 / 상품명·옵션 / 상태뱃지 / 할인율·가격·수량 / 태그 / 배송조회 + 진행단계

### 정책 반영
- **결제금액·영수증**: 반품·취소 상품 금액은 집계에서 제외 (교환은 유지). 전액 반품·취소 시 배송비도 0
- **배송지 변경 버튼**: 결제완료 상태 상품이 하나라도 있어야 활성화 (`addressChangeable`)


## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 소비자가 주문 상세를 확인할 수 있는 상세 조회 기능이 추가되었습니다.
  * 결제 내역, 배송지 정보, 주문 상품별 상태/진행 단계, 배송 추적 정보가 함께 표시됩니다.

* **Bug Fixes**
  * 존재하지 않거나 접근 권한이 없는 주문 조회 시 명확한 오류 응답이 반환되도록 개선되었습니다.
  * 반품·취소된 상품은 결제 금액 계산에서 제외되도록 처리되었습니다.

* **Tests**
  * 주문 상세 조회의 성공/실패 케이스와 금액·배송 정보 매핑 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->