### PR TITLE
[FEAT] 구매확정api구현

### DIFF
--- a/src/main/java/com/bbangle/bbangle/delivery/domain/Shipping.java
+++ b/src/main/java/com/bbangle/bbangle/delivery/domain/Shipping.java
@@ -55,4 +55,12 @@ public class Shipping {
         this.trackingNumber = trackingNumber;
     }
 
+    /**
+     * 배송완료 시각을 기록합니다.
+     * 배송완료 후 N일 자동 구매확정의 기산점으로 사용됩니다.
+     */
+    public void markDelivered(LocalDateTime deliveredAt) {
+        this.deliveredAt = deliveredAt;
+    }
+
 }

--- a/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
+++ b/src/main/java/com/bbangle/bbangle/exception/BbangleErrorCode.java
@@ -185,6 +185,8 @@ public enum BbangleErrorCode {
     CUSTOMER_ORDER_UNAUTHORIZED(-786, "주문 조회를 위해 로그인이 필요합니다.", UNAUTHORIZED),
     CUSTOMER_ORDER_MEMBER_NOT_FOUND(-787, "존재하지 않는 회원의 주문 조회 요청입니다.", NOT_FOUND),
     CUSTOMER_ORDER_NOT_FOUND(-788, "존재하지 않거나 접근할 수 없는 주문입니다.", NOT_FOUND),
+    PURCHASE_CONFIRM_NOT_ALLOWED(-789, "구매확정이 불가능한 상태입니다. 배송완료 후에만 구매확정할 수 있습니다.", BAD_REQUEST),
+    CUSTOMER_ORDER_ITEM_NOT_FOUND(-790, "존재하지 않거나 접근할 수 없는 주문상품입니다.", NOT_FOUND),
 
     // Settlement Error(801 ~ 820)
     SETTLEMENT_NOT_FOUND(-802, "존재하지 않는 정산 내역입니다.", NOT_FOUND),

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderApi.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderApi.java
@@ -31,4 +31,16 @@ public interface CustomerOrderApi {
         Long memberId,
         @Parameter(description = "주문 ID", example = "1") Long orderId
     );
+
+    @Operation(
+        summary = "(소비자) 구매확정",
+        description = "본인 소유의 배송완료된 주문상품을 구매확정합니다. "
+            + "배송완료 후 7일이 지나면 자동으로 구매확정되며, 그 전이라도 이 API로 직접 확정할 수 있습니다. "
+            + "구매확정 이후에는 주문 조회 응답의 reviewable 플래그가 true 가 되어 후기작성 버튼이 노출됩니다."
+    )
+    SingleResult<Long> confirmPurchase(
+        Long memberId,
+        @Parameter(description = "주문 ID", example = "1") Long orderId,
+        @Parameter(description = "주문상품 ID", example = "10") Long orderItemId
+    );
 }

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderController.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderController.java
@@ -6,6 +6,7 @@ import com.bbangle.bbangle.config.security.CustomerApiPath;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderDetailResponse.CustomerOrderDetail;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderPageResponse;
 import com.bbangle.bbangle.order.customer.service.CustomerOrderService;
+import com.bbangle.bbangle.order.customer.service.PurchaseConfirmService;
 import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderDetailCommand;
 import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderSearchCommand;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,6 +27,7 @@ public class CustomerOrderController implements CustomerOrderApi {
 
     private final ResponseService responseService;
     private final CustomerOrderService customerOrderService;
+    private final PurchaseConfirmService purchaseConfirmService;
 
     /**
      * 소비자 주문목록 조회. 기본 정렬은 주문일(orderDate) 최신순입니다.
@@ -62,5 +65,20 @@ public class CustomerOrderController implements CustomerOrderApi {
         CustomerOrderDetail response = customerOrderService.getOrderDetail(command);
 
         return responseService.getSingleResult(response);
+    }
+
+    /**
+     * 소비자 구매확정. 본인 소유의 배송완료된 주문상품만 구매확정할 수 있습니다.
+     */
+    @Override
+    @PostMapping("/{orderId}/items/{orderItemId}/confirm")
+    public SingleResult<Long> confirmPurchase(
+        @AuthenticationPrincipal Long memberId,
+        @PathVariable Long orderId,
+        @PathVariable Long orderItemId
+    ) {
+        Long confirmedOrderItemId = purchaseConfirmService.confirm(memberId, orderId, orderItemId);
+
+        return responseService.getSingleResult(confirmedOrderItemId);
     }
 }

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/dto/response/CustomerOrderDetailResponse.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/dto/response/CustomerOrderDetailResponse.java
@@ -86,7 +86,9 @@ public class CustomerOrderDetailResponse {
         @Schema(description = "배송조회 버튼 노출 여부 (운송장 등록 시 true)") boolean deliveryTrackable,
         @Schema(description = "택배사", example = "CJ대한통운") String courierCompany,
         @Schema(description = "운송장 번호", example = "123-456-789") String trackingNumber,
-        @Schema(description = "진행 단계 정보") CustomerOrderProgress progress
+        @Schema(description = "진행 단계 정보") CustomerOrderProgress progress,
+        @Schema(description = "구매확정 버튼 노출 여부 (배송완료 && 구매확정 전이면 true)") boolean purchaseConfirmable,
+        @Schema(description = "후기작성 버튼 노출 여부 (구매확정 상태면 true)") boolean reviewable
     ) {
 
     }

