### PR TITLE
[Feature] (소비자) 장바구니 상품 옵션 수량 변경 API

### DIFF
--- a/src/main/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartController.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartController.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.cart.customer.controller;
 
 import com.bbangle.bbangle.cart.customer.controller.dto.CartRequest;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.CartListResponse;
+import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.UpdateCartOptionResponse;
 import com.bbangle.bbangle.cart.customer.controller.swagger.CustomerCartApi;
 import com.bbangle.bbangle.cart.customer.facade.CustomerCartFacade;
 import com.bbangle.bbangle.common.dto.CommonResult;
@@ -11,8 +12,10 @@ import com.bbangle.bbangle.config.security.CustomerApiPath;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,8 +52,23 @@ public class CustomerCartController implements CustomerCartApi {
     @Override
     @GetMapping
     public SingleResult<CartListResponse> getCart(
-        @AuthenticationPrincipal Long memberId) {
+        @AuthenticationPrincipal Long memberId
+    ) {
+        return responseService.getSingleResult(
+            customerCartFacade.getCart(memberId)
+        );
+    }
 
-        return responseService.getSingleResult(customerCartFacade.getCart(memberId));
+    // TODO : Test
+    @Override
+    @PatchMapping("/options/{cartOptionId}")
+    public SingleResult<UpdateCartOptionResponse> updateCartOption(
+        @AuthenticationPrincipal Long memberId,
+        @PathVariable Long cartOptionId,
+        @Valid @RequestBody CartRequest.UpdateCartOptionRequest request
+    ) {
+        return responseService.getSingleResult(
+            customerCartFacade.updateQuantity(memberId, cartOptionId, request)
+        );
     }
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartController.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartController.java
@@ -59,7 +59,6 @@ public class CustomerCartController implements CustomerCartApi {
         );
     }
 
-    // TODO : Test
     @Override
     @PatchMapping("/options/{cartOptionId}")
     public SingleResult<UpdateCartOptionResponse> updateCartOption(

--- a/src/main/java/com/bbangle/bbangle/cart/customer/controller/dto/CartRequest.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/controller/dto/CartRequest.java
@@ -35,4 +35,11 @@ public class CartRequest {
             int quantity
         ) {}
     }
+
+    public record UpdateCartOptionRequest(
+        @Min(value = 1, message = "수량은 1개 이상 입력해주세요.")
+        @Max(value = 999, message = "수량은 999개 이하로 입력해주세요.")
+        @Schema(description = "변경할 상품 옵션의 수량", example = "1")
+        int quantity
+    ) {}
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/controller/dto/CartResponse.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/controller/dto/CartResponse.java
@@ -89,10 +89,10 @@ public class CartResponse {
     public record UpdateCartOptionResponse (
         @Schema(description = "장바구니에 담긴 상품 옵션 Id", example = "1")
         Long cartOptionId,
+        @Schema(description = "상품 옵션 Id", example = "1")
+        Long optionId,
         @Schema(description = "상품 옵션 명", example = "저당 초콜릿")
         String optionName,
-        @Schema(description = "상품 옵션 추가 금액", example = "2000")
-        Integer addedPrice,
         @Schema(description = "장바구니에 담긴 상품 옵션의 수량", example = "2")
         Integer quantity
     ) {}

--- a/src/main/java/com/bbangle/bbangle/cart/customer/controller/dto/CartResponse.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/controller/dto/CartResponse.java
@@ -84,4 +84,16 @@ public class CartResponse {
             Integer quantity
         ) {}
     }
+
+    @Builder
+    public record UpdateCartOptionResponse (
+        @Schema(description = "장바구니에 담긴 상품 옵션 Id", example = "1")
+        Long cartOptionId,
+        @Schema(description = "상품 옵션 명", example = "저당 초콜릿")
+        String optionName,
+        @Schema(description = "상품 옵션 추가 금액", example = "2000")
+        Integer addedPrice,
+        @Schema(description = "장바구니에 담긴 상품 옵션의 수량", example = "2")
+        Integer quantity
+    ) {}
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/controller/swagger/CustomerCartApi.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/controller/swagger/CustomerCartApi.java
@@ -2,12 +2,14 @@ package com.bbangle.bbangle.cart.customer.controller.swagger;
 
 import com.bbangle.bbangle.cart.customer.controller.dto.CartRequest;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.CartListResponse;
