### PR TITLE
[Feat] (소비자) 장바구니 상품 옵션 변경 API

### DIFF
--- a/src/main/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartController.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartController.java
@@ -70,4 +70,15 @@ public class CustomerCartController implements CustomerCartApi {
             customerCartFacade.updateQuantity(memberId, cartOptionId, request)
         );
     }
+
+    @Override
+    @PatchMapping("/options/{cartOptionId}/option")
+    public CommonResult changeCartOption(
+        @AuthenticationPrincipal Long memberId,
+        @PathVariable Long cartOptionId,
+        @Valid @RequestBody CartRequest.ChangeCartOptionRequest request
+    ) {
+        customerCartFacade.changeOption(memberId, cartOptionId, request);
+        return responseService.getSuccessResult();
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/controller/dto/CartRequest.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/controller/dto/CartRequest.java
@@ -42,4 +42,10 @@ public class CartRequest {
         @Schema(description = "변경할 상품 옵션의 수량", example = "1")
         int quantity
     ) {}
+
+    public record ChangeCartOptionRequest(
+        @NotNull
+        @Schema(description = "새로 선택한 상품 옵션 Id", example = "1")
+        Long optionId
+    ) {}
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/controller/swagger/CustomerCartApi.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/controller/swagger/CustomerCartApi.java
@@ -48,4 +48,14 @@ public interface CustomerCartApi {
         @PathVariable Long cartOptionId,
         @Valid @RequestBody CartRequest.UpdateCartOptionRequest request
     );
+
+    @Operation(
+        summary = "(커스토머) 장바구니 상품 옵션 변경",
+        description = "장바구니에서 선택한 상품 옵션을 다른 옵션으로 변경합니다."
+    )
+    CommonResult changeCartOption(
+        @AuthenticationPrincipal Long memberId,
+        @PathVariable Long cartOptionId,
+        @Valid @RequestBody CartRequest.ChangeCartOptionRequest request
+    );
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
@@ -312,7 +312,7 @@ public class CustomerCartFacade {
 
         Product newOption = getProduct(request.optionId());
         newOption.validateBelongsTo(board);
-        validateNotDuplicated(cartItem, cartOption, newOption);
+        validateNotDuplicated(cartItem, newOption);
         newOption.validateStock(cartOption.getQuantity());
 
         customerCartOptionService.changeOption(cartOption, newOption);
@@ -325,9 +325,8 @@ public class CustomerCartFacade {
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.PRODUCT_NOT_FOUND));
     }
 
