### PR TITLE
[Refactor] 소비자 클레임(취소/반품/교환) API 및 서비스 통합

### DIFF
--- a/src/main/java/com/bbangle/bbangle/claim/customer/controller/CustomerClaimController.java
+++ b/src/main/java/com/bbangle/bbangle/claim/customer/controller/CustomerClaimController.java
@@ -3,7 +3,7 @@ package com.bbangle.bbangle.claim.customer.controller;
 import com.bbangle.bbangle.claim.customer.controller.dto.CustomerCancelRequest;
 import com.bbangle.bbangle.claim.customer.controller.dto.CustomerExchangeRequest;
 import com.bbangle.bbangle.claim.customer.controller.dto.CustomerReturnRequest;
-import com.bbangle.bbangle.claim.customer.service.CustomerOrderService;
+import com.bbangle.bbangle.claim.customer.service.CustomerClaimService;
 import com.bbangle.bbangle.common.dto.CommonResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.config.security.CustomerApiPath;
@@ -19,10 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping(CustomerApiPath.PREFIX + "/orders")
 @RestController
-public class CustomerOrderController {
+public class CustomerClaimController {
 
     private final ResponseService responseService;
-    private final CustomerOrderService customerOrderService;
+    private final CustomerClaimService customerClaimService;
 
     @PatchMapping("/{orderId}/cancel")
     public CommonResult requestCancel(
@@ -30,7 +30,7 @@ public class CustomerOrderController {
         @Valid @RequestBody CustomerCancelRequest request,
         @AuthenticationPrincipal Long customerId
     ) {
-        customerOrderService.cancelOrder(orderId, customerId, request);
+        customerClaimService.cancelOrder(orderId, customerId, request);
         return responseService.getSuccessResult();
     }
 
@@ -40,7 +40,7 @@ public class CustomerOrderController {
         @Valid @RequestBody CustomerReturnRequest request,
         @AuthenticationPrincipal Long customerId
     ) {
-        customerOrderService.requestReturn(orderId, customerId, request);
+        customerClaimService.requestReturn(orderId, customerId, request);
         return responseService.getSuccessResult();
     }
 
@@ -50,7 +50,7 @@ public class CustomerOrderController {
         @Valid @RequestBody CustomerExchangeRequest request,
         @AuthenticationPrincipal Long customerId
     ) {
-        customerOrderService.requestExchange(orderId, customerId, request);
+        customerClaimService.requestExchange(orderId, customerId, request);
         return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/bbangle/bbangle/claim/customer/service/CustomerClaimService.java
+++ b/src/main/java/com/bbangle/bbangle/claim/customer/service/CustomerClaimService.java
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
-public class CustomerOrderService {
+public class CustomerClaimService {
 
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;

--- a/src/test/java/com/bbangle/bbangle/claim/customer/service/CustomerClaimServiceTest.java
+++ b/src/test/java/com/bbangle/bbangle/claim/customer/service/CustomerClaimServiceTest.java
@@ -37,12 +37,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-@DisplayName("[단위 테스트] CustomerOrderService")
+@DisplayName("[단위 테스트] CustomerClaimService")
 @ExtendWith(MockitoExtension.class)
-class CustomerOrderServiceTest {
+class CustomerClaimServiceTest {
 
     @InjectMocks
-    private CustomerOrderService sut;
+    private CustomerClaimService sut;
 
     @Mock
     private OrderRepository orderRepository;


### PR DESCRIPTION
---
name: "✅ Feature"
about: Feature 요구 사항을 입력해주세요.
title: "✅ Feature"
labels: ✅ Feature
assignees: ''

---
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

## 🚀 Major Changes & Explanations

- 소비자 클레임 도메인 대통합 리팩토링
    - Cancel(주문 취소), Return(반품 요청), Exchange(교환 요청) 관련 Controller, Service, Test 코드를 CustomerClaimController, CustomerClaimService, CustomerClaimServiceTest 하나의 파일로 통합 
- 빈 네이밍 충돌 해결 및 클래스명 개선
    - 취소/반품/교환이 표현할 수 있도록 Order에서 Claim으로 세련되게 변경 및 적용

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 주문 취소, 반품, 교환 요청이 고객 클레임 처리 흐름으로 일관되게 연결되도록 정리되었습니다.
  * 관련 처리 응답과 요청 검증, 인증 정보 연동은 그대로 유지됩니다.

* **Refactor**
  * 고객 주문 관련 명칭이 고객 클레임 중심으로 정리되어, 코드와 테스트 이름이 더 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->