--- a/src/main/java/com/bbangle/bbangle/order/customer/controller/dto/response/CustomerOrderResponse.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/controller/dto/response/CustomerOrderResponse.java
@@ -73,7 +73,9 @@ public class CustomerOrderResponse {
         @Schema(description = "배송 상태") String deliveryStatus,
         @Schema(description = "택배사") String courierCompany,
         @Schema(description = "운송장 번호") String trackingNumber,
-        @Schema(description = "진행 단계 정보") CustomerOrderProgress progress
+        @Schema(description = "진행 단계 정보") CustomerOrderProgress progress,
+        @Schema(description = "구매확정 버튼 노출 여부 (배송완료 && 구매확정 전이면 true)") boolean purchaseConfirmable,
+        @Schema(description = "후기작성 버튼 노출 여부 (구매확정 상태면 true)") boolean reviewable
     ) {
 
     }

--- a/src/main/java/com/bbangle/bbangle/order/customer/scheduler/PurchaseConfirmScheduler.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/scheduler/PurchaseConfirmScheduler.java
@@ -1,0 +1,26 @@
+package com.bbangle.bbangle.order.customer.scheduler;
+
+import com.bbangle.bbangle.order.customer.service.PurchaseConfirmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 배송완료 후 7일이 지난 주문상품을 자동으로 구매확정하는 스케줄러.
+ * 매일 자정에 실행됩니다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PurchaseConfirmScheduler {
+
+    private final PurchaseConfirmService purchaseConfirmService;
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 밤 12시
+    public void autoConfirm() {
+        log.info("자동 구매확정 스케줄러 시작");
+        int confirmed = purchaseConfirmService.autoConfirmExpired();
+        log.info("자동 구매확정 스케줄러 종료 - {}건 처리", confirmed);
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/customer/service/CustomerOrderService.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/service/CustomerOrderService.java
@@ -215,6 +215,8 @@ public class CustomerOrderService {
             trackingNumber = delivery.getShipping().getTrackingNumber();
         }
         boolean deliveryTrackable = courierCompany != null && trackingNumber != null;
+        boolean purchaseConfirmable = isPurchaseConfirmable(item.getOrderStatus(), deliveryStatus);
+        boolean reviewable = item.getOrderStatus() == OrderStatus.PURCHASE_CONFIRMED;
 
         Product product = item.getProduct();
         String storeName = product != null && product.getStore() != null ? product.getStore().getName() : null;
@@ -243,8 +245,18 @@ public class CustomerOrderService {
             deliveryTrackable,
             courierCompany,
             trackingNumber,
-            progress
+            progress,
+            purchaseConfirmable,
+            reviewable
         );
+    }
+
+    /**
+     * 구매확정 버튼 노출 여부.
+     * 배송완료(상품발송 + 배송상태 DELIVERED) 상태이면서 아직 구매확정 전일 때만 노출합니다.
+     */
+    private boolean isPurchaseConfirmable(OrderStatus orderStatus, OrderDeliveryStatus deliveryStatus) {
+        return orderStatus == OrderStatus.SHIPPED && deliveryStatus == OrderDeliveryStatus.DELIVERED;
     }
 
     private int calculateDiscountRate(int productPrice, int unitPrice) {
@@ -317,6 +329,8 @@ public class CustomerOrderService {
         }
 
         CustomerOrderProgress progress = CustomerOrderStepMapper.resolve(item.getOrderStatus(), deliveryStatus);
+        boolean purchaseConfirmable = isPurchaseConfirmable(item.getOrderStatus(), deliveryStatus);
+        boolean reviewable = item.getOrderStatus() == OrderStatus.PURCHASE_CONFIRMED;
 
         return new CustomerOrderItemInfo(
             item.getId(),
@@ -330,7 +344,9 @@ public class CustomerOrderService {
             deliveryStatusLabel,
             courierCompany,
             trackingNumber,
-            progress
+            progress,
+            purchaseConfirmable,
+            reviewable
         );
     }
 

--- a/src/main/java/com/bbangle/bbangle/order/customer/service/PurchaseConfirmService.java
+++ b/src/main/java/com/bbangle/bbangle/order/customer/service/PurchaseConfirmService.java
@@ -1,0 +1,75 @@
+package com.bbangle.bbangle.order.customer.service;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.order.domain.OrderDelivery;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
+import com.bbangle.bbangle.order.repository.OrderDeliveryRepository;
+import com.bbangle.bbangle.order.repository.OrderItemRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 구매확정 서비스.
+ *
+ * <p>정책: 배송완료(DELIVERED) 후 7일이 지나면 자동으로 구매확정되며, 그 전이라도 고객이 직접 구매확정할 수 있습니다.
+ * 구매확정 이후에는 화면 버튼이 "후기작성"으로 전환됩니다(노출 여부는 주문 조회 응답의 플래그로 내려줍니다).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PurchaseConfirmService {
+
+    /** 배송완료 후 자동 구매확정까지의 기간(일). */
+    public static final int AUTO_CONFIRM_DEADLINE_DAYS = 7;
+
+    private final OrderItemRepository orderItemRepository;
+    private final OrderDeliveryRepository orderDeliveryRepository;
+
+    /**
+     * 고객의 수동 구매확정.
+     * 본인 소유의 배송완료된 주문상품만 구매확정할 수 있습니다.
+     *
+     * @return 구매확정된 주문상품 ID
+     */
+    @Transactional
+    public Long confirm(Long memberId, Long orderId, Long orderItemId) {
+        OrderItem orderItem = orderItemRepository.findOwnedOrderItem(memberId, orderId, orderItemId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.CUSTOMER_ORDER_ITEM_NOT_FOUND));
+
+        if (!isDelivered(orderItemId)) {
+            throw new BbangleException(BbangleErrorCode.PURCHASE_CONFIRM_NOT_ALLOWED);
+        }
+
+        orderItem.confirmPurchase(LocalDateTime.now());
+        return orderItem.getId();
+    }
+
+    /**
+     * 배송완료 후 7일이 지난 주문상품을 일괄 자동 구매확정합니다. (스케줄러에서 호출)
+     */
+    @Transactional
+    public int autoConfirmExpired() {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(AUTO_CONFIRM_DEADLINE_DAYS);
+        List<OrderItem> targets = orderItemRepository.findAutoConfirmTargets(cutoff);
+
+        LocalDateTime confirmedAt = LocalDateTime.now();
+        targets.forEach(orderItem -> orderItem.confirmPurchase(confirmedAt));
+
+        log.info("배송완료 후 {}일 경과 자동 구매확정 완료 - {}건 (cutoff={})",
+            AUTO_CONFIRM_DEADLINE_DAYS, targets.size(), cutoff);
+        return targets.size();
+    }
+
+    private boolean isDelivered(Long orderItemId) {
+        return orderDeliveryRepository.findByOrderItemId(orderItemId)
+            .map(OrderDelivery::getStatus)
+            .filter(status -> status == OrderDeliveryStatus.DELIVERED)
+            .isPresent();
+    }
+}

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderDelivery.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderDelivery.java
@@ -9,6 +9,7 @@ import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
+import java.time.LocalDateTime;
 import java.util.Set;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -94,6 +95,22 @@ public class OrderDelivery extends BaseEntity {
             throw new BbangleException(BbangleErrorCode.DELIVERY_MODIFY_NOT_ALLOWED);
         }
         this.shipping.modifyShippingInfo(courierName, trackingNumber);
+    }
+
+    /**
+     * 배송완료 처리. 상태를 DELIVERED 로 바꾸고 배송완료 시각을 기록합니다.
+     * 배송완료 후 7일 자동 구매확정 배치의 기산점이 됩니다.
+     */
+    public void markDelivered(LocalDateTime deliveredAt) {
+        if (this.shipping == null) {
+            this.shipping = Shipping.empty();
+        }
+        this.shipping.markDelivered(deliveredAt);
+        this.status = OrderDeliveryStatus.DELIVERED;
+    }
+
+    public LocalDateTime getDeliveredAt() {
+        return this.shipping != null ? this.shipping.getDeliveredAt() : null;
     }
 
 }