-    private void validateNotDuplicated(CartItem cartItem, CartOption cartOption, Product newOption) {
+    private void validateNotDuplicated(CartItem cartItem, Product newOption) {
         boolean duplicated = cartItem.getOptions().stream()
-            .filter(option -> !option.getId().equals(cartOption.getId()))
             .anyMatch(option -> option.getOption().getId().equals(newOption.getId()));
 
         if (duplicated) {

--- a/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacade.java
@@ -303,4 +303,35 @@ public class CustomerCartFacade {
             .quantity(cartOption.getQuantity())
             .build();
     }
+
+    @Transactional
+    public void changeOption(Long memberId, Long cartOptionId, CartRequest.ChangeCartOptionRequest request) {
+        CartOption cartOption = customerCartOptionService.findByIdAndMemberId(memberId, cartOptionId);
+        CartItem cartItem = cartOption.getCartItem();
+        Board board = cartItem.getItem();
+
+        Product newOption = getProduct(request.optionId());
+        newOption.validateBelongsTo(board);
+        validateNotDuplicated(cartItem, cartOption, newOption);
+        newOption.validateStock(cartOption.getQuantity());
+
+        customerCartOptionService.changeOption(cartOption, newOption);
+    }
+
+    private Product getProduct(Long optionId) {
+        return productService.findAllByIds(List.of(optionId))
+            .stream()
+            .findFirst()
+            .orElseThrow(() -> new BbangleException(BbangleErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    private void validateNotDuplicated(CartItem cartItem, CartOption cartOption, Product newOption) {
+        boolean duplicated = cartItem.getOptions().stream()
+            .filter(option -> !option.getId().equals(cartOption.getId()))
+            .anyMatch(option -> option.getOption().getId().equals(newOption.getId()));
+
+        if (duplicated) {
+            throw new BbangleException(BbangleErrorCode.DUPLICATED_PRODUCT_OPTION);
+        }
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/cart/customer/service/CustomerCartOptionService.java
+++ b/src/main/java/com/bbangle/bbangle/cart/customer/service/CustomerCartOptionService.java
@@ -34,6 +34,11 @@ public class CustomerCartOptionService {
         cartOption.updateQuantity(quantity);
     }
 
+    @Transactional
+    public void changeOption(CartOption cartOption, Product newOption) {
+        cartOption.changeOption(newOption);
+    }
+
     @Transactional(readOnly = true)
     public List<CartOption> findAllByCartItemIds(List<Long> cartItemIds) {
         return cartOptionRepository.findCartOptionsByCartItemIds(cartItemIds);

--- a/src/main/java/com/bbangle/bbangle/cart/domain/CartOption.java
+++ b/src/main/java/com/bbangle/bbangle/cart/domain/CartOption.java
@@ -76,4 +76,8 @@ public class CartOption extends BaseEntity {
         if (quantity < 1 || quantity > 999) throw new BbangleException(BbangleErrorCode.INVALID_REQUEST_QUANTITY);
         this.quantity = quantity;
     }
+
+    public void changeOption(Product newOption) {
+        this.option = newOption;
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/controller/CustomerCartControllerTest.java
@@ -279,4 +279,89 @@ class CustomerCartControllerTest {
             verify(customerCartFacade).updateQuantity(memberId, cartOptionId, request);
         }
     }
+
+    @Nested
+    @DisplayName("changeCartOption() 테스트")
+    class ChangeCartOptionTest {
+
+        @Test
+        @WithMockAuthenticationPrincipal
+        @DisplayName("장바구니 옵션을 다른 옵션으로 변경한다.")
+        void success_changeCartOption() throws Exception {
+
+            // given
+            Long memberId = 1L;
+            Long cartOptionId = 2L;
+            Long optionId = 3L;
+
+            CartRequest.ChangeCartOptionRequest request = new CartRequest.ChangeCartOptionRequest(optionId);
+
+            // when & then
+            mockMvc.perform(patch(CustomerApiPath.PREFIX + "/carts/options/{cartOptionId}/option", cartOptionId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.message").value("SUCCESS"));
+
+            then(customerCartFacade).should().changeOption(memberId, cartOptionId, request);
+        }
+
+        @Test
+        @WithMockAuthenticationPrincipal
+        @DisplayName("이미 담긴 옵션으로 변경하면 예외를 반환한다.")
+        void fail_changeCartOption_duplicated() throws Exception {
+
+            // given
+            Long memberId = 1L;
+            Long cartOptionId = 2L;
+            Long optionId = 3L;
+
+            CartRequest.ChangeCartOptionRequest request = new CartRequest.ChangeCartOptionRequest(optionId);
+
+            willThrow(new BbangleException(BbangleErrorCode.DUPLICATED_PRODUCT_OPTION))
+                .given(customerCartFacade)
+                .changeOption(memberId, cartOptionId, request);
+
+            // when & then
+            mockMvc.perform(patch(CustomerApiPath.PREFIX + "/carts/options/{cartOptionId}/option", cartOptionId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(BbangleErrorCode.DUPLICATED_PRODUCT_OPTION.getCode()))
+                .andExpect(jsonPath("$.message").value(BbangleErrorCode.DUPLICATED_PRODUCT_OPTION.getMessage()));
+
+            then(customerCartFacade).should().changeOption(memberId, cartOptionId, request);
+        }
+
+        @Test
+        @WithMockAuthenticationPrincipal
+        @DisplayName("장바구니 옵션이 존재하지 않으면 예외를 반환한다.")
+        void fail_changeCartOption_notFoundCartOption() throws Exception {
+
+            // given
+            Long memberId = 1L;
+            Long cartOptionId = 2L;
+            Long optionId = 3L;
+
+            CartRequest.ChangeCartOptionRequest request = new CartRequest.ChangeCartOptionRequest(optionId);
+
+            willThrow(new BbangleException(BbangleErrorCode.NOT_FOUND_CART_OPTION))
+                .given(customerCartFacade)
+                .changeOption(memberId, cartOptionId, request);
+
+            // when & then
+            mockMvc.perform(patch(CustomerApiPath.PREFIX + "/carts/options/{cartOptionId}/option", cartOptionId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(BbangleErrorCode.NOT_FOUND_CART_OPTION.getCode()))
+                .andExpect(jsonPath("$.message").value(BbangleErrorCode.NOT_FOUND_CART_OPTION.getMessage()));
+
+            then(customerCartFacade).should().changeOption(memberId, cartOptionId, request);
+        }
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeIntegrationTest.java
@@ -737,4 +737,159 @@ class CustomerCartFacadeIntegrationTest {
                 });
         }
     }
+
+    @Nested
+    @DisplayName("changeOption() 테스트")
+    class ChangeOptionTest {
+
+        private Member member;
+        private Member otherMember;
+        private Board board;
+        private CartItem cartItem;
+        private CartOption cartOption;
+        private Product newOption;
+
+        @BeforeEach
+        void setUp() {
+
+            Store store = storeRepository.save(StoreFixture.defaultStore());
+            board = boardRepository.save(BoardFixture.defaultBoardWithStore(store, "board"));
+
+            member = memberRepository.save(MemberFixture.defaultMember());
+            otherMember = memberRepository.save(MemberFixture.createMemberWithName("other@test.com"));
+
+            Cart cart = cartRepository.save(Cart.create(member));
+            cartRepository.save(Cart.create(otherMember));
+
+            cartItem = cartItemRepository.save(CartItem.create(cart, board));
+
+            Product option = productRepository.save(ProductFixture.createWithStock(board, "옵션", 10));
+            newOption = productRepository.save(ProductFixture.createWithStock(board, "새옵션", 10));
+
+            cartOption = cartOptionRepository.save(CartOption.create(cartItem, option, 2));
+
+            em.flush();
+            em.clear();
+        }
+
+        @Test
+        @DisplayName("장바구니 옵션을 다른 옵션으로 변경한다.")
+        void success_changeOption() {
+
+            // given
+            CartRequest.ChangeCartOptionRequest request = new CartRequest.ChangeCartOptionRequest(newOption.getId());
+
+            // when
+            customerCartFacade.changeOption(member.getId(), cartOption.getId(), request);
+
+            em.flush();
+            em.clear();
+
+            // then
+            CartOption changed = cartOptionRepository.findById(cartOption.getId()).orElseThrow();
+
+            assertThat(changed.getOption().getId()).isEqualTo(newOption.getId());
+            assertThat(changed.getQuantity()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 옵션으로 변경하면 예외가 발생한다.")
+        void fail_changeOption_product_notFound() {
+
+            // given
+            CartRequest.ChangeCartOptionRequest request = new CartRequest.ChangeCartOptionRequest(99999L);
+
+            // when & then
+            assertThatThrownBy(() ->
+                customerCartFacade.changeOption(member.getId(), cartOption.getId(), request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.PRODUCT_NOT_FOUND);
+                });
+        }
+
+        @Test
+        @DisplayName("다른 상품에 속한 옵션으로 변경하면 예외가 발생한다.")
+        void fail_changeOption_product_not_belongs_to_board() {
+
+            // given
+            Board otherBoard = boardRepository.save(BoardFixture.defaultBoardWithStore(board.getStore(), "다른상품"));
+            Product otherBoardOption = productRepository.save(ProductFixture.createWithStock(otherBoard, "옵션", 10));
+
+            CartRequest.ChangeCartOptionRequest request = new CartRequest.ChangeCartOptionRequest(otherBoardOption.getId());
+
+            // when & then
+            assertThatThrownBy(() ->
+                customerCartFacade.changeOption(member.getId(), cartOption.getId(), request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.PRODUCT_NOT_FOUND);
+                });
+        }
+
+        @Test
+        @DisplayName("이미 담긴 옵션으로 변경하면 예외가 발생한다.")
+        void fail_changeOption_duplicated() {
+
+            // given
+            CartOption existingOption = cartOptionRepository.save(CartOption.create(cartItem, newOption, 1));
+
+            em.flush();
+            em.clear();
+
+            CartRequest.ChangeCartOptionRequest request = new CartRequest.ChangeCartOptionRequest(newOption.getId());
+
+            // when & then
+            assertThatThrownBy(() ->
+                customerCartFacade.changeOption(member.getId(), cartOption.getId(), request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.DUPLICATED_PRODUCT_OPTION);
+                });
+        }
+
+        @Test
+        @DisplayName("새 옵션의 재고가 부족하면 예외가 발생한다.")
+        void fail_changeOption_insufficientStock() {
+
+            // given
+            Product lowStockOption = productRepository.save(ProductFixture.createWithStock(board, "품절임박", 1));
+
+            CartRequest.ChangeCartOptionRequest request = new CartRequest.ChangeCartOptionRequest(lowStockOption.getId());
+
+            // when & then
+            assertThatThrownBy(() ->
+                customerCartFacade.changeOption(member.getId(), cartOption.getId(), request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.INVALID_REQUEST_STOCK);
+                });
+        }
+
+        @Test
+        @DisplayName("다른 회원의 장바구니 옵션이면 예외가 발생한다.")
+        void fail_changeOption_notFoundCartOption() {
+
+            // given
+            CartRequest.ChangeCartOptionRequest request = new CartRequest.ChangeCartOptionRequest(newOption.getId());
+
+            // when & then
+            assertThatThrownBy(() ->
+                customerCartFacade.changeOption(otherMember.getId(), cartOption.getId(), request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.NOT_FOUND_CART_OPTION);
+                });
+        }
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeIntegrationTest.java
@@ -855,6 +855,24 @@ class CustomerCartFacadeIntegrationTest {
         }
 
         @Test
+        @DisplayName("이미 선택되어 있는 옵션(자기 자신)으로 변경하면 예외가 발생한다.")
+        void fail_changeOption_duplicated_self() {
+
+            // given
+            CartRequest.ChangeCartOptionRequest request = new CartRequest.ChangeCartOptionRequest(cartOption.getOption().getId());
+
+            // when & then
+            assertThatThrownBy(() ->
+                customerCartFacade.changeOption(member.getId(), cartOption.getId(), request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.DUPLICATED_PRODUCT_OPTION);
+                });
+        }
+
+        @Test
         @DisplayName("새 옵션의 재고가 부족하면 예외가 발생한다.")
         void fail_changeOption_insufficientStock() {
 

--- a/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeUnitTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -484,6 +485,119 @@ class CustomerCartFacadeUnitTest {
                 });
 
             verify(customerCartOptionService, never()).updateQuantity(any(), anyInt());
+        }
+    }
+
+    @Nested
+    @DisplayName("changeOption() 테스트")
+    class ChangeOptionTest {
+
+        Long memberId = 1L;
+        Long cartOptionId = 1L;
+        Long newOptionId = 2L;
+        CartRequest.ChangeCartOptionRequest request = new CartRequest.ChangeCartOptionRequest(newOptionId);
+
+        CartOption cartOption = mock(CartOption.class);
+        CartItem cartItem = mock(CartItem.class);
+        Board board = mock(Board.class);
+        Product newOption = mock(Product.class);
+
+        @Test
+        @DisplayName("장바구니 옵션을 다른 옵션으로 변경한다.")
+        void success_changeOption() {
+
+            // given
+            given(customerCartOptionService.findByIdAndMemberId(memberId, cartOptionId)).willReturn(cartOption);
+            given(cartOption.getCartItem()).willReturn(cartItem);
+            given(cartOption.getQuantity()).willReturn(2);
+            given(cartItem.getItem()).willReturn(board);
+            given(cartItem.getOptions()).willReturn(List.of());
+            given(productService.findAllByIds(List.of(newOptionId))).willReturn(List.of(newOption));
+
+            // when
+            customerCartFacade.changeOption(memberId, cartOptionId, request);
+
+            // then
+            then(newOption).should().validateBelongsTo(board);
+            then(newOption).should().validateStock(2);
+            then(customerCartOptionService).should().changeOption(cartOption, newOption);
+        }
+
+        @Test
+        @DisplayName("변경하려는 옵션이 존재하지 않으면 예외가 발생한다.")
+        void fail_changeOption_product_notFound() {
+
+            // given
+            given(customerCartOptionService.findByIdAndMemberId(memberId, cartOptionId)).willReturn(cartOption);
+            given(cartOption.getCartItem()).willReturn(cartItem);
+            given(cartItem.getItem()).willReturn(board);
+            given(productService.findAllByIds(List.of(newOptionId))).willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() -> customerCartFacade.changeOption(memberId, cartOptionId, request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.PRODUCT_NOT_FOUND);
+                });
+
+            then(customerCartOptionService).should(never()).changeOption(any(), any());
+        }
+
+        @Test
+        @DisplayName("같은 상품에 이미 담긴 옵션으로 변경하려 하면 예외가 발생한다.")
+        void fail_changeOption_duplicated() {
+
+            // given
+            CartOption existingOption = mock(CartOption.class);
+
+            given(customerCartOptionService.findByIdAndMemberId(memberId, cartOptionId)).willReturn(cartOption);
+            given(cartOption.getCartItem()).willReturn(cartItem);
+            given(cartOption.getId()).willReturn(cartOptionId);
+            given(cartItem.getItem()).willReturn(board);
+            given(cartItem.getOptions()).willReturn(List.of(existingOption));
+            given(existingOption.getId()).willReturn(99L);
+            given(existingOption.getOption()).willReturn(newOption);
+            given(newOption.getId()).willReturn(newOptionId);
+            given(productService.findAllByIds(List.of(newOptionId))).willReturn(List.of(newOption));
+
+            // when & then
+            assertThatThrownBy(() -> customerCartFacade.changeOption(memberId, cartOptionId, request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.DUPLICATED_PRODUCT_OPTION);
+                });
+
+            then(customerCartOptionService).should(never()).changeOption(any(), any());
+        }
+
+        @Test
+        @DisplayName("새 옵션의 재고가 부족하면 예외가 발생한다.")
+        void fail_changeOption_insufficientStock() {
+
+            // given
+            given(customerCartOptionService.findByIdAndMemberId(memberId, cartOptionId)).willReturn(cartOption);
+            given(cartOption.getCartItem()).willReturn(cartItem);
+            given(cartOption.getQuantity()).willReturn(5);
+            given(cartItem.getItem()).willReturn(board);
+            given(cartItem.getOptions()).willReturn(List.of());
+            given(productService.findAllByIds(List.of(newOptionId))).willReturn(List.of(newOption));
+            willThrow(new BbangleException(BbangleErrorCode.INVALID_REQUEST_STOCK))
+                .given(newOption).validateStock(5);
+
+            // when & then
+            assertThatThrownBy(() -> customerCartFacade.changeOption(memberId, cartOptionId, request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.INVALID_REQUEST_STOCK);
+                });
+
+            then(customerCartOptionService).should(never()).changeOption(any(), any());
         }
     }
 }