+import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.UpdateCartOptionResponse;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Customer Cart", description = "(커스토머) 장바구니 API")
@@ -36,4 +38,14 @@ public interface CustomerCartApi {
         description = "장바구니에 담긴 상품들을 조회합니다."
     )
     SingleResult<CartListResponse> getCart(@AuthenticationPrincipal Long memberId);
+
+    @Operation(
+        summary = "(커스토머) 장바구니 상품 옵션 수량 변경",
+        description = "장바구니에서 선택한 상품 옵션의 수량을 변경합니다."
+    )
+    SingleResult<UpdateCartOptionResponse> updateCartOption(
+        @AuthenticationPrincipal Long memberId,
+        @PathVariable Long cartOptionId,
+        @Valid @RequestBody CartRequest.UpdateCartOptionRequest request
+    );
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
@@ -7,12 +7,14 @@ import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.domain.Product;
 import com.bbangle.bbangle.board.domain.ProductImg;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartRequest;
+import com.bbangle.bbangle.cart.customer.controller.dto.CartRequest.UpdateCartOptionRequest;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.CartListResponse;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.CartListResponse.AvailableOptionDTO;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.CartListResponse.CartItemDTO;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.CartListResponse.CartItemDTO.PriceDTO;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.CartListResponse.CartStoreDTO;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.CartListResponse.SelectedOptionDTO;
+import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.UpdateCartOptionResponse;
 import com.bbangle.bbangle.cart.customer.service.CustomerCartItemService;
 import com.bbangle.bbangle.cart.customer.service.CustomerCartOptionService;
 import com.bbangle.bbangle.cart.customer.service.CustomerCartService;
@@ -25,8 +27,8 @@ import com.bbangle.bbangle.member.customer.service.MemberService;
 import com.bbangle.bbangle.member.domain.Member;
 import com.bbangle.bbangle.store.domain.Store;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -102,34 +104,6 @@ public class CustomerCartFacade {
         }
     }
 
-    @Transactional
-    public void deleteCartOptions(Long memberId, CartRequest.DeleteCartOptionsRequest request) {
-        List<Long> optionIds = request.cartOptionIds();
-
-        List<CartItem> cartItems = customerCartItemService.findAllWithOptionsByMemberIdAndOptionIds(memberId,
-            optionIds);
-        validateAllOptionsFound(cartItems, optionIds);
-
-        Set<Long> targetOptionIds = new HashSet<>(optionIds);
-        cartItems.forEach(cartItem -> cartItem.removeOptions(targetOptionIds));
-
-        cartItems.stream()
-            .filter(CartItem::hasNoOptions)
-            .forEach(customerCartItemService::delete);
-    }
-
-    private void validateAllOptionsFound(List<CartItem> cartItems, List<Long> requestedIds) {
-        Set<Long> requestedSet = new HashSet<>(requestedIds);
-        long foundCount = cartItems.stream()
-            .flatMap(ci -> ci.getOptions().stream())
-            .map(CartOption::getId)
-            .filter(requestedSet::contains)
-            .count();
-        if (foundCount != requestedIds.size()) {
-            throw new BbangleException(BbangleErrorCode.NOT_FOUND_CART_OPTION);
-        }
-    }
-
     /**
      * 요청에 포함된 상품 옵션들을 조회하여 Map으로 변환
      */
@@ -156,6 +130,34 @@ public class CustomerCartFacade {
                 option -> option.getOption().getId(),
                 Function.identity()
             ));
+    }
+
+    @Transactional
+    public void deleteCartOptions(Long memberId, CartRequest.DeleteCartOptionsRequest request) {
+        List<Long> optionIds = request.cartOptionIds();
+
+        List<CartItem> cartItems = customerCartItemService.findAllWithOptionsByMemberIdAndOptionIds(memberId,
+            optionIds);
+        validateAllOptionsFound(cartItems, optionIds);
+
+        Set<Long> targetOptionIds = new HashSet<>(optionIds);
+        cartItems.forEach(cartItem -> cartItem.removeOptions(targetOptionIds));
+
+        cartItems.stream()
+            .filter(CartItem::hasNoOptions)
+            .forEach(customerCartItemService::delete);
+    }
+
+    private void validateAllOptionsFound(List<CartItem> cartItems, List<Long> requestedIds) {
+        Set<Long> requestedSet = new HashSet<>(requestedIds);
+        long foundCount = cartItems.stream()
+            .flatMap(ci -> ci.getOptions().stream())
+            .map(CartOption::getId)
+            .filter(requestedSet::contains)
+            .count();
+        if (foundCount != requestedIds.size()) {
+            throw new BbangleException(BbangleErrorCode.NOT_FOUND_CART_OPTION);
+        }
     }
 
     @Transactional(readOnly = true)
