### PR TITLE
[Feature] (관리자) 스토어명 중복 체크 API

### DIFF
--- a/src/main/java/com/bbangle/bbangle/board/customer/controller/BoardDetailController.java
+++ b/src/main/java/com/bbangle/bbangle/board/customer/controller/BoardDetailController.java
@@ -10,7 +10,6 @@ import com.bbangle.bbangle.board.customer.service.BoardDetailService;
 import com.bbangle.bbangle.board.customer.service.ProductService;
 import com.bbangle.bbangle.board.customer.service.dto.StoreInfo;
 import com.bbangle.bbangle.board.customer.service.dto.StoreInfo.Store;
-import com.bbangle.bbangle.common.aop.ExecutionTimeLog;
 import com.bbangle.bbangle.common.dto.SingleResult;
 import com.bbangle.bbangle.common.service.ResponseService;
 import com.bbangle.bbangle.review.customer.dto.SummarizedReviewResponse;
@@ -94,7 +93,6 @@ public class BoardDetailController {
         return responseService.getSingleResult(productResponse);
     }
 
-    @ExecutionTimeLog
     @Operation(summary = "리뷰 조회")
     @GetMapping("/{boardId}/review")
     public SingleResult<SummarizedReviewResponse> getReviewResponse(
@@ -104,7 +102,6 @@ public class BoardDetailController {
         return responseService.getSingleResult(response);
     }
 
-    @ExecutionTimeLog
     @Operation(summary = "게시판 조회(new)")
     @GetMapping("/{boardId}/new")
     public SingleResult<Main> getBoardDetail(

--- a/src/main/java/com/bbangle/bbangle/board/customer/facade/BoardDetailFacade.java
+++ b/src/main/java/com/bbangle/bbangle/board/customer/facade/BoardDetailFacade.java
@@ -3,7 +3,6 @@ package com.bbangle.bbangle.board.customer.facade;
 import com.bbangle.bbangle.board.customer.service.BoardDetailService;
 import com.bbangle.bbangle.board.customer.service.dto.BoardDetailCommand;
 import com.bbangle.bbangle.board.customer.service.dto.BoardDetailInfo;
-import com.bbangle.bbangle.common.aop.ExecutionTimeLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,7 +12,6 @@ public class BoardDetailFacade {
 
     private final BoardDetailService boardDetailService;
 
-    @ExecutionTimeLog
     public BoardDetailInfo.Main getBoardDetail(BoardDetailCommand.Main command) {
         boardDetailService.increaseVisitor(command);
         return boardDetailService.getBoardDetail(command);

--- a/src/main/java/com/bbangle/bbangle/board/customer/facade/BoardFacade.java
+++ b/src/main/java/com/bbangle/bbangle/board/customer/facade/BoardFacade.java
@@ -1,6 +1,5 @@
 package com.bbangle.bbangle.board.customer.facade;
 
-import com.bbangle.bbangle.common.aop.ExecutionTimeLog;
 import com.bbangle.bbangle.common.page.CursorPagination;
 import com.bbangle.bbangle.search.customer.service.SearchService;
 import com.bbangle.bbangle.search.customer.service.dto.SearchCommand;
@@ -19,7 +18,6 @@ public class BoardFacade {
     private final SearchService searchService;
     private final WishListBoardService wishListBoardService;
 
-    @ExecutionTimeLog
     @Transactional(readOnly = true)
     public CursorPagination<SearchInfo.Select> getBoardList(@Valid SearchCommand.Main command) {
         SearchInfo.BoardsInfo boardsInfo = searchService.getBoardList(command);

--- a/src/main/java/com/bbangle/bbangle/board/customer/service/BoardDetailService.java
+++ b/src/main/java/com/bbangle/bbangle/board/customer/service/BoardDetailService.java
@@ -19,7 +19,6 @@ import com.bbangle.bbangle.board.repository.BoardRepository;
 import com.bbangle.bbangle.board.repository.dao.TagsDao;
 import com.bbangle.bbangle.boardstatistic.customer.service.BoardStatisticService;
 import com.bbangle.bbangle.boardstatistic.repository.BoardStatisticRepository;
-import com.bbangle.bbangle.common.aop.ExecutionTimeLog;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.push.repository.PushRepository;
@@ -228,7 +227,6 @@ public class BoardDetailService {
             boardDetailHtmlWithCdnUrl);
     }
 
-    @ExecutionTimeLog
     public BoardDetailInfo.Main getBoardDetail(BoardDetailCommand.Main command) {
 
         Board board = boardRepository.findById(command.boardId()).orElseThrow(() -> new BbangleException(BbangleErrorCode.BOARD_NOT_FOUND));
@@ -246,15 +244,11 @@ public class BoardDetailService {
     }
 
     private List<Long> getBbankettingProductsIds(Board board, Long memberId) {
-        long start = System.currentTimeMillis();    // TODO : 임시 출력 로그 - 추후 삭제 예정
         List<Long> productIds = board.getProducts().stream().map(Product::getId).toList();
-        List<Long> result = pushRepository.findExistingPushProductIds(productIds, memberId);
-        log.info("[PERF] BoardDetailService.getBbankettingProductsIds() : {} ms", System.currentTimeMillis() - start);  // TODO : 임시 출력 로그 - 추후 삭제 예정
-        return result;
+        return pushRepository.findExistingPushProductIds(productIds, memberId);
     }
 
     // 패키지 구조 수정 시, 로직 변경해야함
-    @ExecutionTimeLog
     @Transactional
     public void increaseVisitor(BoardDetailCommand.Main command) {
         String visitorInfo = ViewCount.builder()

--- a/src/main/java/com/bbangle/bbangle/review/customer/service/ReviewService.java
+++ b/src/main/java/com/bbangle/bbangle/review/customer/service/ReviewService.java
@@ -9,7 +9,6 @@ import static java.util.Locale.ROOT;
 import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.repository.BoardRepository;
 import com.bbangle.bbangle.boardstatistic.customer.service.BoardStatisticService;
-import com.bbangle.bbangle.common.aop.ExecutionTimeLog;
 import com.bbangle.bbangle.common.page.ImageCustomPage;
 import com.bbangle.bbangle.common.page.ReviewCustomPage;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
@@ -307,7 +306,6 @@ public class ReviewService {
         imageRepository.delete(reviewImg);
     }
 
-    @ExecutionTimeLog
     @Transactional
     public SummarizedReviewResponse getSummarizedReview(Long boardId) {
         List<ReviewBadgeDto> reviews = reviewRepository.findReviewBadgeByBoardId(boardId);

--- a/src/main/java/com/bbangle/bbangle/search/customer/service/SearchService.java
+++ b/src/main/java/com/bbangle/bbangle/search/customer/service/SearchService.java
@@ -64,13 +64,10 @@ public class SearchService {
 
     @ExecutionTimeLog
     public SearchInfo.BoardsInfo getBoardList(Main command) {
-        long start = System.currentTimeMillis();    // TODO : 임시 출력 로그 - 추후 삭제 예정
 
         SearchInfo.CursorCondition cursorCondition = Objects.nonNull(command.cursorId()) ?
             searchRepository.getCursorCondition(command.cursorId()) :
             SearchInfo.CursorCondition.empty();
-
-        log.info("[PERF] getCursorCondition : {} ms", System.currentTimeMillis() - start);  // TODO : 임시 출력 로그 - 추후 삭제 예정
 
         return command.isExcludedProduct() ?
             getRecommendBoardList(command, cursorCondition) :
@@ -79,24 +76,18 @@ public class SearchService {
 
     private SearchInfo.BoardsInfo getDefaultBoardList(Main command,
         SearchInfo.CursorCondition cursorCondition) {
-        long start = System.currentTimeMillis();    // TODO : 임시 출력 로그 - 추후 삭제 예정
         List<Board> boards = searchRepository.getBoards(command, cursorCondition);
         Long boardCount = searchRepository.getAllCount(command, cursorCondition);
-        SearchInfo.BoardsInfo result = searchInfoMapper.toBoardsInfo(boards, boardCount, command.limitSize());
-        log.info("[PERF] SearchService.getDefaultBoardList() : {} ms", System.currentTimeMillis() - start); // TODO : 임시 출력 로그 - 추후 삭제 예정
-        return result;
+        return searchInfoMapper.toBoardsInfo(boards, boardCount, command.limitSize());
     }
 
     private SearchInfo.BoardsInfo getRecommendBoardList(Main command,
         SearchInfo.CursorCondition cursorCondition) {
-        long start = System.currentTimeMillis();    // TODO : 임시 출력 로그 - 추후 삭제 예정
         MemberSegment memberSegment = memberSegmentRepository.findByMemberId(command.memberId())
             .orElseThrow(() -> new BbangleException(BbangleErrorCode.MEMBER_PREFERENCE_NOT_FOUND));
         List<Board> boards = searchRepository.getRecommendBoardList(command, cursorCondition, memberSegment);
         Long boardCount = searchRepository.getRecommendAllCount(command, cursorCondition, memberSegment);
-        SearchInfo.BoardsInfo result = searchInfoMapper.toBoardsInfo(boards, boardCount, command.limitSize());
-        log.info("[PERF] SearchService.getRecommendBoardList() : {} ms", System.currentTimeMillis() - start); // TODO : 임시 출력 로그 - 추후 삭제 예정
-        return result;
+        return searchInfoMapper.toBoardsInfo(boards, boardCount, command.limitSize());
     }
 
     @ExecutionTimeLog

--- a/src/main/java/com/bbangle/bbangle/search/repository/SearchQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/search/repository/SearchQueryDSLRepository.java
@@ -2,6 +2,7 @@ package com.bbangle.bbangle.search.repository;
 
 import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.domain.MemberSegment;
+import com.bbangle.bbangle.common.aop.ExecutionTimeLog;
 import com.bbangle.bbangle.search.customer.dto.KeywordDto;
 import com.bbangle.bbangle.search.customer.service.dto.SearchCommand;
 import com.bbangle.bbangle.search.customer.service.dto.SearchInfo;
@@ -10,18 +11,23 @@ import java.util.List;
 
 public interface SearchQueryDSLRepository {
 
+    @ExecutionTimeLog
     SearchInfo.CursorCondition getCursorCondition(Long cursorId);
 
+    @ExecutionTimeLog
     List<Board> getBoards(SearchCommand.Main command, SearchInfo.CursorCondition condition);
 
-    Long getAllCount(
+    @ExecutionTimeLog
+    Long getAllCount(SearchCommand.Main command, SearchInfo.CursorCondition condition);
+
+    @ExecutionTimeLog
+    List<Board> getRecommendBoardList(
         SearchCommand.Main command,
-        SearchInfo.CursorCondition condition
+        SearchInfo.CursorCondition condition,
+        MemberSegment memberSegment
     );
 
-    List<Board> getRecommendBoardList(SearchCommand.Main command,
-        SearchInfo.CursorCondition condition, MemberSegment memberSegment);
-
+    @ExecutionTimeLog
     Long getRecommendAllCount(
         SearchCommand.Main command,
         SearchInfo.CursorCondition condition,

--- a/src/main/java/com/bbangle/bbangle/store/admin/controller/AdminStoreController.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/controller/AdminStoreController.java
@@ -134,4 +134,15 @@ public class AdminStoreController implements AdminStoreApi {
             adminStoreService.rejectStoreName(requestId, request)
         );
     }
+
+    // TODO : Test
+    @Override
+    @GetMapping("/check-name")
+    public SingleResult<Boolean> duplicateStoreName(
+        @RequestParam String storeName
+    ) {
+        return responseService.getSingleResult(
+            adminStoreService.isDuplicateStoreName(storeName)
+        );
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/store/admin/controller/AdminStoreController.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/controller/AdminStoreController.java
@@ -135,7 +135,6 @@ public class AdminStoreController implements AdminStoreApi {
         );
     }
 
-    // TODO : Test
     @Override
     @GetMapping("/check-name")
     public SingleResult<Boolean> duplicateStoreName(

--- a/src/main/java/com/bbangle/bbangle/store/admin/controller/swagger/AdminStoreApi.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/controller/swagger/AdminStoreApi.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -103,5 +104,19 @@ public interface AdminStoreApi {
         @Parameter(description = "거절할 요청 번호", example = "1")
         @PathVariable Long requestId,
         @RequestBody @Valid UpdateStoreNameRejectRequest request
+    );
+
+    @Operation(
+        summary = "(관리자) 스토어명 중복 검사",
+        description = "스토어명의 중복 여부를 검사합니다."
+    )
+    SingleResult<Boolean> duplicateStoreName(
+        @RequestParam
+        @NotBlank(message = "스토어 이름은 필수입니다.")
+        @Parameter(
+            description = "중복 여부를 확인할 스토어명입니다. 공백을 제거한 후 요청해주세요.",
+            example = "빵그리"
+        )
+        String storeName
     );
 }

--- a/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
@@ -261,4 +261,11 @@ public class AdminStoreService {
             .seller(application.getSeller())
             .build();
     }
+
+    // TODO : Test
+    @Transactional(readOnly = true)
+    public boolean isDuplicateStoreName(String storeName) {
+        String normalized = storeName.replaceAll("\\s+", "");
+        return storeRepository.existsByNormalizedStoreName(normalized);
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
+++ b/src/main/java/com/bbangle/bbangle/store/admin/service/AdminStoreService.java
@@ -262,7 +262,6 @@ public class AdminStoreService {
             .build();
     }
 
-    // TODO : Test
     @Transactional(readOnly = true)
     public boolean isDuplicateStoreName(String storeName) {
         String normalized = storeName.replaceAll("\\s+", "");

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreQueryDSLRepository.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreQueryDSLRepository.java
@@ -33,4 +33,6 @@ public interface StoreQueryDSLRepository {
      * normalizedStoreName 이 빈 문자열이면 전체 조회
      */
     Page<Store> findActiveStoresByName(String normalizedStoreName, Pageable pageable);
+
+    boolean existsByNormalizedStoreName(String normalizedStoreName);
 }

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
@@ -175,7 +175,6 @@ public class StoreRepositoryImpl implements StoreQueryDSLRepository {
             .contains(normalized);
     }
 
-    // TODO : Test
     @Override
     public boolean existsByNormalizedStoreName(String normalizedStoreName) {
         Integer result = queryFactory

--- a/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/bbangle/bbangle/store/repository/StoreRepositoryImpl.java
@@ -174,4 +174,19 @@ public class StoreRepositoryImpl implements StoreQueryDSLRepository {
         return Expressions.stringTemplate("REPLACE({0}, ' ', '')", store.name)
             .contains(normalized);
     }
+
+    // TODO : Test
+    @Override
+    public boolean existsByNormalizedStoreName(String normalizedStoreName) {
+        Integer result = queryFactory
+            .selectOne()
+            .from(store)
+            .where(
+                Expressions.stringTemplate("REPLACE({0}, ' ', '')", store.name).eq(normalizedStoreName),
+                store.isDeleted.isFalse()
+            )
+            .fetchFirst();
+
+        return result != null;
+    }
 }

--- a/src/main/java/com/bbangle/bbangle/wishlist/customer/service/WishListBoardService.java
+++ b/src/main/java/com/bbangle/bbangle/wishlist/customer/service/WishListBoardService.java
@@ -3,7 +3,6 @@ package com.bbangle.bbangle.wishlist.customer.service;
 import com.bbangle.bbangle.board.domain.Board;
 import com.bbangle.bbangle.board.repository.BoardRepository;
 import com.bbangle.bbangle.boardstatistic.customer.service.BoardStatisticService;
-import com.bbangle.bbangle.common.aop.ExecutionTimeLog;
 import com.bbangle.bbangle.exception.BbangleErrorCode;
 import com.bbangle.bbangle.exception.BbangleException;
 import com.bbangle.bbangle.member.domain.Member;
@@ -100,7 +99,6 @@ public class WishListBoardService {
         }
     }
 
-    @ExecutionTimeLog
     public Map<Long, Boolean> getBoardWishedMap(Long memberId, List<Board> boards) {
         if (Objects.isNull(memberId)) {
             return Collections.emptyMap();

--- a/src/test/java/com/bbangle/bbangle/store/admin/controller/AdminStoreControllerTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/admin/controller/AdminStoreControllerTest.java
@@ -708,4 +708,29 @@ class AdminStoreControllerTest {
                 .andExpect(status().isBadRequest());
         }
     }
+
+    @Nested
+    @DisplayName("duplicateStoreName() 테스트")
+    class DuplicateStoreNameTest {
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("스토어명 중복 여부를 반환한다.")
+        void duplicateStoreName() throws Exception {
+
+            // given
+            given(adminStoreService.isDuplicateStoreName("빵그리")).willReturn(true);
+
+            // when & then
+            mockMvc.perform(get(AdminApiPath.PREFIX + "/stores/check-name")
+                    .param("storeName", "빵그리"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.message").value("SUCCESS"))
+                .andExpect(jsonPath("$.result").value(true));
+
+            then(adminStoreService).should().isDuplicateStoreName("빵그리");
+        }
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceIntegrationTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceIntegrationTest.java
@@ -574,4 +574,27 @@ class AdminStoreServiceIntegrationTest {
             assertThat(rollbackStore).usingRecursiveComparison().isEqualTo(store);
         }
     }
+
+    @Nested
+    @DisplayName("isDuplicateStoreName() 테스트")
+    class IsDuplicateStoreNameTest {
+
+        @Test
+        @DisplayName("공백이 포함된 스토어명을 정규화하여 중복 여부를 조회한다.")
+        void isDuplicateStoreName() {
+
+            // given
+            Store store = StoreFixture.defaultStore("빵 그리");
+            storeRepository.save(store);
+
+            em.flush();
+            em.clear();
+
+            // when
+            boolean result = adminStoreService.isDuplicateStoreName("빵그리");
+
+            // then
+            assertThat(result).isTrue();
+        }
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceUnitTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/admin/service/AdminStoreServiceUnitTest.java
@@ -934,4 +934,39 @@ class AdminStoreServiceUnitTest {
             verify(adminStoreMapper, never()).toStoreDetailResponse(any());
         }
     }
+
+    @Nested
+    @DisplayName("isDuplicateStoreName() 테스트")
+    class IsDuplicateStoreNameTest {
+
+        @Test
+        @DisplayName("공백을 제거한 스토어명으로 중복 여부를 조회한다.")
+        void isDuplicateStoreName() {
+
+            // given
+            given(storeRepository.existsByNormalizedStoreName("빵그리")).willReturn(true);
+
+            // when
+            boolean result = adminStoreService.isDuplicateStoreName("빵 그리");
+
+            // then
+            assertThat(result).isTrue();
+            then(storeRepository).should().existsByNormalizedStoreName("빵그리");
+        }
+
+        @Test
+        @DisplayName("중복되는 스토어명이 없으면 false를 반환한다.")
+        void isDuplicateStoreName_notExists() {
+
+            // given
+            given(storeRepository.existsByNormalizedStoreName("빵그리")).willReturn(false);
+
+            // when
+            boolean result = adminStoreService.isDuplicateStoreName("빵 그리");
+
+            // then
+            assertThat(result).isFalse();
+            then(storeRepository).should().existsByNormalizedStoreName("빵그리");
+        }
+    }
 }

--- a/src/test/java/com/bbangle/bbangle/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/bbangle/bbangle/store/repository/StoreRepositoryTest.java
@@ -12,8 +12,10 @@ import com.bbangle.bbangle.search.repository.component.SearchFilter;
 import com.bbangle.bbangle.search.repository.component.SearchSort;
 import com.bbangle.bbangle.store.domain.Store;
 import com.querydsl.core.NonUniqueResultException;
+import jakarta.persistence.EntityManager;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -37,6 +39,9 @@ public class StoreRepositoryTest {
 
     @Autowired
     private StoreRepository storeRepository;
+
+    @Autowired
+    private EntityManager em;
 
     @Test
     @DisplayName("스토어 이름으로 검색을 성공합니다.")
@@ -79,5 +84,65 @@ public class StoreRepositoryTest {
         // when & then
         assertThatThrownBy(() -> storeRepository.findByStoreName(searchKeyword))
             .isInstanceOf(NonUniqueResultException.class);
+    }
+
+    @Nested
+    @DisplayName("existsByNormalizedStoreName() 테스트")
+    class ExistsByNormalizedStoreNameTest {
+
+        @Test
+        @DisplayName("공백을 제거한 스토어명이 존재하면 true를 반환한다.")
+        void existsByNormalizedStoreName() {
+
+            // given
+            Store store = StoreFixture.defaultStore("빵 그리");
+            storeRepository.save(store);
+
+            em.flush();
+            em.clear();
+
+            // when
+            boolean result = storeRepository.existsByNormalizedStoreName("빵그리");
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("삭제된 스토어는 중복 검사 대상에서 제외한다.")
+        void existsByNormalizedStoreName_deleted() {
+
+            // given
+            Store store = StoreFixture.defaultStore("빵그리");
+            storeRepository.save(store);
+            store.delete();
+
+            em.flush();
+            em.clear();
+
+            // when
+            boolean result = storeRepository.existsByNormalizedStoreName("빵그리");
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("공백을 제거한 스토어명이 존재하지 않으면 false를 반환한다.")
+        void existsByNormalizedStoreName_notExists() {
+
+            // given
+            Store store = StoreFixture.defaultStore("빵그리");
+            storeRepository.save(store);
+
+            em.flush();
+            em.clear();
+
+            // when
+            boolean result = storeRepository.existsByNormalizedStoreName("케이크");
+
+            // then
+            assertThat(result).isFalse();
+        }
     }
 }


### PR DESCRIPTION
## History

<!--연관된 내용, 이슈 링크를 달아주세요-->
<!--이슈 태스크를 모두 완료하고 닫는다면 * Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 * Closes #번호-->
<!--열어둔다면 * #번호-->

- 연관된 이슈 : #730 
- [API 명세서](https://app.notion.com/p/sideproject-unione/3ac622e86d3d802c9482ea3a0ddef922?source=copy_link)

## 🚀 Major Changes & Explanations

<!--빠른 리뷰를 위해 이해를 도울 만한 설명을 자세히 적어주세요-->
- (관리자) 스토어명 중복 API 기능 구현
- 메서드 실행 시간을 측정하기 위해 이전에 부착하였던 실행 시간 측정 코드 제거
  - API 실행 시간의 약 80%가 Service 메서드에서 차지하는 것을 확인
  - 한번 API 지연이 일어났을 때 특정 Service 메서드만이 아닌 다른 Service에서도 실행 지연이 일어나는 것을 확인
  - Repository 메서드 (QueryDSL로 구현한 메서드만 가능)에 실행 시간 측정 어노테이션을 부착함
  - 리포지토리 메서드 실행 시간에 따라 커넥션 풀 상태를 확인할지 예정

## 📷 Test Image

<!-- postman, swagger 등을 활용한 api 결과, 각종 Edge case 테스트 결과 이미지를 붙여주세요-->
<!-- 이미지가 많거나 클 경우 오른쪽 패턴을 이용해주세요<img src = "CREATED_IMG_URL" width = "400px">-->
<img width="565" height="253" alt="image" src="https://github.com/user-attachments/assets/211899af-cab8-4f52-8f16-5c767496db45" />
<img width="146" height="95" alt="image" src="https://github.com/user-attachments/assets/d1be80c3-07ce-493a-9f71-fc794a846f19" />

## 💡 ETC

<!-- ex) 질문. 작업 관련 사항, 고민한 내용 등등을 적어주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 매장 등록 시 매장명 중복 여부를 확인할 수 있는 기능을 추가했습니다.
  * 매장명 내 공백을 정리한 기준으로 중복을 검사하며, 삭제된 매장은 검사 대상에서 제외됩니다.

* **개선 사항**
  * 게시판, 검색, 리뷰 및 찜 목록 조회의 처리 흐름을 정리해 보다 간결하고 안정적으로 동작하도록 개선했습니다.

* **테스트**
  * 매장명 중복 검사와 공백 처리, 삭제된 매장 제외 시나리오를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->