--- a/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/customer/facade/CustomerCartFacadeUnitTest.java
@@ -554,11 +554,34 @@ class CustomerCartFacadeUnitTest {
 
             given(customerCartOptionService.findByIdAndMemberId(memberId, cartOptionId)).willReturn(cartOption);
             given(cartOption.getCartItem()).willReturn(cartItem);
-            given(cartOption.getId()).willReturn(cartOptionId);
             given(cartItem.getItem()).willReturn(board);
             given(cartItem.getOptions()).willReturn(List.of(existingOption));
-            given(existingOption.getId()).willReturn(99L);
             given(existingOption.getOption()).willReturn(newOption);
+            given(newOption.getId()).willReturn(newOptionId);
+            given(productService.findAllByIds(List.of(newOptionId))).willReturn(List.of(newOption));
+
+            // when & then
+            assertThatThrownBy(() -> customerCartFacade.changeOption(memberId, cartOptionId, request)
+            )
+                .isInstanceOf(BbangleException.class)
+                .satisfies(e -> {
+                    BbangleException ex = (BbangleException) e;
+                    assertThat(ex.getBbangleErrorCode()).isEqualTo(BbangleErrorCode.DUPLICATED_PRODUCT_OPTION);
+                });
+
+            then(customerCartOptionService).should(never()).changeOption(any(), any());
+        }
+
+        @Test
+        @DisplayName("이미 선택되어 있는 옵션(자기 자신)으로 변경하려 하면 예외가 발생한다.")
+        void fail_changeOption_duplicated_self() {
+
+            // given
+            given(customerCartOptionService.findByIdAndMemberId(memberId, cartOptionId)).willReturn(cartOption);
+            given(cartOption.getCartItem()).willReturn(cartItem);
+            given(cartItem.getItem()).willReturn(board);
+            given(cartItem.getOptions()).willReturn(List.of(cartOption));
+            given(cartOption.getOption()).willReturn(newOption);
             given(newOption.getId()).willReturn(newOptionId);
             given(productService.findAllByIds(List.of(newOptionId))).willReturn(List.of(newOption));
 

--- a/src/test/java/com/bbangle/bbangle/cart/domain/CartOptionUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/cart/domain/CartOptionUnitTest.java
@@ -15,6 +15,7 @@ import com.bbangle.bbangle.fixture.member.MemberFixture;
 import com.bbangle.bbangle.fixture.store.domain.StoreFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -98,6 +99,31 @@ class CartOptionUnitTest {
                     BbangleException ex = (BbangleException) e;
                     assertThat(ex.getMessage()).isEqualTo(BbangleErrorCode.INVALID_REQUEST_QUANTITY.getMessage());
                 });