@@ -284,5 +286,22 @@ public class CustomerCartFacade {
                 .items(cartItemMap.getOrDefault(store.getId(), List.of()))
                 .build()
             ).toList();
+    }
+
+    // TODO : Test
+    @Transactional
+    public UpdateCartOptionResponse updateQuantity(Long memberId, Long cartOptionId, UpdateCartOptionRequest request) {
+        CartOption cartOption = customerCartOptionService.findByIdAndMemberId(memberId, cartOptionId);
+        Product option = cartOption.getOption();
+
+        option.validateStock(request.quantity());
+        customerCartOptionService.updateQuantity(cartOption, request.quantity());
+
+        return UpdateCartOptionResponse.builder()
+            .cartOptionId(cartOption.getId())
+            .optionName(option.getTitle())
+            .addedPrice(option.getPrice())
+            .quantity(cartOption.getQuantity())
+            .build();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
@@ -299,8 +299,8 @@ public class CustomerCartFacade {
 
         return UpdateCartOptionResponse.builder()
             .cartOptionId(cartOption.getId())
+            .optionId(option.getId())
             .optionName(option.getTitle())
-            .addedPrice(option.getPrice())
             .quantity(cartOption.getQuantity())
             .build();
     }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
@@ -288,7 +288,6 @@ public class CustomerCartFacade {
             ).toList();
     }
 
-    // TODO : Test
     @Transactional
     public UpdateCartOptionResponse updateQuantity(Long memberId, Long cartOptionId, UpdateCartOptionRequest request) {
         CartOption cartOption = customerCartOptionService.findByIdAndMemberId(memberId, cartOptionId);

--- a/src/main/java/com/bbangle/bbangle/cart/customer/service/CustomerCartOptionService.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/service/CustomerCartOptionService.java
@@ -4,6 +4,8 @@ import com.bbangle.bbangle.board.domain.Product;
 import com.bbangle.bbangle.cart.domain.CartItem;
 import com.bbangle.bbangle.cart.domain.CartOption;
 import com.bbangle.bbangle.cart.repository.CartOptionRepository;
+import com.bbangle.bbangle.exception.BbangleErrorCode;
+import com.bbangle.bbangle.exception.BbangleException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,5 +37,11 @@ public class CustomerCartOptionService {
     @Transactional(readOnly = true)
     public List<CartOption> findAllByCartItemIds(List<Long> cartItemIds) {
         return cartOptionRepository.findCartOptionsByCartItemIds(cartItemIds);
+    }
+
+    @Transactional(readOnly = true)
+    public CartOption findByIdAndMemberId(Long memberId, Long cartOptionId) {
+        return cartOptionRepository.findByIdAndMemberId(cartOptionId, memberId)
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.NOT_FOUND_CART_OPTION));
     }
 }