--- a/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
+++ b/src/main/java/com/bbangle/bbangle/order/domain/OrderItem.java
@@ -25,6 +25,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -61,6 +62,9 @@ public class OrderItem extends BaseEntity {
 
     @Column(name = "total_price")
     private Integer totalPrice;
+
+    @Column(name = "purchase_confirmed_at")
+    private LocalDateTime purchaseConfirmedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id")
@@ -129,6 +133,27 @@ public class OrderItem extends BaseEntity {
             throw new BbangleException(BbangleErrorCode.ORDER_INVALID_STATUS);
         }
         this.orderStatus = OrderStatus.SHIPPED;
+    }
+
+    /**
+     * 구매확정이 가능한 상태인지 여부.
+     * 배송완료(상품발송 + 배송상태 DELIVERED) 이후에만 확정할 수 있으므로,
+     * 배송상태 검증은 호출 측(서비스)에서 별도로 수행합니다.
+     */
+    public boolean canConfirmPurchase() {
+        return this.orderStatus == OrderStatus.SHIPPED;
+    }
+
+    /**
+     * 구매확정 처리. 상품발송(SHIPPED) 상태에서만 구매확정으로 전환하고 확정 시각을 기록합니다.
+     * 고객의 수동 확정과 배송완료 후 7일 자동 확정 배치에서 공통으로 사용합니다.
+     */
+    public void confirmPurchase(LocalDateTime confirmedAt) {
+        if (!canConfirmPurchase()) {
+            throw new BbangleException(BbangleErrorCode.PURCHASE_CONFIRM_NOT_ALLOWED);
+        }
+        this.orderStatus = OrderStatus.PURCHASE_CONFIRMED;
+        this.purchaseConfirmedAt = confirmedAt;
     }
 
     public boolean canRequestCancel() {

--- a/src/main/java/com/bbangle/bbangle/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/bbangle/bbangle/order/repository/OrderItemRepository.java
@@ -1,6 +1,7 @@
 package com.bbangle.bbangle.order.repository;
 
 import com.bbangle.bbangle.order.domain.OrderItem;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -51,4 +52,37 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
         WHERE oi.id IN :ids
         """)
     List<OrderItem> findWithOrderAndProductByIdIn(@Param("ids") List<Long> ids);
+
+    /**
+     * 회원 소유의 단일 주문상품을 조회합니다. (수동 구매확정 시 소유권 검증용)
+     */
+    @Query("""
+        SELECT oi FROM OrderItem oi
+        JOIN FETCH oi.order o
+        WHERE oi.id = :orderItemId
+          AND o.id = :orderId
+          AND o.member.id = :memberId
+        """)
+    Optional<OrderItem> findOwnedOrderItem(
+        @Param("memberId") Long memberId,
+        @Param("orderId") Long orderId,
+        @Param("orderItemId") Long orderItemId
+    );
+
+    /**
+     * 자동 구매확정 대상 조회.
+     * 상품발송(SHIPPED) 상태이면서, 배송완료(DELIVERED) 처리된 지 기준시각(cutoff) 이상 지난 주문상품을 찾습니다.
+     */
+    @Query("""
+        SELECT oi FROM OrderItem oi
+        WHERE oi.orderStatus = com.bbangle.bbangle.order.domain.model.OrderStatus.SHIPPED
+          AND EXISTS (
+            SELECT 1 FROM OrderDelivery od
+            WHERE od.orderItem = oi
+              AND od.status = com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus.DELIVERED
+              AND od.shipping.deliveredAt IS NOT NULL
+              AND od.shipping.deliveredAt <= :cutoff
+          )
+        """)
+    List<OrderItem> findAutoConfirmTargets(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/bbangle/bbangle/order/service/DeliveryCompletionService.java
+++ b/src/main/java/com/bbangle/bbangle/order/service/DeliveryCompletionService.java
@@ -1,0 +1,45 @@
+package com.bbangle.bbangle.order.service;
+
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.order.domain.OrderDelivery;
+import com.bbangle.bbangle.order.repository.OrderDeliveryRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 배송완료 처리 서비스.
+ *
+ * <p>주문상품의 배송정보를 배송완료(DELIVERED)로 전환하고 배송완료 시각({@code deliveredAt})을 기록합니다.
+ * 이 시각은 "배송완료 후 7일 자동 구매확정"({@code PurchaseConfirmService}) 배치의 기산점이 됩니다.
+ *
+ * <p>TODO: 현재는 배송완료를 알려주는 트리거가 연결되어 있지 않습니다.
+ * 추후 택배사 배송추적 API(웹훅)를 수신하는 컨트롤러를 추가하고, 운송장 상태가 "배송완료"로 바뀌면
+ * 이 {@link #completeDelivery(Long, LocalDateTime)} 를 호출하도록 연결해야 합니다.
+ * (연동 전까지는 이 메서드를 호출하는 진입점이 없어 deliveredAt 이 채워지지 않습니다.)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeliveryCompletionService {
+
+    private final OrderDeliveryRepository orderDeliveryRepository;
+
+    /**
+     * 주문상품의 배송을 완료 처리합니다.
+     *
+     * @param orderItemId 배송완료된 주문상품 ID
+     * @param deliveredAt 택배사가 통지한 실제 배송완료 시각
+     */
+    @Transactional
+    public void completeDelivery(Long orderItemId, LocalDateTime deliveredAt) {
+        OrderDelivery delivery = orderDeliveryRepository.findByOrderItemId(orderItemId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.DELIVERY_NOT_FOUND));
+
+        delivery.markDelivered(deliveredAt);
+        log.info("배송완료 처리 - orderItemId={}, deliveredAt={}", orderItemId, deliveredAt);
+    }
+}

--- a/src/main/resources/flyway/V62__app.sql
+++ b/src/main/resources/flyway/V62__app.sql
@@ -1,0 +1,3 @@
+-- 구매확정 시각 컬럼 추가 (수동 확정 / 배송완료 후 7일 자동확정 시 기록)
+ALTER TABLE order_item
+    ADD COLUMN purchase_confirmed_at DATETIME(6) NULL AFTER delivery_status;

--- a/src/test/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderControllerSliceTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/customer/controller/CustomerOrderControllerSliceTest.java
@@ -6,7 +6,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -30,6 +32,7 @@ import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderR
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderProgress;
 import com.bbangle.bbangle.order.customer.controller.dto.response.CustomerOrderResponse.CustomerOrderStatusCounts;
 import com.bbangle.bbangle.order.customer.service.CustomerOrderService;
+import com.bbangle.bbangle.order.customer.service.PurchaseConfirmService;
 import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderDetailCommand;
 import com.bbangle.bbangle.order.customer.service.model.CustomerOrderCommand.CustomerOrderSearchCommand;
 import com.bbangle.bbangle.order.domain.model.CustomerOrderCategory;
@@ -74,6 +77,9 @@ class CustomerOrderControllerSliceTest {
     @MockBean
     private CustomerOrderService customerOrderService;
 
+    @MockBean
+    private PurchaseConfirmService purchaseConfirmService;
+
     private static UsernamePasswordAuthenticationToken memberAuth(Long memberId) {
         return new UsernamePasswordAuthenticationToken(
             memberId, "N/A", List.of(new SimpleGrantedAuthority("ROLE_CUSTOMER")));
@@ -90,7 +96,7 @@ class CustomerOrderControllerSliceTest {
             List.of("결제완료", "상품제작중", "상품발송", "배송완료", "구매확정"));
         CustomerOrderItemInfo item = new CustomerOrderItemInfo(
             10L, "저당 베이글 세트", "저칼로리 베이글", 2, 4700L, 9400L,
-            OrderStatus.SHIPPED, "배송완료", "CJ대한통운", "123-456", progress);
+            OrderStatus.SHIPPED, "배송완료", "CJ대한통운", "123-456", progress, true, false);
         CustomerOrderInfo orderInfo = new CustomerOrderInfo(
             1L, "ORDER-2025-06-14-00001", LocalDate.of(2025, 6, 14), 9400L, null, List.of(item));
 
@@ -181,7 +187,7 @@ class CustomerOrderControllerSliceTest {
         CustomerOrderDetailItem item = new CustomerOrderDetailItem(
             10L, "비건빵빵이네", "저당 베이글 세트", "저칼로리 베이글", "상품발송",
             OrderStatus.SHIPPED, 5800L, 4700L, 19, 2, 9400L,
-            List.of("고단백", "글루텐프리"), true, "CJ대한통운", "123-456-789", progress);
+            List.of("고단백", "글루텐프리"), true, "CJ대한통운", "123-456-789", progress, false, false);
         CustomerPaymentSummary payment = new CustomerPaymentSummary(
             11600L, 2200L, 2500L, 11900L, 2200L, "총 2,200원 할인 받았어요", true, null);
         CustomerDeliveryInfo delivery = new CustomerDeliveryInfo(
@@ -228,6 +234,49 @@ class CustomerOrderControllerSliceTest {
             .andExpect(status().is4xxClientError())
             .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.code").value(BbangleErrorCode.CUSTOMER_ORDER_NOT_FOUND.getCode()));
+
+        then(globalControllerAdvice).should(times(1))
+            .handleBbangleException(any(), any(BbangleException.class));
+    }
+
+    @DisplayName("구매확정 API - 성공")
+    @Test
+    void givenDeliveredOrderItem_whenConfirmPurchase_thenReturnsConfirmedId() throws Exception {
+        // given
+        Long memberId = 1L;
+        Long orderId = 100L;
+        Long orderItemId = 10L;
+
+        given(purchaseConfirmService.confirm(memberId, orderId, orderItemId)).willReturn(orderItemId);
+
+        // when & then
+        mvc.perform(post("/api/v1/customer/orders/{orderId}/items/{orderItemId}/confirm", orderId, orderItemId)
+                .with(authentication(memberAuth(memberId)))
+                .with(csrf()))
+
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value(SUCCESS.getCode()))
+            .andExpect(jsonPath("$.result").value(orderItemId));
+
+        then(purchaseConfirmService).should(times(1)).confirm(memberId, orderId, orderItemId);
+    }
+
+    @DisplayName("구매확정 API - 실패(배송완료 전 구매확정 시도)")
+    @Test
+    void givenNotDeliveredOrderItem_whenConfirmPurchase_thenReturns4xx() throws Exception {
+        // given
+        given(purchaseConfirmService.confirm(any(), any(), any()))
+            .willThrow(new BbangleException(BbangleErrorCode.PURCHASE_CONFIRM_NOT_ALLOWED));
+
+        // when & then
+        mvc.perform(post("/api/v1/customer/orders/{orderId}/items/{orderItemId}/confirm", 100L, 10L)
+                .with(authentication(memberAuth(1L)))
+                .with(csrf()))
+
+            .andExpect(status().is4xxClientError())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value(BbangleErrorCode.PURCHASE_CONFIRM_NOT_ALLOWED.getCode()));
 
         then(globalControllerAdvice).should(times(1))
             .handleBbangleException(any(), any(BbangleException.class));

--- a/src/test/java/com/bbangle/bbangle/order/customer/service/PurchaseConfirmServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/customer/service/PurchaseConfirmServiceUnitTest.java
@@ -1,0 +1,178 @@
+package com.bbangle.bbangle.order.customer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.bbangle.bbangle.delivery.domain.Shipping;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
+import com.bbangle.bbangle.fixture.order.domain.OrderItemFixture;
+import com.bbangle.bbangle.order.domain.OrderDelivery;
+import com.bbangle.bbangle.order.domain.OrderItem;
+import com.bbangle.bbangle.order.domain.model.OrderDeliveryStatus;
+import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import com.bbangle.bbangle.order.repository.OrderDeliveryRepository;
+import com.bbangle.bbangle.order.repository.OrderItemRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("[단위 테스트] PurchaseConfirmService")
+@ExtendWith(MockitoExtension.class)
+class PurchaseConfirmServiceUnitTest {
+
+    @InjectMocks
+    private PurchaseConfirmService sut;
+
+    @Mock
+    private OrderItemRepository orderItemRepository;
+
+    @Mock
+    private OrderDeliveryRepository orderDeliveryRepository;
+
+    private OrderItem shippedOrderItem(Long id) {
+        OrderItem orderItem = OrderItemFixture.createOrderItemWithStatus(OrderStatus.SHIPPED);
+        ReflectionTestUtils.setField(orderItem, "id", id);
+        return orderItem;
+    }
+
+    private OrderDelivery deliveryWithStatus(OrderItem orderItem, OrderDeliveryStatus status) {
+        return OrderDelivery.create(null, null, Shipping.of("CJ대한통운", "1234567890"), status, orderItem);
+    }
+
+    @Nested
+    @DisplayName("수동 구매확정 (confirm)")
+    class ConfirmTest {
+
+        private static final Long MEMBER_ID = 1L;
+        private static final Long ORDER_ID = 100L;
+        private static final Long ORDER_ITEM_ID = 10L;
+
+        @DisplayName("본인 소유의 배송완료된 주문상품이면 PURCHASE_CONFIRMED로 전환되고 확정 시각이 기록된다")
+        @Test
+        void givenOwnedDeliveredItem_whenConfirm_thenPurchaseConfirmed() {
+            // given
+            OrderItem orderItem = shippedOrderItem(ORDER_ITEM_ID);
+
+            given(orderItemRepository.findOwnedOrderItem(MEMBER_ID, ORDER_ID, ORDER_ITEM_ID))
+                .willReturn(Optional.of(orderItem));
+            given(orderDeliveryRepository.findByOrderItemId(ORDER_ITEM_ID))
+                .willReturn(Optional.of(deliveryWithStatus(orderItem, OrderDeliveryStatus.DELIVERED)));
+
+            // when
+            Long result = sut.confirm(MEMBER_ID, ORDER_ID, ORDER_ITEM_ID);
+
+            // then
+            assertThat(result).isEqualTo(ORDER_ITEM_ID);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.PURCHASE_CONFIRMED);
+            assertThat(orderItem.getPurchaseConfirmedAt()).isNotNull();
+        }
+
+        @DisplayName("본인 소유가 아니거나 존재하지 않는 주문상품이면 CUSTOMER_ORDER_ITEM_NOT_FOUND 예외가 발생한다")
+        @Test
+        void givenNotOwnedItem_whenConfirm_thenThrowsNotFound() {
+            // given
+            given(orderItemRepository.findOwnedOrderItem(MEMBER_ID, ORDER_ID, ORDER_ITEM_ID))
+                .willReturn(Optional.empty());
+
+            // when
+            BbangleException result = assertThrows(BbangleException.class,
+                () -> sut.confirm(MEMBER_ID, ORDER_ID, ORDER_ITEM_ID));
+
+            // then
+            assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.CUSTOMER_ORDER_ITEM_NOT_FOUND);
+            then(orderDeliveryRepository).should(never()).findByOrderItemId(ORDER_ITEM_ID);
+        }
+
+        @DisplayName("배송완료(DELIVERED) 상태가 아니면 PURCHASE_CONFIRM_NOT_ALLOWED 예외가 발생하고 상태가 변경되지 않는다")
+        @Test
+        void givenNotDeliveredItem_whenConfirm_thenThrowsNotAllowed() {
+            // given
+            OrderItem orderItem = shippedOrderItem(ORDER_ITEM_ID);
+
+            given(orderItemRepository.findOwnedOrderItem(MEMBER_ID, ORDER_ID, ORDER_ITEM_ID))
+                .willReturn(Optional.of(orderItem));
+            given(orderDeliveryRepository.findByOrderItemId(ORDER_ITEM_ID))
+                .willReturn(Optional.of(deliveryWithStatus(orderItem, OrderDeliveryStatus.DELIVERING)));
+
+            // when
+            BbangleException result = assertThrows(BbangleException.class,
+                () -> sut.confirm(MEMBER_ID, ORDER_ID, ORDER_ITEM_ID));
+
+            // then
+            assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.PURCHASE_CONFIRM_NOT_ALLOWED);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.SHIPPED);
+            assertThat(orderItem.getPurchaseConfirmedAt()).isNull();
+        }
+
+        @DisplayName("배송 정보가 아예 없으면 PURCHASE_CONFIRM_NOT_ALLOWED 예외가 발생한다")
+        @Test
+        void givenNoDelivery_whenConfirm_thenThrowsNotAllowed() {
+            // given
+            OrderItem orderItem = shippedOrderItem(ORDER_ITEM_ID);
+
+            given(orderItemRepository.findOwnedOrderItem(MEMBER_ID, ORDER_ID, ORDER_ITEM_ID))
+                .willReturn(Optional.of(orderItem));
+            given(orderDeliveryRepository.findByOrderItemId(ORDER_ITEM_ID))
+                .willReturn(Optional.empty());
+
+            // when
+            BbangleException result = assertThrows(BbangleException.class,
+                () -> sut.confirm(MEMBER_ID, ORDER_ID, ORDER_ITEM_ID));
+
+            // then
+            assertThat(result.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.PURCHASE_CONFIRM_NOT_ALLOWED);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.SHIPPED);
+        }
+    }
+
+    @Nested
+    @DisplayName("자동 구매확정 배치 (autoConfirmExpired)")
+    class AutoConfirmTest {
+
+        @DisplayName("배송완료 후 7일이 지난 대상 주문상품을 모두 구매확정하고 처리 건수를 반환한다")
+        @Test
+        void givenExpiredTargets_whenAutoConfirm_thenAllConfirmedAndCountReturned() {
+            // given
+            OrderItem target1 = shippedOrderItem(10L);
+            OrderItem target2 = shippedOrderItem(11L);
+
+            given(orderItemRepository.findAutoConfirmTargets(org.mockito.ArgumentMatchers.any()))
+                .willReturn(List.of(target1, target2));
+
+            // when
+            int confirmedCount = sut.autoConfirmExpired();
+
+            // then
+            assertThat(confirmedCount).isEqualTo(2);
+            assertThat(target1.getOrderStatus()).isEqualTo(OrderStatus.PURCHASE_CONFIRMED);
+            assertThat(target2.getOrderStatus()).isEqualTo(OrderStatus.PURCHASE_CONFIRMED);
+            assertThat(target1.getPurchaseConfirmedAt()).isNotNull();
+            assertThat(target2.getPurchaseConfirmedAt()).isNotNull();
+        }
+
+        @DisplayName("자동확정 대상이 없으면 0건을 반환한다")
+        @Test
+        void givenNoTargets_whenAutoConfirm_thenReturnsZero() {
+            // given
+            given(orderItemRepository.findAutoConfirmTargets(org.mockito.ArgumentMatchers.any()))
+                .willReturn(List.of());
+
+            // when
+            int confirmedCount = sut.autoConfirmExpired();
+
+            // then
+            assertThat(confirmedCount).isZero();
+        }
+    }
+}

--- a/src/test/java/com/bbangle/bbangle/order/domain/OrderItemTest.java
+++ b/src/test/java/com/bbangle/bbangle/order/domain/OrderItemTest.java
@@ -3,9 +3,11 @@ package com.bbangle.bbangle.order.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.fixture.order.OrderItemFixture;
 import com.bbangle.bbangle.order.domain.model.OrderStatus;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -57,6 +59,53 @@ class OrderItemTest {
             // then
             assertThat(result).isFalse();
             assertThat(orderItem.getOrderStatus()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmPurchase()")
+    class ConfirmPurchase {
+
+        @Test
+        @DisplayName("SHIPPED 상태에서 confirmPurchase()를 호출하면 PURCHASE_CONFIRMED로 전환되고 확정 시각이 기록된다")
+        void confirmPurchase_success_when_shipped() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.SHIPPED);
+            LocalDateTime confirmedAt = LocalDateTime.of(2025, 6, 29, 12, 0);
+
+            // when
+            orderItem.confirmPurchase(confirmedAt);
+
+            // then
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.PURCHASE_CONFIRMED);
+            assertThat(orderItem.getPurchaseConfirmedAt()).isEqualTo(confirmedAt);
+        }
+
+        @Test
+        @DisplayName("SHIPPED가 아닌 상태에서 confirmPurchase()를 호출하면 예외가 발생하고 상태/확정시각은 변경되지 않는다")
+        void confirmPurchase_fail_when_not_shipped() {
+            // given
+            OrderItem orderItem = OrderItemFixture.orderItemWithStatus(OrderStatus.PAYMENT_COMPLETED);
+
+            // when & then
+            assertThatThrownBy(() -> orderItem.confirmPurchase(LocalDateTime.now()))
+                .isInstanceOf(BbangleException.class)
+                .extracting(e -> ((BbangleException) e).getBbangleErrorCode())
+                .isEqualTo(BbangleErrorCode.PURCHASE_CONFIRM_NOT_ALLOWED);
+            assertThat(orderItem.getOrderStatus()).isEqualTo(OrderStatus.PAYMENT_COMPLETED);
+            assertThat(orderItem.getPurchaseConfirmedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("canConfirmPurchase()는 SHIPPED 상태에서만 true를 반환한다")
+        void canConfirmPurchase_true_only_when_shipped() {
+            // given
+            OrderItem shipped = OrderItemFixture.orderItemWithStatus(OrderStatus.SHIPPED);
+            OrderItem confirmed = OrderItemFixture.orderItemWithStatus(OrderStatus.PURCHASE_CONFIRMED);
+
+            // when & then
+            assertThat(shipped.canConfirmPurchase()).isTrue();
+            assertThat(confirmed.canConfirmPurchase()).isFalse();
         }
     }
 


### PR DESCRIPTION

## 🚀 Major Changes & Explanations

배송완료 후 7일이 지나면 자동확정, 그 전에는 고객이 직접 확정할 수 있는 구매확정 기능을 구현했습니다. 구매확정 이후에는 화면 버튼이 "후기작성"으로 전환됩니다.
  
 
**1. 도메인 상태 전환**
- `OrderItem.confirmPurchase()` — `SHIPPED` → `PURCHASE_CONFIRMED` 전환 및 확정 시각(`purchaseConfirmedAt`) 기록. 수동/자동 확정 공통 사용
- `OrderDelivery.markDelivered()` / `Shipping.markDelivered()` — 배송완료 시각(`deliveredAt`) 기록. 7일 자동확정의 기산점

**2. 수동 구매확정 API**
- `POST /api/v1/customer/orders/{orderId}/items/{orderItemId}/confirm`
- 본인 소유 + 배송완료(`DELIVERED`) 상태의 주문상품만 확정 가능 (`PurchaseConfirmService.confirm`)

**3. 자동 구매확정 배치**
- `PurchaseConfirmScheduler` — 매일 0시(`0 0 0 * * *`) 실행
- 배송완료 후 7일 경과 주문상품을 일괄 자동확정 (`autoConfirmExpired`)

**4. 화면 버튼 노출 플래그**
- 주문 목록/상세 응답에 `purchaseConfirmable`(구매확정 버튼), `reviewable`(후기작성 버튼) 추가

**5. 배송완료 연동은 TODO 스텁**
- `DeliveryCompletionService.completeDelivery()` 가 `deliveredAt`을 세팅하는 진입점이나, 이를 호출할 **택배사 API/웹훅은 아직 미연동**이라 TODO로 남겨둠. 연동 전까지는 7일 자동확정이 실제 동작하지 않음




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 주문상품 구매확정 기능이 추가되었습니다.
  * 배송완료 시각 기록 및 자동 확정 처리 흐름이 도입되었습니다.
  * 주문 상세/목록에서 구매확정 가능 여부와 리뷰 작성 가능 여부가 표시됩니다.

* **Bug Fixes**
  * 배송완료 전 구매확정 시 적절한 오류가 반환되도록 개선되었습니다.
  * 존재하지 않거나 접근할 수 없는 주문상품에 대한 오류 처리가 강화되었습니다.

* **Chores**
  * 관련 데이터 저장 구조와 테스트가 함께 갱신되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->