+        }
+    }
+
+    @Nested
+    @DisplayName("changeOption() 테스트")
+    class ChangeOptionTest {
+
+        Cart cart = CartFixture.defaultCart(MemberFixture.defaultMember());
+        CartItem cartItem = CartItemFixture.defaultCartItem(cart, BoardFixture.defaultBoard());
+        Product option = ProductFixture.defaultProductWithStore(StoreFixture.defaultStore());
+        Product newOption = ProductFixture.defaultProductWithStore(StoreFixture.defaultStore());
+
+        @Test
+        @DisplayName("장바구니 옵션이 다른 상품 옵션으로 변경된다.")
+        void success_changeOption() {
+
+            // given
+            CartOption cartOption = CartOptionFixture.defaultCartOption(cartItem, option, 2);
+
+            // when
+            cartOption.changeOption(newOption);
+
+            // then
+            assertThat(cartOption.getOption()).isEqualTo(newOption);
+            assertThat(cartOption.getQuantity()).isEqualTo(2);
         }
     }
 }


### PR DESCRIPTION
## History

* #없음 (신규 기능)

## 🚀 Major Changes & Explanations

* [feat] (소비자) 장바구니 상품 옵션 변경 API 구현
  - `PATCH /api/v1/customer/carts/options/{cartOptionId}/option`
  - 장바구니에서 선택한 상품 옵션을 다른 옵션으로 교체 (수량은 변경 없이 유지)
  - `CartOption.changeOption()` 도메인 메서드 추가
  - 검증: 본인 소유 CartOption 여부, 새 옵션이 동일 Board 소속인지, 같은 CartItem 내 중복 옵션 여부, 재고 충분 여부