--- a/src/main/java/com/bbangle/bbangle/cart/repository/CartOptionRepository.java
+++ b/src/main/java/com/bbangle/bbangle/cart/repository/CartOptionRepository.java
@@ -20,7 +20,6 @@ public interface CartOptionRepository extends JpaRepository<CartOption, Long> {
         """)
     List<CartOption> findCartOptionsByCartItemIds(@Param("cartItemIds") List<Long> cartItemIds);
 
-    // TODO : Test
     @Query("""
         select co
         from CartOption co

--- a/src/main/java/com/bbangle/bbangle/cart/repository/CartOptionRepository.java
+++ b/src/main/java/com/bbangle/bbangle/cart/repository/CartOptionRepository.java
@@ -3,6 +3,7 @@ package com.bbangle.bbangle.cart.repository;
 import com.bbangle.bbangle.cart.domain.CartItem;
 import com.bbangle.bbangle.cart.domain.CartOption;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +19,15 @@ public interface CartOptionRepository extends JpaRepository<CartOption, Long> {
             WHERE co.cartItem.id IN :cartItemIds
         """)
     List<CartOption> findCartOptionsByCartItemIds(@Param("cartItemIds") List<Long> cartItemIds);
+
+    // TODO : Test
+    @Query("""
+        select co
+        from CartOption co
+            join fetch co.option
+            join co.cartItem ci
+            join ci.cart c
+        where co.id = :cartOptionId and c.member.id = :memberId
+        """)
+    Optional<CartOption> findByIdAndMemberId(@Param("cartOptionId") Long cartOptionId, @Param("memberId") Long memberId);
 }

--- a/src/test/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartControllerTest.java
@@ -3,18 +3,20 @@ package com.bbangle.bbangle.cart.customer.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bbangle.bbangle.cart.customer.controller.dto.CartRequest;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.CartListResponse;
+import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.UpdateCartOptionResponse;
 import com.bbangle.bbangle.cart.customer.facade.CustomerCartFacade;
 import com.bbangle.bbangle.common.adaptor.slack.TestSlackAdaptorConfig;
 import com.bbangle.bbangle.common.client.annotation.WithMockAuthenticationPrincipal;
@@ -205,6 +207,76 @@ class CustomerCartControllerTest {
                 .andExpect(jsonPath("$.result.carts").isArray());
 
             verify(customerCartFacade).getCart(1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateCartOption() 테스트")
+    class UpdateCartOptionTest {
+
+        @Test
+        @WithMockAuthenticationPrincipal
+        @DisplayName("장바구니 옵션의 수량을 변경한다.")
+        void success_updateCartOption() throws Exception {
+
+            // given
+            Long memberId = 1L;
+            Long cartOptionId = 2L;
+            Long optionId = 3L;
+            String optionName = "락토 프리";
+            int quantity = 4;
+
+            CartRequest.UpdateCartOptionRequest request = new CartRequest.UpdateCartOptionRequest(quantity);
+
+            UpdateCartOptionResponse response = UpdateCartOptionResponse.builder()
+                .cartOptionId(cartOptionId)
+                .optionId(optionId)
+                .optionName(optionName)
+                .quantity(quantity)
+                .build();
+
+            given(customerCartFacade.updateQuantity(memberId, cartOptionId, request)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(patch(CustomerApiPath.PREFIX + "/carts/options/{cartOptionId}", cartOptionId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.message").value("SUCCESS"))
+                .andExpect(jsonPath("$.result.cartOptionId").value(cartOptionId))
+                .andExpect(jsonPath("$.result.optionId").value(optionId))
+                .andExpect(jsonPath("$.result.optionName").value(optionName))
+                .andExpect(jsonPath("$.result.quantity").value(quantity));
+
+            verify(customerCartFacade).updateQuantity(memberId, cartOptionId, request);
+        }
+
+        @Test
+        @WithMockAuthenticationPrincipal
+        @DisplayName("장바구니 옵션이 존재하지 않으면 예외를 반환한다.")
+        void fail_updateCartOption_notFoundCartOption() throws Exception {
+
+            // given
+            Long memberId = 1L;
+            Long cartOptionId = 2L;
+
+            CartRequest.UpdateCartOptionRequest request = new CartRequest.UpdateCartOptionRequest(3);
+
+            given(customerCartFacade.updateQuantity(memberId, cartOptionId, request))
+                .willThrow(new BbangleException(BbangleErrorCode.NOT_FOUND_CART_OPTION));
+
+            // when & then
+            mockMvc.perform(patch(CustomerApiPath.PREFIX + "/carts/options/{cartOptionId}", cartOptionId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(BbangleErrorCode.NOT_FOUND_CART_OPTION.getCode()))
+                .andExpect(jsonPath("$.message").value(BbangleErrorCode.NOT_FOUND_CART_OPTION.getMessage()));
+
+            verify(customerCartFacade).updateQuantity(memberId, cartOptionId, request);
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeIntegrationTest.java
@@ -10,7 +10,9 @@ import com.bbangle.bbangle.board.repository.BoardRepository;
 import com.bbangle.bbangle.board.repository.ProductImgRepository;
 import com.bbangle.bbangle.board.repository.ProductRepository;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartRequest;
+import com.bbangle.bbangle.cart.customer.controller.dto.CartRequest.UpdateCartOptionRequest;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.CartListResponse;
+import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.UpdateCartOptionResponse;
 import com.bbangle.bbangle.cart.domain.Cart;
 import com.bbangle.bbangle.cart.domain.CartItem;
 import com.bbangle.bbangle.cart.domain.CartOption;
@@ -642,6 +644,97 @@ class CustomerCartFacadeIntegrationTest {
 
             // then
             assertThat(result.carts()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateQuantity() 테스트")
+    class UpdateQuantityTest {
+
+        private Member member;
+        private Member otherMember;
+        private CartOption cartOption;
+        private Product option;
+
+        @BeforeEach
+        void setUp() {
+
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            Board board = boardRepository.save(BoardFixture.defaultBoardWithStore(store, "board"));
+
+            member = memberRepository.save(MemberFixture.defaultMember());
+            otherMember = memberRepository.save(MemberFixture.createMemberWithName("other@test.com"));
+
+            Cart cart = cartRepository.save(Cart.create(member));
+            cartRepository.save(Cart.create(otherMember));
+
+            CartItem cartItem = cartItemRepository.save(CartItem.create(cart, board));
+
+            option = productRepository.save(ProductFixture.createWithStock(board, "옵션", 10));
+
+            cartOption = cartOptionRepository.save(CartOption.create(cartItem, option, 2));
+
+            em.flush();
+            em.clear();
+        }
+
+        @Test
+        @DisplayName("장바구니 옵션의 수량을 변경한다.")
+        void success_updateQuantity() {
+
+            // given
+            UpdateCartOptionRequest request = new UpdateCartOptionRequest(5);
+
+            // when
+            UpdateCartOptionResponse result = customerCartFacade.updateQuantity(member.getId(), cartOption.getId(), request);
+
+            em.flush();
+            em.clear();
+
+            CartOption updatedCartOption = cartOptionRepository.findById(cartOption.getId()).orElseThrow();
+
+            // then
+            assertThat(result.cartOptionId()).isEqualTo(cartOption.getId());
+            assertThat(result.optionId()).isEqualTo(option.getId());
+            assertThat(result.optionName()).isEqualTo(option.getTitle());
+            assertThat(result.quantity()).isEqualTo(5);
+            assertThat(updatedCartOption.getQuantity()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("재고보다 많은 수량이면 예외가 발생한다.")
+        void fail_updateQuantity_insufficientStock() {
+
+            // given
+            UpdateCartOptionRequest request = new UpdateCartOptionRequest(11);
+
+            // when & then
+            assertThatThrownBy(() ->
+                customerCartFacade.updateQuantity(member.getId(), cartOption.getId(), request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.INVALID_REQUEST_STOCK);
+                });
+        }
+
+        @Test
+        @DisplayName("다른 회원의 장바구니 옵션이면 예외가 발생한다.")
+        void fail_updateQuantity_notFoundCartOption() {
+
+            // given
+            UpdateCartOptionRequest request = new UpdateCartOptionRequest(5);
+
+            // when & then
+            assertThatThrownBy(() ->
+                customerCartFacade.updateQuantity(otherMember.getId(), cartOption.getId(), request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.NOT_FOUND_CART_OPTION);
+                });
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeUnitTest.java
@@ -3,10 +3,13 @@ package com.bbangle.bbangle.cart.customer.facade;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -17,7 +20,9 @@ import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.domain.Product;
 import com.bbangle.bbangle.board.domain.ProductImg;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartRequest;
+import com.bbangle.bbangle.cart.customer.controller.dto.CartRequest.UpdateCartOptionRequest;
 import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.CartListResponse;
+import com.bbangle.bbangle.cart.customer.controller.dto.CartResponse.UpdateCartOptionResponse;
 import com.bbangle.bbangle.cart.customer.service.CustomerCartItemService;
 import com.bbangle.bbangle.cart.customer.service.CustomerCartOptionService;
 import com.bbangle.bbangle.cart.customer.service.CustomerCartService;
@@ -48,6 +53,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("[단위테스트] CustomerCartFacade")
 @ExtendWith(MockitoExtension.class)
@@ -388,6 +394,96 @@ class CustomerCartFacadeUnitTest {
 
             // then
             assertThat(result.carts()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateQuantity() 테스트")
+    class UpdateQuantityTest {
+
+        @Test
+        @DisplayName("장바구니 옵션의 수량을 변경한다.")
+        void success_updateQuantity() {
+
+            // given
+            Long memberId = 1L;
+            Long cartOptionId = 1L;
+            UpdateCartOptionRequest request = new UpdateCartOptionRequest(3);
+
+            Board board = mock(Board.class);
+            Product option = ProductFixture.createWithStock(board, "옵션1", 10);
+            ReflectionTestUtils.setField(option, "id", 1L);
+
+            CartOption cartOption = mock(CartOption.class);
+
+            given(customerCartOptionService.findByIdAndMemberId(memberId, cartOptionId)).willReturn(cartOption);
+            given(cartOption.getId()).willReturn(cartOptionId);
+            given(cartOption.getOption()).willReturn(option);
+            given(cartOption.getQuantity()).willReturn(3);
+
+            // when
+            UpdateCartOptionResponse result = customerCartFacade.updateQuantity(memberId, cartOptionId, request);
+
+            // then
+            assertThat(result.cartOptionId()).isEqualTo(cartOptionId);
+            assertThat(result.optionId()).isEqualTo(option.getId());
+            assertThat(result.optionName()).isEqualTo(option.getTitle());
+            assertThat(result.quantity()).isEqualTo(3);
+
+            verify(customerCartOptionService).findByIdAndMemberId(memberId, cartOptionId);
+            verify(customerCartOptionService).updateQuantity(cartOption, 3);
+        }
+
+        @Test
+        @DisplayName("재고보다 많은 수량이면 예외가 발생한다.")
+        void fail_updateQuantity_insufficientStock() {
+
+            // given
+            Long memberId = 1L;
+            Long cartOptionId = 1L;
+            UpdateCartOptionRequest request = new UpdateCartOptionRequest(11);
+
+            Board board = mock(Board.class);
+            Product option = ProductFixture.createWithStock(board, "옵션1", 10);
+            CartOption cartOption = mock(CartOption.class);
+
+            given(customerCartOptionService.findByIdAndMemberId(memberId, cartOptionId)).willReturn(cartOption);
+            given(cartOption.getOption()).willReturn(option);
+
+            // when & then
+            assertThatThrownBy(() -> customerCartFacade.updateQuantity(memberId, cartOptionId, request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.INVALID_REQUEST_STOCK);
+                });
+
+            verify(customerCartOptionService, never()).updateQuantity(any(), anyInt());
+        }
+
+        @Test
+        @DisplayName("장바구니 옵션이 존재하지 않으면 예외가 발생한다.")
+        void fail_updateQuantity_notFoundCartOption() {
+
+            // given
+            Long memberId = 1L;
+            Long cartOptionId = 1L;
+            UpdateCartOptionRequest request = new UpdateCartOptionRequest(3);
+
+            given(customerCartOptionService.findByIdAndMemberId(memberId, cartOptionId))
+                .willThrow(new BbangleException(BbangleErrorCode.NOT_FOUND_CART_OPTION));
+
+            // when & then
+            assertThatThrownBy(() -> customerCartFacade.updateQuantity(memberId, cartOptionId, request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.NOT_FOUND_CART_OPTION);
+                });
+
+            verify(customerCartOptionService, never()).updateQuantity(any(), anyInt());
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/cart/repository/CartOptionRepositoryTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/repository/CartOptionRepositoryTest.java
@@ -22,7 +22,9 @@ import com.bbangle.bbangle.search.repository.component.SearchSort;
 import com.bbangle.bbangle.store.domain.Store;
 import com.bbangle.bbangle.store.repository.StoreRepository;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -71,33 +73,35 @@ class CartOptionRepositoryTest {
     @Autowired
     EntityManager em;
 
+    private CartItem cartItem;
+    private Member member;
+    private CartOption cartOption;
+
+    @BeforeEach
+    void setUp() {
+
+        Store store = storeRepository.save(StoreFixture.defaultStore());
+        Board board = boardRepository.save(BoardFixture.defaultBoardWithStore(store, "board"));
+
+        member = memberRepository.save(MemberFixture.defaultMember());
+
+        Cart cart = cartRepository.save(Cart.create(member));
+
+        cartItem = cartItemRepository.save(CartItem.create(cart, board));
+
+        Product option1 = productRepository.save(ProductFixture.createWithStock(board, "옵션1", 10));
+        Product option2 = productRepository.save(ProductFixture.createWithStock(board, "옵션2", 10));
+
+        cartOption = cartOptionRepository.save(CartOption.create(cartItem, option1, 5));
+        cartOptionRepository.save(CartOption.create(cartItem, option2, 1));
+
+        em.flush();
+        em.clear();
+    }
+
     @Nested
     @DisplayName("findCartOptionsByCartItemIds() 테스트")
     class FindCartOptionsByCartItemIdsTest {
-
-        private CartItem cartItem;
-
-        @BeforeEach
-        void setUp() {
-
-            Store store = storeRepository.save(StoreFixture.defaultStore());
-            Board board = boardRepository.save(BoardFixture.defaultBoardWithStore(store, "board"));
-
-            Member member = memberRepository.save(MemberFixture.defaultMember());
-
-            Cart cart = cartRepository.save(Cart.create(member));
-
-            cartItem = cartItemRepository.save(CartItem.create(cart, board));
-
-            Product option1 = productRepository.save(ProductFixture.createWithStock(board, "옵션1", 10));
-            Product option2 = productRepository.save(ProductFixture.createWithStock(board, "옵션2", 10));
-
-            cartOptionRepository.save(CartOption.create(cartItem, option1, 5));
-            cartOptionRepository.save(CartOption.create(cartItem, option2, 1));
-
-            em.flush();
-            em.clear();
-        }
 
         @Test
         @DisplayName("CartItemIds에 해당하는 CartOption과 Product가 함께 조회된다.")
@@ -113,6 +117,60 @@ class CartOptionRepositoryTest {
             assertThat(result).hasSize(2);
             assertThat(result).extracting(co -> co.getCartItem().getId()).containsOnly(cartItem.getId());
             assertThat(result).extracting(co -> co.getOption().getTitle()).containsExactlyInAnyOrder("옵션1", "옵션2");
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdAndMemberId() 테스트")
+    class FindByIdAndMemberIdTest {
+
+        @Test
+        @DisplayName("회원의 CartOption을 Product와 함께 조회한다.")
+        void success_findByIdAndMemberId() {
+
+            // given
+            Long cartOptionId = cartOption.getId();
+
+            // when
+            Optional<CartOption> result = cartOptionRepository.findByIdAndMemberId(cartOptionId, member.getId());
+
+            // then
+            assertThat(result).isPresent();
+
+            CartOption found = result.get();
+            assertThat(found.getId()).isEqualTo(cartOptionId);
+            assertThat(found.getOption().getTitle()).isEqualTo("옵션1");
+
+            PersistenceUnitUtil util = em.getEntityManagerFactory().getPersistenceUnitUtil();
+            assertThat(util.isLoaded(found.getOption())).isTrue();
+        }
+
+        @Test
+        @DisplayName("다른 회원의 CartOption이면 조회되지 않는다.")
+        void fail_findByIdAndMemberId_invalidMemberId() {
+
+            // given
+            Member otherMember = memberRepository.save(MemberFixture.createMemberWithName("other@test.com"));
+
+            // when
+            Optional<CartOption> result = cartOptionRepository.findByIdAndMemberId(cartOption.getId(), otherMember.getId());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 CartOption이면 조회되지 않는다.")
+        void fail_findByIdAndMemberId_invalidCartOptionId() {
+
+            // given
+            Long invalidCartOptionId = 99999L;
+
+            // when
+            Optional<CartOption> result = cartOptionRepository.findByIdAndMemberId(invalidCartOptionId, member.getId());
+
+            // then
+            assertThat(result).isEmpty();
         }
     }
 }


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

- 연관된 이슈 : #717 
- [Notion 개발 일정](https://app.notion.com/p/sideproject-unione/3-_-_-2f0622e86d3d807fba1fcb6b00885b96?source=copy_link)
- [API 명세서](https://app.notion.com/p/sideproject-unione/38e622e86d3d8012aaddc33a7027e2e8?v=2c6622e86d3d8157890d000cc857bdd2&source=copy_link)

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->

- 장바구니에 담긴 상품의 옵션 수량을 변경하는 API 구현

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->
<img width="386" height="167" alt="image" src="https://github.com/user-attachments/assets/3507e4bb-e60f-419d-95e7-d767619b6f7d" />
<img width="218" height="180" alt="image" src="https://github.com/user-attachments/assets/69789140-c3b5-4b84-a3d7-13591f41cdd5" />

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 장바구니 상품 옵션의 수량을 변경할 수 있는 기능이 추가되었습니다.
  * 변경 결과에 옵션 정보와 수량이 포함되어 반환됩니다.

* **Bug Fixes**
  * 다른 회원의 장바구니 옵션은 조회/수정되지 않도록 검증이 강화되었습니다.
  * 수량 변경 시 재고 초과 요청에 대한 오류 처리가 추가되었습니다.

* **Tests**
  * 수량 변경 API, 서비스, 저장소에 대한 성공/실패 시나리오 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->