* [test] 단위/통합/컨트롤러 테스트 작성
  - `CartOptionUnitTest`: changeOption()
  - `CustomerCartFacadeUnitTest` / `CustomerCartFacadeIntegrationTest`: changeOption()
  - `CustomerCartControllerTest`: changeCartOption()

## 📷 Test Image

<!-- 스크린샷 없음 -->

## 💡 ETC

* 응답은 변경된 옵션 정보를 담지 않고 `CommonResult`만 반환합니다. 옵션 변경 시 가격/재고 등 화면 전체가 갱신되어야 해서 FE에서 성공 후 `GET /api/v1/customer/carts`를 재조회하는 흐름을 전제로 설계했습니다.
* 같은 상품에 이미 담긴 옵션으로 변경을 시도하면 `DUPLICATED_PRODUCT_OPTION`(400)으로 막습니다. FE에서는 드롭다운에서 이미 선택된 옵션을 비활성화 처리하는 것을 권장합니다.
* 명세 문서: `.claude/docs/api/customer/장바구니/장바구니옵션변경.md` (gitignore 대상이라 이 PR에는 포함되지 않음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 장바구니 상품 옵션을 다른 옵션으로 변경할 수 있는 API가 추가되었습니다.
  * 변경 시 동일 상품 여부, 중복 옵션, 재고 및 장바구니 소유권을 자동으로 검증합니다.

* **버그 수정**
  * 존재하지 않거나 변경할 수 없는 옵션 요청에 대해 적절한 오류 응답을 제공합니다.

* **테스트**
  * 옵션 변경 성공 및 중복, 재고 부족, 권한 오류 등 다양한 상황에 대한 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->